### PR TITLE
removed obsolete javascript code from cachemap2.php

### DIFF
--- a/cachemap2.php
+++ b/cachemap2.php
@@ -246,12 +246,6 @@ if ($usr == false) {
                     }
                 }
             }
-            // Create a function that will receive data sent from the server
-            ajaxRequest.onreadystatechange = function(){
-                if(ajaxRequest.readyState == 4){
-                    document.myForm.time.value = ajaxRequest.responseText;
-                }
-            }
 
             var mapid;
             switch (map.getCurrentMapType()) {


### PR DESCRIPTION
The only effect of this code is that it produces a Javascript error when leaving the cachemap2 page:

`TypeError: document.myForm is undefined`

There is no form "myForm" and no form element "time"; must be some leftover code.