### PR TITLE
added the option to disable google translations

### DIFF
--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -497,4 +497,7 @@ $config['garmin-key'] = array(
 
 $titled_cache_nr_found=10;
 $titled_cache_period_prefix='week';
+
+// set this to true to disable automatic translation of cache descs
+$disable_google_translation = false;
 ?>

--- a/viewcache.php
+++ b/viewcache.php
@@ -1114,14 +1114,14 @@ if ($error == false) {
             $desclang = $_REQUEST['desclang'];
         }
 
-        $enable_google_translation = false;
-
         //is no description available in the wished language?
         if (array_search($desclang, $desclangs) === false) {
             $desclang = $desclangs[0];
         }
 
-        if (strtolower($desclang) != $lang && $lang != 'pl')
+        if (isset($disable_google_translation) && $disable_google_translation)
+            $enable_google_translation = false;
+        else if (strtolower($desclang) != $lang && $lang != 'pl')
             $enable_google_translation = true;
         else
             $enable_google_translation = false;

--- a/viewcache.php
+++ b/viewcache.php
@@ -1119,12 +1119,15 @@ if ($error == false) {
             $desclang = $desclangs[0];
         }
 
-        if (isset($disable_google_translation) && $disable_google_translation)
+        if (isset($disable_google_translation) && $disable_google_translation) {
             $enable_google_translation = false;
-        else if (strtolower($desclang) != $lang && $lang != 'pl')
+        }
+        else if (strtolower($desclang) != $lang && $lang != 'pl') {
             $enable_google_translation = true;
-        else
+        }
+        else {
             $enable_google_translation = false;
+        }
 
         //build langs list
         $langlist = '';


### PR DESCRIPTION
I have set up a (devel) site and would like to see the original cache descriptions here (site lang is English, example descs are German).