### PR TITLE
fix admin menu report statistics on newlogs and logmap page

### DIFF
--- a/logmap.php
+++ b/logmap.php
@@ -2,7 +2,6 @@
 
 global $dateFormat;
 require_once ('./lib/common.inc.php');
-db_disconnect();
 
 //Preprocessing
 if ($error == false) {

--- a/newlogs.php
+++ b/newlogs.php
@@ -7,8 +7,6 @@ if (!isset($rootpath))
 //include template handling
 require_once ($rootpath . 'lib/common.inc.php');
 require_once($stylepath . '/lib/icons.inc.php');
-// this file use only database class. We don't need mysql_ connectors anymore.
-db_disconnect();
 
 //Preprocessing
 if ($error == false) {


### PR DESCRIPTION
With commit 02d2f6b, a `db_disconnect()` was inserted at the top of newlogs.php. As a result, the mysql_ calls at line 179ff of main.tpl do not work. They produce PHP warnings (if enabled) when evaluating the template code, and the numbers in the admin menu are missing on the new logs page.

There is no other page with does a `db_disconnect()`, except for index.php which does it at the very end. So I think for consistency, this problem can be solved by removing this statement.