### PR TITLE
Now COG can left note about user. Fixes #246

### DIFF
--- a/lib/languages/pl.php
+++ b/lib/languages/pl.php
@@ -2568,4 +2568,6 @@ $translations = array(
     'month_titled_cache_congratulations' => '<p><img src="tpl/stdstyle/images/free_icons/award_star_gold_1.png" class="icon16" alt="Skrzynka miesiąca" title="Skrzynka miesiąca" />&nbsp Witaj !!! <br/> <br/>&nbsp&nbsp&nbsp&nbspMiło nam poinformować, iż Twoja skrzynka została wybrana skrzynką miesiąca.</p><p><span style="color: #008000;"><strong><br />SERDECZNIE GRATULUJEMY !!!</strong></span><br />Zespół OpenCaching</p>',
     'titled_cache_date' => 'Data<br>wyróżnienia',
     'show_more_titled_caches' => 'Pokaż więcej Skrzynek Tygodnia',
+    'COG_note' => 'Notatka COG o użytkowniku',
+    'COG_note_visible' => 'Ta sekcja jest widoczna tylko dla członków COG',
 );

--- a/sqlAlters/2016-02-23_user_cog_note.sql
+++ b/sqlAlters/2016-02-23_user_cog_note.sql
@@ -1,0 +1,5 @@
+--
+-- Adding field to database for keeping the COG-note about user
+--
+
+ALTER TABLE `user` ADD `cog_note` VARCHAR( 4096 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'COG note for user' AFTER `verify_all`

--- a/viewprofile.php
+++ b/viewprofile.php
@@ -124,6 +124,19 @@ if ($error == false) {
                 tpl_set_var('lastlogin', tr('more_12_month'));
         }
 
+        // COG Note
+        if($usr['admin'])
+        {
+            if(isset($_POST['save']) && isset($_POST['note_content']))
+                sql("UPDATE `user` SET `cog_note`='&1' WHERE `user_id`='&2'", $_POST['note_content'], $user_id);
+            $content .= '<p>&nbsp;</p><div class="content2-container bg-blue02"><p class="content-title-noshade-size1">&nbsp;<img src="tpl/stdstyle/images/blue/logs.png" class="icon32" alt="Cog Note" title="Cog Note" />&nbsp;&nbsp;&nbsp;' . tr('COG_note') . '</p></div><br /><div class="content2-container">';
+            $note_query = sql("SELECT `user`.`cog_note` AS `user_note`
+                FROM `user`
+                WHERE `user_id`='&1'", $user_id);
+            $record = sql_fetch_array($note_query);
+            $content .= cogNoteForm($record["user_note"], $user_id);
+        }
+
         $ars = sql("SELECT
                     `user`.`hidden_count` AS    `ukryte`,
                     `user`.`founds_count` AS    `znalezione`,
@@ -773,4 +786,30 @@ function myUrlEncode($string)
     return str_replace($entities, $replacements, urlencode($string));
 }
 
+function cogNoteForm($note, $user_id)
+{
+    return '<form action="viewprofile.php?userid='.$user_id.'" method="post" name="user_note">
+            <input type="hidden" name="cacheid" value="{cacheid}" />
+
+            <table id="cache_note1" class="table">
+                <tr valign="top">
+                    <td></td>
+                    <td>
+                        <textarea name="note_content" rows="4" cols="85" style="font-size:13px;">'.$note.'</textarea>
+                    </td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td colspan="2">
+                        <button type="submit" name="save" value="save" style="width:100px">'.tr('save').'</button>&nbsp;&nbsp;
+                    <img src="tpl/stdstyle/images/misc/16x16-info.png" class="icon16" alt="Info" />
+                    <small>
+                        '.tr('COG_note_visible').'
+                    </small>
+                    </td>
+                </tr>
+            </table>
+        </form>
+    </div>';
+}
 ?>


### PR DESCRIPTION
Moja propozycja rozwiązania do #246.
Zaimplementowałem drugą propozycję Szanto: '2. Tylko okienko, pozostawiając wpisy uczciwości użytkowników.'

Tak to wygląda:
![zrzut ekranu z 2016-02-23 23 46 24](https://cloud.githubusercontent.com/assets/13780868/13269643/1ce74e94-da89-11e5-8113-c62d520243d7.png)
![zrzut ekranu z 2016-02-23 23 46 44](https://cloud.githubusercontent.com/assets/13780868/13269644/1ce820bc-da89-11e5-9104-31b584c46b3f.png)