### PR TITLE
set some missing template variables

### DIFF
--- a/myneighborhood.php
+++ b/myneighborhood.php
@@ -678,8 +678,10 @@ if ($error == false) {
     if ( $dbcLocCache->rowCount() > 10) {
         tpl_set_var('more_topcaches', '<a class="links" href="myn_topcaches.php">[' . tr("show_more") . '...]</a>');
         $limit = 10;
-    } else
+    } else {
+        tpl_set_var('more_topcaches', '');
         $limit = $dbcLocCache->rowCount();
+    }
 
     if ($limit == 0) {
         $file_content = "<p>&nbsp;&nbsp;&nbsp;&nbsp;<b>" . tr('list_of_caches_is_empty') . "</b></p><br />";

--- a/removelog.php
+++ b/removelog.php
@@ -175,6 +175,7 @@ function removelog($log_id, $language, $lang)
                 tpl_set_var('logid', htmlspecialchars($log_id, ENT_COMPAT, 'UTF-8'));
                 $log = read_file($stylepath . '/viewcache_log.tpl.php');
                 $log = mb_ereg_replace('{date}', htmlspecialchars(strftime("%d %B %Y", strtotime($log_record['log_date'])), ENT_COMPAT, 'UTF-8'), $log);
+                $log = mb_ereg_replace('{time}', htmlspecialchars(strftime("%H:%M", strtotime($log_record['log_date'])), ENT_COMPAT, 'UTF-8'), $log);
                 if (isset($log_record['recommended']) && $log_record['recommended'] == 1) {
                     $log = mb_ereg_replace('{ratingimage}', $rating_picture, $log);
                 } else {


### PR DESCRIPTION
{more_topcaches} was displayed on the "My neighborhood" page if there were less then 11 recommended caches in the area.

{time} was displayed when removing logs.