### PR TITLE
get rid of some PHP notices

### DIFF
--- a/cachemap2.php
+++ b/cachemap2.php
@@ -161,15 +161,17 @@ global $lang;
 
 $userid = '';
 
-$get_userid = strip_tags($_REQUEST['userid']);
+if (isset($_REQUEST['userid'])) {
+	$get_userid = strip_tags($_REQUEST['userid']);
+} else {
+	$get_userid = '';
+}
+
 //user logged in?
 if ($usr == false) {
     $target = urlencode(tpl_get_current_page());
     tpl_redirect('login.php?target=' . $target);
 } else {
-    session_start();
-
-
 
     if ($get_userid == '')
         $userid = $usr['userid'];
@@ -177,7 +179,7 @@ if ($usr == false) {
         $userid = $get_userid;
     $rs = mysql_query("SELECT `latitude`, `longitude`, `username` FROM `user` WHERE `user_id`='$userid'");
     $record = mysql_fetch_array($rs);
-    if (($_REQUEST['lat'] != "" && $_REQUEST['lon'] != "") && ($_REQUEST['lat'] != 0 && $_REQUEST['lon'] != 0)) {
+    if ((isset($_REQUEST['lat']) && isset($_REQUEST['lon']) && $_REQUEST['lat'] != "" && $_REQUEST['lon'] != "") && ($_REQUEST['lat'] != 0 && $_REQUEST['lon'] != 0)) {
         $coordsXY = $_REQUEST['lat'] . "," . $_REQUEST['lon'];
         $coordsX = $_REQUEST['lat'];
         if ($_REQUEST['inputZoom'] != "")
@@ -210,7 +212,7 @@ if ($usr == false) {
     }
 
     tpl_set_var('coords', $coordsXY);
-    tpl_set_var('username', $record[username]);
+    tpl_set_var('username', $record['username']);
 
     $filter = getDBFilter($usr['userid']);
 

--- a/editcache.php
+++ b/editcache.php
@@ -631,7 +631,7 @@ if ($error == false) {
                     if (isset($config['cacheLimitByTypePerUser'][$cache_type]) && $cacheLimitByTypePerUser[$cache_type] >= $config['cacheLimitByTypePerUser'][$cache_type] && !$usr['admin']) {
                         continue;
                     }
-                    if (isset($config['cacheLimitByTypePerUser'][$type['id']]) && $cacheLimitByTypePerUser[$type['id']] >= $config['cacheLimitByTypePerUser'][$type['id']] && !$usr['admin']) {
+                    if (isset($cacheLimitByTypePerUser[$type['id']]) && isset($config['cacheLimitByTypePerUser'][$type['id']]) && $cacheLimitByTypePerUser[$type['id']] >= $config['cacheLimitByTypePerUser'][$type['id']] && !$usr['admin']) {
                         continue;
                     }
 

--- a/lib/marker.php
+++ b/lib/marker.php
@@ -1,6 +1,5 @@
 <?php
 
-session_start();
 // ini_set ('display_errors', on);
 
 require "../lib/settings.inc.php";

--- a/newcache.php
+++ b/newcache.php
@@ -332,7 +332,7 @@ if ($error == false) {
                 continue;
             }
             /* apply cache limit by type per user */
-            if (isset($config['cacheLimitByTypePerUser'][$typeId]) && $cacheLimitByTypePerUser[$typeId] >= $config['cacheLimitByTypePerUser'][$typeId]) {
+            if (isset($config['cacheLimitByTypePerUser'][$typeId]) && isset($cacheLimitByTypePerUser[$typeId]) && $cacheLimitByTypePerUser[$typeId] >= $config['cacheLimitByTypePerUser'][$typeId]) {
                 continue;
             }
             if ($typeId == $sel_type) {

--- a/newevents.php
+++ b/newevents.php
@@ -162,11 +162,11 @@ if ($error == false) {
                 }
                 $file_content .= "</tr>";
                 $content .=$file_content;
+                mysql_free_result($rs_log);
             }
         }
     }
 
-    mysql_free_result($rs_log);
     mysql_free_result($rs);
     tpl_set_var('file_content', $content);
 

--- a/pagination_class.php
+++ b/pagination_class.php
@@ -18,7 +18,7 @@ class Pagination
         $param1 = ($current_page - 1) * $per_page;
         $this->data = array_slice($values, $param1, $per_page);
 
-
+        $numbers = array();
         for ($x = 1; $x <= $counts; $x++) {
             $numbers[] = $x;
         }

--- a/printcache.php
+++ b/printcache.php
@@ -12,8 +12,9 @@ if ($_POST['flush_print_list'] != "")
     $_SESSION['print_list'] = array();
 
 //Preprocessing
-if ($_GET['cacheid'] == '') {
-    if ($error == true || !$usr || ((count($_SESSION['print_list']) == 0 ) && ($_GET['source'] != 'mywatches'))) {
+$cache_id = isset($_GET['cacheid']) ? $_GET['cacheid'] + 0 : 0;
+if (!$cache_id) {
+    if ($error == true || !$usr || ((!isset($_SESSION['print_list']) || count($_SESSION['print_list']) == 0) && ($_GET['source'] != 'mywatches'))) {
         header("Location:index.php");
         die();
     }
@@ -89,12 +90,12 @@ if ($_GET['cacheid'] == '') {
     if (!isset($_POST['nocrypt']))
         $_POST['nocrypt'] = '';
 
-    if ($_GET['cacheid'] != "") {
+    if ($cache_id) {
         $showlogs = $_POST['showlogs'];
         $pictures = $_POST['showpictures'] != "" ? $_POST['showpictures'] : "&pictures=no";
         $nocrypt = $_POST['nocrypt'];
         $spoiler_only = $_POST['spoiler_only'];
-    } else if ($_POST['flush_print_list'] != "" || $_POST['submit'] != "") {
+    } else if ($_POST['flush_print_list'] != "" || (isset($_POST['submit']) && $_POST['submit'] != "")) {
         $showlogs = $_POST['showlogs'];
         $pictures = $_POST['showpictures'];
         $nocrypt = $_POST['nocrypt'];
@@ -116,9 +117,9 @@ if ($_GET['cacheid'] == '') {
                 //var_dump($record);
             }
         }
-    } else if ($_GET['cacheid'] != "") {
+    } else if ($cache_id) {
         $caches_list = array();
-        $caches_list[] = $_GET['cacheid'];
+        $caches_list[] = $cache_id;
     } else {
         $caches_list = $_SESSION['print_list'];
     }
@@ -182,9 +183,9 @@ if ($_GET['cacheid'] == '') {
 
         <div class="nodisplay-onprint">
         <?php
-        if ($_GET['cacheid']) {
+        if ($cache_id) {
         ?>
-        <form action="printcache.php?cacheid=<?php print intval($_GET['cacheid']);?>" method="POST">
+        <form action="printcache.php?cacheid=<?php print $cache_id; ?>" method="POST">
             <?php
             } else if ((!isset($_GET['source'])) || ($_GET['source'] != 'mywatches')) {
             ?>
@@ -212,7 +213,7 @@ if ($_GET['cacheid'] == '') {
                 <input type="submit" name="submit" value="<?php print tr('printcache_09'); ?>">
 
                 <?php
-                if($_GET['cacheid'] == '')
+                if (!$cache_id)
                     if ((!isset($_GET['source'])) || ($_GET['source'] != 'mywatches')) {
                 ?>
                 &nbsp;&nbsp;&nbsp;

--- a/printcache.php
+++ b/printcache.php
@@ -153,7 +153,7 @@ if ($_GET['cacheid'] == '') {
     $checked_7 = "";
     $checked_8 = "";
 
-    if ($_POST['shownologbook'] == "&logbook=no")
+    if (isset($_POST['shownologbook']) && $_POST['shownologbook'] == "&logbook=no")
         $checked_0 = "checked";
     if (!isset($_POST['showlogs']))
         $_POST['showlogs'] = '';

--- a/tpl/stdstyle/cachemap2.tpl.php
+++ b/tpl/stdstyle/cachemap2.tpl.php
@@ -322,9 +322,10 @@ if ($usr) {
                         var marker = createMarker(point, markers[i]);
                         map.addOverlay(marker);
     <?php
-    $cacheData = getCacheData(intval($_REQUEST['cacheid']));
+    $cache_id = isset($_REQUEST['cacheid']) ? $_REQUEST['cacheid'] + 0 : 0;
+    $cacheData = getCacheData($cache_id);
     ?>
-                var cache_id = <?php echo ($_REQUEST['cacheid'] == '' ? 0 : $_REQUEST['cacheid']); ?>;
+                var cache_id = <?php echo $cache_id; ?>;
                         var cache_name = "<?php echo $cacheData['cachename']; ?>";
                         var cache_owner = "<?php echo $cacheData['username']; ?>";
                         var cache_topratings = <?php echo ($cacheData['topratings'] == '' ? '0' : $cacheData['topratings']); ?>;
@@ -362,7 +363,7 @@ if ($usr) {
                         for (ii = 0; ii < cache_topratings; ii++)
                         print_topratings += gwiazdka;
                 }
-    <?php ((onTheList($_SESSION['print_list'], $_REQUEST['cacheid']) == -1 ) ? $yn = 'y' : $yn = 'n'); ?>
+    <?php ((onTheList($_SESSION['print_list'], $cache_id) == -1 ) ? $yn = 'y' : $yn = 'n'); ?>
 
                 if (markers[i].getAttribute("id") == cache_id)
                 {
@@ -530,7 +531,7 @@ if ($usr) {
                     <input type="hidden" name="cachelimit" id="cachelimit" value="<?php echo (($filter[19] + 1) * 50); ?>">
                     <input type="hidden" name="cachesort" id="cachesort" value="<?php echo $filter[20]; ?>">
     <?php
-    if ($_REQUEST['lat'] == "" || $_REQUEST['lon'] == "") {
+    if (!isset($_REQUEST['lat']) || !isset($_REQUEST['lon']) || $_REQUEST['lat'] == "" || $_REQUEST['lon'] == "") {
         $lat_val = "";
         $lon_val = "";
     } else {

--- a/viewreport.php
+++ b/viewreport.php
@@ -289,7 +289,7 @@ if ($error == false && $usr['admin']) {
         } else {
             $userlogin = strftime("%Y-%m-%d", strtotime(mysql_result($userlogin_query, 0)));
         }
-        $content .= "<tr>";
+        $content = "<tr>";
 
         $content .= "<td><span class='content-title-noshade-size05'>" . $report['report_id'] . "</span></td>";
         $content .= "<td><span class='content-title-noshade-size05'>" . $report['submit_date'] . "</span></td>";
@@ -347,6 +347,7 @@ if ($error == false && $usr['admin']) {
         tpl_set_var('active_form', $active_form);
 
         $actions = '';
+        $mail_actions = '';
         //$actions .= "<li><a href='voting.php?reportid=".$report['report_id']."'>Zarządź głosowanie</a></li>";
         for ($i = 0; $i < 3; $i++)
             $mail_actions .= "<li><a href='viewreport.php?reportid=" . $report['report_id'] . "&amp;mailto=$i'>" . tr('cache_reports_25') . "  " . writeRe($i) . "</a></li>";

--- a/viewreports.php
+++ b/viewreports.php
@@ -66,7 +66,7 @@ $tplname = 'viewreports';
 $content = '';
 // tylko dla członków Rady
 if ($error == false && $usr['admin']) {
-    if ($_GET['archiwum'] == 1) {
+    if (isset($_GET['archiwum']) && $_GET['archiwum'] == 1) {
         tpl_set_var('arch_curr', tr("cache_reports_34"));
         tpl_set_var('archiwum', 0);
         $show_archive = " reports.status = 2 AND ";


### PR DESCRIPTION
There were some PHP notices and warnings when running OCPL code with PHP setting `error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT`.

The `session_start()` in cachemap2.php and lib/marker.php is redundant to `session_start()` in common.inc.php.