### PR TITLE
non-working translations based on google removed (in context of #214)

### DIFF
--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -94,6 +94,9 @@ final class OcConfig
         }else{
             $this->mapsConfig = array();
         }
+
+        $this->isGoogleTranslationEnabled = !( isset( $disable_google_translation ) && $disable_google_translation );
+
     }
 
     function getDateFormat()
@@ -111,7 +114,7 @@ final class OcConfig
         return $this->wikiLinks;
     }
 
-        function getContactMail()
+    function getContactMail()
     {
         return $this->contactMail;
     }
@@ -204,6 +207,14 @@ final class OcConfig
     public function getPowerTrailModuleSwitchOn()
     {
         return $this->powerTrailModuleSwitchOn;
+    }
+
+    /**
+     * returns true if google automatic translation is enabled in config
+     */
+    public function isGoogleTranslationEnabled()
+    {
+        return $this->isGoogleTranslationEnabled;
     }
 
     protected function getMapsConfig()

--- a/tpl/stdstyle/viewcache.tpl.php
+++ b/tpl/stdstyle/viewcache.tpl.php
@@ -1,7 +1,3 @@
-<?php
-
-?>
-
 <!-- Text container -->
 {body_scripts}
 
@@ -189,7 +185,6 @@
         {desc_langs}&nbsp;{add_rr_comment}&nbsp;{remove_rr_comment}
     </p></div>
 <div class="content2-container">
-    <div id='branding'>{branding}</div>
     <div id="description">
         <div id="viewcache-description">
             {desc}

--- a/tpl/stdstyle/viewcache_print.tpl.php
+++ b/tpl/stdstyle/viewcache_print.tpl.php
@@ -1,6 +1,3 @@
-<?php
-
-?>
 <script language="javascript" type="text/javascript">
     function hidediv() {
         if (document.getElementById) { // DOM3 = IE5, NS6
@@ -44,7 +41,6 @@ global $usr, $lang, $hide_coords;
 </div>
 
 <div class="content2-container">
-    <div id="branding">{branding}</div>
     <div id="description">
         <div id="viewcache-description">
             {desc}


### PR DESCRIPTION
Google translation in version 1 (used in oc code) is not available anymore.
New version (v2) is now a paid service so is useless for our project.

I save a stub of config in the code - maybe we'll decide to use google translation plugin instead of previous translation solution - then it would be useful.