### PR TITLE
fast fix for admin notes (#246)

### DIFF
--- a/lib/Objects/User/AdminNote.php
+++ b/lib/Objects/User/AdminNote.php
@@ -165,7 +165,7 @@ class AdminNote
 
     public static function getAllUserNotes($user_id)
     {
-        $results = [];
+        $results = array();
         $i = 0;
         $db = DataBaseSingleton::Instance();
         $query = "SELECT `admin_id`, `cache_id`, `automatic`, `datetime`, `content` FROM `admin_user_notes` WHERE `user_id`=:1 ORDER BY `datetime` DESC";


### PR DESCRIPTION
@mzylowski, 

tworzenie tablic w php w formie $tablica = [] psuje instalacje ze starszą wersją php (w każdym razie na moim 5.3.* to jest error i się skrypt wywala)