### PR TITLE
use fixed version of google maps api on map_v3

### DIFF
--- a/cachemap-full.php
+++ b/cachemap-full.php
@@ -233,7 +233,7 @@ if ($usr == false) {
       } */
 
     /* SET YOUR MAP CODE HERE */
-    tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=true&amp;language=' . $lang . '" type="text/javascript"></script>
+    tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=true&amp;v=3.21&amp;language=' . $lang . '" type="text/javascript"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">');
     /*
      * Generate dynamic URL to cachemap3.js file, this will make sure it will be reloaded by the browser.

--- a/cachemap-mini.php
+++ b/cachemap-mini.php
@@ -34,7 +34,7 @@ tpl_set_var("map_type", "0");
 tpl_set_var('cachemap_mapper', $cachemap_mapper);
 
 /* SET YOUR MAP CODE HERE */
-tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=false&amp;language=' . $lang . '" type="text/javascript"></script>');
+tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=false&amp;v=3.21&amp;language=' . $lang . '" type="text/javascript"></script>');
 /*
  * Generate dynamic URL to cachemap3.js file, this will make sure it will be reloaded by the browser.
  * The time-stamp will be stripped by a rewrite rule in lib/.htaccess.

--- a/cachemap3.php
+++ b/cachemap3.php
@@ -253,7 +253,7 @@ if ($usr == false) {
       } */
 
     /* SET YOUR MAP CODE HERE */
-    tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=false&amp;language=' . $lang . '" type="text/javascript"></script>');
+    tpl_set_var('cachemap_header', '<script src="//maps.googleapis.com/maps/api/js?sensor=false&amp;v=3.21&amp;language=' . $lang . '" type="text/javascript"></script>');
     /*
      * Generate dynamic URL to cachemap3.js file, this will make sure it will be reloaded by the browser.
      * The time-stamp will be stripped by a rewrite rule in lib/.htaccess.


### PR DESCRIPTION
Source of the problem: http://forum.opencaching.pl/viewtopic.php?f=9&t=7281&start=270#p129890

Till now OC Mapv3 used latest version of the Google Maps API, what often caused issues after new API version release.

I postulate the use of fixed version of Google Maps API and upgrade the version after tests from time to time... 

(there is the same situation with map_mini, other maps need check...)