### PR TITLE
Db wrapper for mysql_* functions

### DIFF
--- a/Utils/Database/OcDb.php
+++ b/Utils/Database/OcDb.php
@@ -275,18 +275,29 @@ class OcDb extends OcPdo
     public function multiVariableQueryValue($query, $default)
     {
         $argList = func_get_args();
-        if ( 2 <= count($argList)) {
+        if ( 2 >= count($argList)) {
 
             //only query + default value=> use simpleQuery
             $e = new PDOException('Improper '.__METHOD__.' using. Too low arguments. Use simpleQueryValue() instead');
-            $this->error($message, $e, false, false); //skip sending email
+            $this->error('Improper '.__METHOD__.' using', $e, false, false); //skip sending email
 
             return $this->simpleQueryValue($query, $default);
         }
 
         //more params - remove first two from argList and call...
-        $this->multiVariableQuery($query, $default, array_slice($argList, 2));
-        return $this->dbResultFetchValue($default);
+        $this->multiVariableQuery($query, array_slice($argList, 2));
+
+        $result = $this->dbResultFetchValue($default);
+        if ($result) { //we got a reullt from query
+            $value = reset($result);
+            if ($value == null){
+                return $default;
+            }else{
+                return $value;
+            }
+        } else {
+            return $default;
+        }
     }
 
 

--- a/Utils/Database/OcPdo.php
+++ b/Utils/Database/OcPdo.php
@@ -87,6 +87,12 @@ class OcPdo extends PDO
         }
         $email_text .= "\n\n\tEx_Trace:\n\n".$e->getTraceAsString();
 
+        //get short version of the trace
+        $traceStr = '';
+        foreach($e->getTrace() as $trace){
+            $traceStr.= ' | '.$trace['file'].'::'.$trace['line'];
+        }
+
         //send email to RT
         if($sendEmail)
             EmailSender::adminOnErrorMessage($email_text, OcSpamDomain::DB_ERRORS);
@@ -98,11 +104,11 @@ class OcPdo extends PDO
         if($fatal){
             // TODO: How to better handle error - print some nice error page
             // this is fatal error - stop the script
-            trigger_error("OcPdo Error: $message", E_USER_ERROR);
+            trigger_error("OcPdo Error:\n $message. Trace: ".$traceStr, E_USER_ERROR);
             exit;
         }else{
             // non-fatal error: only print warning
-            trigger_error("OcPdo Error: $message", E_USER_WARNING);
+            trigger_error("OcPdo Error: $message. Trace: ".$traceStr, E_USER_WARNING);
         }
     }
 

--- a/Utils/Database/XDb.php
+++ b/Utils/Database/XDb.php
@@ -7,6 +7,7 @@
  */
 
 namespace Utils\Database;
+use PDOStatement;
 
 class XDb extends OcDb {
 
@@ -110,6 +111,26 @@ class XDb extends OcDb {
         return $stmt->fetchColumn($colNum);
     }
 
+    /**
+     * This is replacement for sql(...) function call from /lib/clicompatbase.php
+     *
+     * IMPORTANT: additional params needs to be converted from &<1-9> to ? in na proper way!
+     * IMPORTANT: additional params can't be used as table/column name!
+     *
+     * @param unknown $sql
+     * @param ... there can be optional list of params to bind with query
+     */
+    public static function xSql($sql){
+        $db = self::instance();
+        $stmt = $db->prepare($sql);
 
+        //$numargs = func_num_args();
+        $argList = func_get_args();
+        unset( $argList[0] ); //remove first param.
+
+        $stmt->execute($argList);
+        return $stmt;
+
+    }
 
 }

--- a/Utils/Database/XDb.php
+++ b/Utils/Database/XDb.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * This class SHOULDN'T BE USED in any new implementations.
+ * This is wrapper on OcDb class created for fast replacement mysql_* functions
+ * without bigger integrations in the code.
+ */
+
+namespace Utils\Database;
+
+class XDb extends OcDb {
+
+    /**
+     * This is replacement for mysql_query()
+     * Oryginal mysql_query has params: sql-string, optional $link, optional params to sql-query
+     * Oc code doesn't contains calls with params to sql query, so this is not implemented.
+     * Link as argument is just ignored.
+     *
+     * @param string $sql
+     * @return PDOStatement or false on error
+     */
+    public static function xQuery($sql)
+    {
+        $db = self::instance();
+        return $db->query($sql);
+    }
+
+    /**
+     * This is replacement for mysql_num_rows()
+     * This function doesn't returns FALSE as mysql_num_rows() //TODO ?
+     *
+     *
+     * @param PDOStatement $stmt
+     * @return
+     */
+    public static function xNumRows(PDOStatement $stmt)
+    {
+        return $stmt->rowCount();
+    }
+
+    /**
+     * This is replacement for mysql_real_escape_string()
+     *
+     * ATTENTION: returned value is in ' ' (quotation marks) - SQL string needs to be refactored
+     *
+     * @param string $string
+     * @return quoted string
+     */
+    public static function xQuote($string)
+    {
+        $db = self::instance();
+        return $db->quote($string);
+    }
+
+    /**
+     * This is replacement for sql_escape function from clicompatbase
+     *
+     * @param string $string
+     */
+    public static function xEscape($string)
+    {
+        $value = self::xQuote($string);
+        $value = substr($value, 1, -1); //remove ' char from the begining and end of the string
+        $value = mb_ereg_replace('&', '\&', $value);
+        return $value;
+    }
+
+
+    /**
+     * This is replacement for mysql_free_result()
+     */
+    public static function xFreeResults(PDOStatement $stmt)
+    {
+        return $stmt->closeCursor();
+    }
+
+    /**
+     * This is replacement for mysql_fetch_array()
+     * Second optional arg. of mysql_fetch_array is never used in OC code
+     * so return value is in the same format as original
+     *
+     * @param PDOStatement $stmt
+     * @return mixed row in style  MYSQL_BOTH/PDO::FETCH_BOTH
+     */
+    public static function xFetchArray(PDOStatement $stmt)
+    {
+        return $stmt->fetch(self::FETCH_BOTH); //PDO::FETCH_BOTH
+    }
+
+    /**
+     * This is replacement for mysql_fetch_row()
+     *
+     * @param PDOStatement $stmt
+     * @return array row in style PDO::FETCH_NUM
+     */
+    public static function xFetchRow(PDOStatement $stmt)
+    {
+        return $stmt->fetch(self::FETCH_NUM); //PDO::FETCH_NUM
+    }
+
+    /**
+     * This is replacement for mysql_result()
+     *
+     * @param PDOStatement $stmt
+     * @param int $colNum - index of the column in result
+     * @return string value from the column at index $colNum
+     */
+    public static function xResult(PDOStatement $stmt, $colNum)
+    {
+        return $stmt->fetchColumn($colNum);
+    }
+
+
+
+}

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -1302,27 +1302,6 @@ function typeToLetter($type)
     }
 }
 
-function wpToId($wp)
-{
-    $ocWP = $GLOBALS['oc_waypoint'];
-    $wpType = mb_substr($wp, 0, 2);
-    switch ($wpType) {
-        case $ocWP:
-            $tab_name = "wp_oc";
-            break;
-        case 'GC':
-            $tab_name = "wp_gc";
-            break;
-        case 'GE':
-            $tab_name = "wp_nc";
-            break;
-        default:
-            return "";
-    }
-    $sql = "SELECT cache_id FROM caches WHERE " . $tab_name . " = '" . sql_escape($wp) . "' LIMIT 1";
-    return mysql_result(mysql_query($sql), 1);
-}
-
 function fixPlMonth($string)
 {
     $string = str_ireplace('styczeń', 'stycznia', $string);


### PR DESCRIPTION
This is next stage of works around #276.
XDb class is a temporary wrapper for functions:
- mysql_*
- sql() from /lib/clicompatbase.php
- sql_* from /lib/clicompatbase.php

The intention is to used is only to the time of refactoring of the code - 
**XDb class shouldn't be use in any new implementations.**