### PR TITLE
new Db access class + new Email* classes

### DIFF
--- a/Utils/Database/OcDb.php
+++ b/Utils/Database/OcDb.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace Utils\Database;
+use PDOException;
+
+class OcDb extends OcPdo
+{
+
+    protected $stmt; //internal PDOStatement
+
+    const BIND_CHAR = ':'; //
+
+    /**
+     * @return one row from result, or FALSE if there are no more rows available
+     * The data is returned as an array indexed by column name, as returned in your
+     * SQL SELECT
+     */
+    public function dbResultFetch()
+    {
+        return $this->stmt->fetch();
+    }
+
+    /**
+     * for queries witch LIMIT 1 return only one row
+     * and reset database class preparing it for next job.
+     */
+    public function dbResultFetchOneRowOnly()
+    {
+        $result = $this->stmt->fetch();
+        $this->reset();
+        return $result;
+    }
+
+    /**
+     * The returned array contains all of the remaining rows
+     * (if you have previously called dbResultFetch(), or all returned rows if not)
+     * in the result set. The array represents each row as an array indexed by column name,
+     * as returned in your SQL SELECT. An empty array is returned
+     * if there are zero results to fetch, or FALSE on failure.
+     *
+     * @return all rows from result as complex array.
+     */
+    public function dbResultFetchAll()
+    {
+        $result = $this->stmt->fetchAll();
+        $this->closeCursor();
+        return $result;
+    }
+
+    /**
+     * This method returns the value from first column of first row in statement
+     *
+     * @param unknown $default - default value to return if there is no results
+     */
+    protected function dbResultFetchValue($default){
+        $row = $this->dbResultFetch();
+        $this->closeCursor();
+        if ($row) {
+            $value = reset($row);
+            if ($value == null){
+                return $default;
+            } else {
+                return $value;
+            }
+        } else {
+            return $default;
+        }
+    }
+
+
+    /**
+     * @return number of row in results (i.e. number of rows returned by SQL SELECT)
+     * or the number of rows affected by the last DELETE, INSERT, or UPDATE statement
+     */
+    public function rowCount()
+    {
+        return $this->stmt->rowCount();
+    }
+
+    /**
+     * simple querry
+     * Use only with static queries, Queries should contain no variables.
+     * For queries with variables use paramQery method
+     *
+     * @param string $query
+     * @return true, if the query succeeded; false, if there was SQL error
+     */
+    public function simpleQuery($query)
+    {
+        try {
+            $this->stmt = $this->prepare($query);
+            $this->stmt->setFetchMode(self::FETCH_ASSOC);
+            $this->stmt->execute();
+
+        } catch (PDOException $e) {
+
+            $this->error('Query: '.$query, $e);
+            return false;
+        }
+
+        if ($this->debug) {
+            self::debugOut(__METHOD__.":\n\nQuery: ".$query);
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes given query. If the query return no rows, or null value, default value is returned.
+     * Otherwise, value of first column in a first row is returned.
+     *
+     * @param $query Query to be executed
+     * @param $default Default value
+     *
+     * @return
+     */
+    public function simpleQueryValue($query, $default)
+    {
+        $this->simpleQuery($query);
+        return $this->dbResultFetchValue($default);
+    }
+
+
+    /**
+     * @param $query - string, with params representation instead variables.
+     * @param $params - array with variables.
+     *
+     * [keyname][value]
+     * [keyname][data_type]
+     *
+     * example:
+     * ----------------------------------------------------------------------------------
+     * $query: 'SELECT * FROM tabele WHERE field1 = :variable1 AND field2 = :variable2'
+     * $params['variable1']['value'] = 1;
+     * $params['variable1']['data_type'] = 'integer';
+     * $params['variable2']['value'] = 'cat is very lovelly animal';
+     * $params['variable2']['data_type'] = 'string';
+     * ----------------------------------------------------------------------------------
+     * data type can be:
+     *
+     * - 'boolean'                  Represents a boolean data type.
+     * - 'null'                     Represents the SQL NULL data type.
+     * - 'integer' or 'int' or 'i'  Represents the SQL INTEGER data type.
+     * - 'string' or 'str' or 's'   Represents the SQL CHAR, VARCHAR, or other string data type.
+     * - 'large'                    Represents the SQL large object data type.
+     * - 'recordset'                Represents a recordset type. Not currently supported by any drivers.
+     *
+     * @return true, if the query succeeded; false, if there was SQL error
+     */
+    public function paramQuery(/*PHP7: string*/ $query, array $params)
+    {
+        try {
+            $this->stmt = $this->prepare($query);
+
+            foreach ($params as $key => $val) {
+                switch ($val['data_type']) {
+                    case 'integer':
+                    case 'int':
+                    case 'i':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_INT);
+                        break;
+                    case 'boolean':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_BOOL);
+                        break;
+                    case 'string':
+                    case 'str':
+                    case 's':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_STR);
+                        break;
+                    case 'null':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_NULL);
+                        break;
+                    case 'large':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_LOB);
+                        break;
+                    case 'recordset':
+                        $this->stmt->bindParam($key, $val['value'], self::PARAM_STMT);
+                        break;
+                    default:
+                        return false;
+                }
+            }
+
+            $this->stmt->setFetchMode(self::FETCH_ASSOC);
+            $this->stmt->execute();
+
+        } catch (PDOException $e) {
+
+            $this->error("Query:\n$query\n\nParams:\n".implode(' | ', $params), $e);
+            return false;
+        }
+        if ($this->debug) {
+            self::debugOut(__METHOD__.":\n\nQuery:\n$query\n\nParams:\n".implode(' | ', $params));
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes given query, as described in method paramQuery().
+     * If the query return no rows, or null value, default value is returned.
+     * Otherwise, value from first column of the first row is returned.
+     *
+     * @param $query Query to be executed
+     * @param $default Default value
+     * @param $params Query params
+     *
+     * @return
+     */
+    public function paramQueryValue($query, $default, array $params)
+    {
+        $this->paramQuery($query, $params);
+        return $this->dbResultFetchValue($default);
+    }
+
+    /**
+     * @param $query - string, with params representation instead variables.
+     * @param $param1, param2 .. paramN - variables.
+     *
+     *
+     * example:
+     * ----------------------------------------------------------------------------------
+     * $param1 = 1;
+     * $param2 = 'cat is very lovelly animal';
+     * // note that variable in query MUST be in format :1, :2, :3 (and so on).
+     * $query = 'SELECT something FROM tabele WHERE field1=:1 AND field2=:2';
+     *
+     * multiVariableQuery($query, $param1, $param2 )
+     * ----------------------------------------------------------------------------------
+     *
+     * @return true, if the query succeeded; false, if there was SQL error
+     */
+    public function multiVariableQuery($query)
+    {
+        $numargs = func_num_args();
+        $arg_list = func_get_args();
+
+        // check if params are passed as array
+        if ($numargs === 2 && is_array($arg_list[1])) {
+            $arg_list = $arg_list[1];
+            $numargs = count($arg_list) + 1;
+        }
+
+        try {
+            $this->stmt = $this->prepare($query);
+
+            for ($i = 1; $i < $numargs; $i++) {
+                $this->stmt->bindParam(self::BIND_CHAR . $i, $arg_list[$i]);
+            }
+            $this->stmt->setFetchMode(self::FETCH_ASSOC);
+            $this->stmt->execute();
+        } catch (PDOException $e) {
+
+            $message = 'Query|Params: '.implode(' | ', $arg_list);
+            $this->error($message, $e);
+            return false;
+        }
+
+        if ($this->debug) {
+            self::debugOut(__METHOD__.":\n\nQuery|Params: ".implode(' | ', $arg_list));
+        }
+        return true;
+    }
+
+
+    /**
+     * Executes given query, as described in method multiVariableQuery().
+     * If the query return no rows, or null value, default value is returned.
+     * Otherwise, value of first column in a first row is returned.
+     *
+     * @param params - Query to be executed, default value, query params
+     *
+     * @return
+     */
+    public function multiVariableQueryValue($query, $default)
+    {
+        $argList = func_get_args();
+        if ( 2 <= count($argList)) {
+
+            //only query + default value=> use simpleQuery
+            $e = new PDOException('Improper '.__METHOD__.' using. Too low arguments. Use simpleQueryValue() instead');
+            $this->error($message, $e, false, false); //skip sending email
+
+            return $this->simpleQueryValue($query, $default);
+        }
+
+        //more params - remove first two from argList and call...
+        $this->multiVariableQuery($query, $default, array_slice($argList, 2));
+        return $this->dbResultFetchValue($default);
+    }
+
+
+    /**
+     * Closes current cursor. Some methods, which drain cursor (like dbResultFetchAll())
+     * or expect only one row (like *QueryValue()) close cursor implicitly.
+     */
+    public function closeCursor()
+    {
+        try{
+
+            if(is_object($this->stmt)){
+                $this->stmt->closeCursor();
+            }
+            $this->stmt = null;
+        }catch (PDOException $e) {
+            $this->error('Unexpected error on cursor close?!', $e);
+        }
+    }
+
+    /**
+     * reset data from prevous results and make class ready for next query
+     */
+    public function reset()
+    {
+        $this->closeCursor();
+    }
+
+}

--- a/Utils/Database/OcPdo.php
+++ b/Utils/Database/OcPdo.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Utils\Database;
+
+use lib\Objects\OcConfig\OcConfig;
+use Utils\Email\EmailSender;
+use PDO;
+use PDOException;
+use Utils\Email\OcSpamDomain;
+
+class OcPdo extends PDO
+{
+
+    protected $debug; //bool, if set enabled debug messages
+
+    /**
+     *
+     * @param string $debug
+     */
+    public function __construct($debug = false)
+    {
+        if ($debug === true) {
+            $this->debug = true;
+        }
+
+        $conf = OcConfig::instance();
+
+        $dsnarr = array(
+            'host' => $conf->getDbHost(),
+            'dbname' => $conf->getDbName(),
+            'charset' => 'utf8'
+        );
+
+        $options = array(
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false
+        );
+
+        /*
+         * Older PHP versions do not support the 'charset' DSN option.
+         * This should be removed in future
+         */
+        if ($dsnarr['charset'] and version_compare(PHP_VERSION, '5.3.6', '<')) {
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $dsnarr['charset'];
+        }
+
+        $dsnpairs = array();
+        foreach ($dsnarr as $k => $v) {
+            if ($v === null) {
+                continue;
+            }
+            $dsnpairs[] = $k . "=" . $v;
+        }
+
+        $dsn = 'mysql:' . implode(';', $dsnpairs);
+        try{
+            parent::__construct(
+                $dsn, $conf->getDbUser(), $conf->getDbPass(), $options
+            );
+        }catch (PDOException $e){
+            $message = "OcPdo object creation failed!";
+            $this->error($message, $e, true); //fatal error!
+            return null;
+        }
+    }
+
+    /**
+     * Handle error/exception occurence around DB operations
+     *
+     * @param string $message - description of the error
+     * @param PDOException $e - exception object
+     * @param bool $fatal     - should this error shutdown the script?
+     * @param bool $sendEmail - should Email about error should be send?
+     */
+    protected function error(/*PHP7:string*/ $message, PDOException $e=null,
+                             /*PHP7:bool*/ $fatal=false, /*PHP7:bool*/ $sendEmail=true){
+
+        $email_text  = "PDO Error: ";
+        $email_text .= "\n\t".$message;
+        if( !is_null($e) ){
+            $email_text .= "\n\n\tEx_Code: ".$e->getCode();
+            $email_text .= "\n\n\tEx_Msg: ".$e->getMessage();
+        }else{
+            //there is no Exception - generate one to get the trace
+            $e = new PDOException();
+        }
+        $email_text .= "\n\n\tEx_Trace:\n\n".$e->getTraceAsString();
+
+        //send email to RT
+        if($sendEmail)
+            EmailSender::adminOnErrorMessage($email_text, OcSpamDomain::DB_ERRORS);
+
+        if($this->debug){
+            d($email_text);
+        }
+
+        if($fatal){
+            // TODO: How to better handle error - print some nice error page
+            // this is fatal error - stop the script
+            trigger_error("OcPdo Error: $message", E_USER_ERROR);
+            exit;
+        }else{
+            // non-fatal error: only print warning
+            trigger_error("OcPdo Error: $message", E_USER_WARNING);
+        }
+    }
+
+    /**
+     * Print debug messages around DB operations
+     *
+     * @param string $text
+     */
+    protected function debugOut(/*PHP7:string*/ $text)
+    {
+        if( ! $this->debug ){
+            return;
+        }
+        d($text);
+    }
+
+    /**
+     * This the ONLY way on which instance of this class
+     * should be accessed
+     *
+     * Returns instance of itself.
+     *
+     * @return OcPdo object
+     */
+    public static function instance()
+    {
+        static $instance = null;
+        if ($instance === null) {
+            $instance = new static(false);
+        }
+        return $instance;
+    }
+
+    /**
+     * Turn on debug messages around DB operations
+     * @param unknown $debug
+     */
+    public function setDebug(/*PHP7:bool*/ $debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * Private clone method to prevent cloning of the instance of the
+     * *Singleton* instance.
+     *
+     * @return void
+     */
+    private function __clone() {}
+
+}

--- a/Utils/Email/Email.php
+++ b/Utils/Email/Email.php
@@ -75,7 +75,7 @@ class Email
         if(!empty($this->toAddr))
             $to = implode(',', $this->toAddr);
         else
-            $to=''; //TODO: is it works?
+            $to=''; //TODO: is it work?
 
         $subject = $this->subjectPrefix . $this->subject;
         $message = $this->body;
@@ -165,14 +165,14 @@ class Email
             empty($this->bccAddr) ){
 
                 //no recipient of this email
-                $this->error(__METHOD__.": Trying to send email with no recipients!");
+                $this->error(__METHOD__.": Trying to send email with no recipients.");
                 return false;
         }
 
         //check subject
         if($this->subject == ''){
             //empty subject email
-            $this->error(__METHOD__.": Trying to send email with no recipients!");
+            $this->error(__METHOD__.": Trying to send email without subject.");
             return false;
         }
 

--- a/Utils/Email/Email.php
+++ b/Utils/Email/Email.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * This is general class to sending emails
+ * It shouldn't be used outside of EmailSender class;
+ *
+ * If you want to send some email from the OC code implement
+ * proper method in EmailSender class.
+ *
+ */
+
+namespace Utils\Email;
+
+class Email
+{
+    private $toAddr = array();
+    private $ccAddr = array();
+    private $bccAddr = array();
+
+    private $fromAddr;
+    private $replyToAddr;
+
+    private $xMailer;
+
+    private $subjectPrefix=''; //subject prefix set in all emails
+    private $subject='';
+
+    private $body='';
+    private $body_header=''; //header of message set in all emails
+    private $body_footer=''; //footer of email set in all emails
+
+    private $isHtmlEmail;
+
+    public function __construct(){
+        $this->xMailer = phpversion();
+        $this->isHtmlEmail = true; //only HTML emails
+
+        //TODO : should be set based on config
+        $this->subjectPrefix = '';
+        $this->body_header = '';
+        $this->body_footer = '';
+    }
+
+    /**
+     * Send the email based on current settings
+     * Returns true on success
+     */
+    public function send(){
+
+        if(! $this->isEmailValid() ){
+            return false;
+        }
+
+        // Each line of message should be separated with a CRLF (\r\n).
+        // Lines should not be larger than 70 characters.
+        //TODO:...
+        //wordwrap($message, 70, "\r\n");
+
+        $headers[] = 'From: '. $this->fromAddr;
+        $headers[] = 'Reply-To: '. $this->replyToAddr;
+        $headers[] = 'X-Mailer: PHP/' . $this->xMailer;
+
+        if($this->isHtmlEmail){
+            // To send HTML mail, the Content-type header must be set
+            $headers[] = 'MIME-Version: 1.0';
+            $headers[] = 'Content-type: text/html; charset=iso-8859-1';
+        }
+
+        // Additional headers
+        if(!empty($this->ccAddr))
+            $headers[] = 'Cc: ' . implode(',',$this->ccAddr);
+
+        if(!empty($this->bccAddr))
+            $headers[] = 'Bcc: ' .implode(',',$this->bccAddr);;
+
+        if(!empty($this->toAddr))
+            $to = implode(',', $this->toAddr);
+        else
+            $to=''; //TODO: is it works?
+
+        $subject = $this->subjectPrefix . $this->subject;
+        $message = $this->body;
+
+        return mb_send_mail($to, $subject, $message, implode("\r\n", $headers));
+    }
+
+    public function addToAddr($addr){
+        if(self::isValidEmail($addr)){
+            $this->toAddr[] = $addr;
+            return true;
+        }else{
+            $this->error(__METHOD__.': improper email address: '.$addr);
+            return false;
+        }
+    }
+
+    public function addCcAddr($addr){
+        if(self::isValidEmail($addr)){
+            $this->ccAddr[] = $addr;
+            return true;
+        }else{
+            $this->error(__METHOD__.': improper email address: '. $addr);
+            return false;
+        }
+    }
+
+    public function addBccAddr($addr){
+        if(self::isValidEmail($addr)){
+            $this->bccAddr[] = $addr;
+            return true;
+        }else{
+            $this->error(__METHOD__.': improper email address: '. $addr);
+            return false;
+        }
+    }
+
+    public function setFromAddr($addr){
+        if(self::isValidEmail($addr)){
+            $this->fromAddr = $addr;
+            return true;
+        }else{
+            $this->error(__METHOD__.': improper email address: '. $addr);
+            return false;
+        }
+    }
+
+    public function setReplyToAddr($addr){
+        if(self::isValidEmail($addr)){
+            $this->replyToAddr = $addr;
+            return true;
+        }else{
+            $this->error(__METHOD__.': improper email address: '. $addr);
+            return false;
+        }
+    }
+
+    public function setSubject($subject){
+        $this->subject = $subject;
+    }
+
+    public function setBody($body){
+        $this->body = $body;
+    }
+
+    /**
+     * returns TRUE is given emailAddress has proper format
+     */
+    public static function isValidEmail($emailAddress)
+    {
+        //if( false === filter_var($emailAddress, FILTER_VALIDATE_EMAIL) ){
+        //    return false;
+        //}
+        return true;
+    }
+
+    private function error($message, Exception $e=null){
+        //TODO:
+        trigger_error($message, E_USER_NOTICE);
+    }
+
+    private function isEmailValid(){
+
+        //check recipients
+        if( empty($this->toAddr) &&
+            empty($this->ccAddr) &&
+            empty($this->bccAddr) ){
+
+                //no recipient of this email
+                $this->error(__METHOD__.": Trying to send email with no recipients!");
+                return false;
+        }
+
+        //check subject
+        if($this->subject == ''){
+            //empty subject email
+            $this->error(__METHOD__.": Trying to send email with no recipients!");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Utils/Email/EmailSender.php
+++ b/Utils/Email/EmailSender.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Purpose of this class: provide simple interface
+ * for sending email messages from the code
+ *
+ * This class is interface to Email class.
+ *
+ */
+
+namespace Utils\Email;
+
+use lib\Objects\OcConfig\OcConfig;
+
+class EmailSender
+{
+    /**
+     * This method provide simple interface to send email messages
+     * to OC Technical Admins (RT) if unexpected error occurs.
+     *
+     * @param string $message
+     */
+    public static function adminOnErrorMessage(
+        $message,
+        $spamDomain=OcSpamDomain::GENERIC_ERRORS)
+    {
+
+        //first check if sending email is allowed
+        if(!OcSpamDomain::isEmailAllowed($spamDomain)){
+            //skip email
+            return;
+        }
+
+        //ok, mail allowed - build it
+        $email = new Email();
+
+        $email->addToAddr( OcConfig::getTechAdminsEmailAddr());
+        $email->setReplyToAddr( OcConfig::getTechAdminsEmailAddr());
+        $email->setFromAddr( OcConfig::getSenderEmailAddr());
+
+        $email->setSubject('[Oc Admin Email] Error in domain: '.$spamDomain); //TODO
+        $email->setBody($message);
+
+        if( ! $email->send() ){
+            trigger_error(__METHOD__.": Email sending failed!", E_USER_NOTICE);
+        }
+    }
+}

--- a/Utils/Email/OcSpamDomain.php
+++ b/Utils/Email/OcSpamDomain.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This class provides simple mechanism for
+ * prevent generation of too many emails sending by oc
+ */
+
+namespace Utils\Email;
+
+class OcSpamDomain {
+
+    //domains - different error-trigger errors can have different domians
+    //TODO: it should be rewrite to some kind of enum
+    const GENERIC_ERRORS = 'genericError';
+    const DB_ERRORS = 'dbError';
+
+    /**
+     * Answer if the email can be sent by OC
+     *
+     * @param enum $domain - only predefined domains are supported
+     * @return boolean - true if email can be sent
+     */
+    public static function isEmailAllowed($domain){
+
+        $lockFile = self::getLockFile($domain);
+        if(is_null($lockFile)){
+            //unknown domain - don't send anything
+            return false;
+        }
+
+        if ( file_exists($lockFile) ){
+
+            $lastEmail = filemtime($lockFile);
+            $timeout = self::getTimeout($domain);
+
+            if (time() - $last_email < $timeout) {
+                //timeout not expired - don't send anything
+                return false;
+            }
+        }
+
+        @touch($lock_file);
+        return true;
+    }
+
+    /**
+     * This function returns timeout used by error-spam-domain
+     * Only predefined domains are supported
+     *
+     * TODO: it should be read from configuration in the future
+     *
+     * @param const $domain - domain const
+     * @return int - timeout in sec.
+     */
+    private static function getTimeout($domain)
+    {
+        switch ($domain){
+            case self::DB_ERRORS:
+                return 60;
+                break;
+
+            case self::GENERIC_ERRORS:
+                return 60;
+                break;
+
+            default:
+                trigger_error(__METHOD__.": Unknown ocSpam domain: ".$domain, E_USER_WARNING);
+                return 1800; //one-per-hour
+        }
+    }
+
+    /**
+     * This function returns lock file used by error-spam-domain
+     * Only predefined domains are supported
+     *
+     * TODO: it should be read from configuration in the future
+     *
+     * @param const $domain - domain const
+     * @return string|NULL
+     */
+    private static function getLockFile($domain)
+    {
+        switch ($domain){
+            case self::DB_ERRORS:
+                return '/tmp/ocSpamDomain-db-errors-emails.lock';
+                break;
+
+            case self::GENERIC_ERRORS:
+                return '/tmp/ocSpamDomain-generic-errors-emails.lock';
+                break;
+
+            // Add another domain config here
+            default:
+                //no such domain - trigger warning
+                trigger_error(__METHOD__.": Unknown ocSpam domain: ".$domain, E_USER_WARNING);
+                return null;
+        }
+    }
+}

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -51,6 +51,10 @@ final class OcConfig
     private $dbHost;
     private $dbName;
 
+    // system emails
+    private $senderEmailAddr; //$emailaddr
+    private $techAdminsEmailAddr; //$mail_rt
+
     /**
      * Call this method to get singleton
      * @return ocConfig
@@ -265,4 +269,19 @@ final class OcConfig
     public function getDbName(){
         return $this->dbName;
     }
+
+    public static function getSenderEmailAddr(){
+        //TODO
+        //it will be immplemented in a future
+
+        return 'noreply@opencaching.pl';
+    }
+    public static function getTechAdminsEmailAddr(){
+        //private $techAdminsEmailAddr;
+        global $mail_rt;
+        //TODO -this is only a fast path to settings
+        //it will be immplemented in a future
+        return $mail_rt;
+    }
+
 }

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -51,10 +51,6 @@ final class OcConfig
     private $dbHost;
     private $dbName;
 
-    // system emails
-    private $senderEmailAddr; //$emailaddr
-    private $techAdminsEmailAddr; //$mail_rt
-
     /**
      * Call this method to get singleton
      * @return ocConfig
@@ -271,17 +267,16 @@ final class OcConfig
     }
 
     public static function getSenderEmailAddr(){
-        //TODO
-        //it will be immplemented in a future
-
+        //it will be implemented in a future
+        //currently this is only a stub...
         return 'noreply@opencaching.pl';
     }
+
     public static function getTechAdminsEmailAddr(){
-        //private $techAdminsEmailAddr;
+        //it will be implemented in a future
+        //currently this is only a stub...
         global $mail_rt;
-        //TODO -this is only a fast path to settings
-        //it will be immplemented in a future
+
         return $mail_rt;
     }
-
 }


### PR DESCRIPTION
This are changes which are preparation for #276.
This is of course proposition only - comments are welcome.

I would like to:
- migrate all code uses old /lib/Database class to OcDb class which has the same interface
- OcPdo is also to use as an option (please remember PDO throws exceptions on errors!)
- migrate sending emails to the EmailSender class (but this is for further works)

Please note: this code is still not well tested. I made some tests but I know this is not the end.  