### PR TITLE
Event icons in cloud on map

### DIFF
--- a/tpl/stdstyle/map/map_cacheinfo.tpl.php
+++ b/tpl/stdstyle/map/map_cacheinfo.tpl.php
@@ -71,21 +71,22 @@
     <div id='div_cacheCounters'>
 
         <p>
-            <img src='/tpl/stdstyle/images/log/16x16-found.png' width='10' height='10' />
-            {cache_founds} x
             <?php //for events founds = attended
                 if(! {is_event} ) { ?>
-                    {{found}}
+                <img src='/tpl/stdstyle/images/log/16x16-found.png' width='10' height='10' />
+                {cache_founds} x {{found}}
             <?php } else { ?>
-                    {{attendends}}
+                <img src='/tpl/stdstyle/images/log/16x16-attend.png' width='10' height='10' />
+                {cache_founds} x {{attendends}}
             <?php } ?>
         </p>
         <p>
-            <img src='/tpl/stdstyle/images/log/16x16-dnf.png' width='10' height='10' />
             <?php //for events founds = attended
                 if(! {is_event} ) { ?>
+                <img src='/tpl/stdstyle/images/log/16x16-dnf.png' width='10' height='10' />
                     {cache_not_founds} x {{not_found}}
             <?php } else { ?>
+                <img src='/tpl/stdstyle/images/log/16x16-will_attend.png' width='10' height='10' />
                     {cache_willattends} x {{will_attend}}
             <?php } ?>
         </p>


### PR DESCRIPTION
Litte commit about issue from #15 
There is a lot work to do but icons are ready now.

Before:
![zaznaczenie_005](https://cloud.githubusercontent.com/assets/13780868/13373276/6bb25d02-dd63-11e5-80ac-776d5f7f896f.png)
After: 
![zaznaczenie_006](https://cloud.githubusercontent.com/assets/13780868/13373277/795dc69e-dd63-11e5-9c85-ba11292471b8.png)
