### PR TITLE
added settings for uploading log pictures via OKAPI

### DIFF
--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -53,6 +53,9 @@ function get_okapi_settings()
         ),
         'VAR_DIR' => rtrim($dynbasepath, '/'),
         'IMAGES_DIR' => rtrim($picdir, '/'),
+        'IMAGES_URL' => rtrim($picurl, '/').'/',
+        'IMAGE_MAX_UPLOAD_SIZE' => $config['limits']['image']['filesize'] * 1024 * 1024,
+        'IMAGE_MAX_PIXEL_COUNT' => $config['limits']['image']['height'] * $config['limits']['image']['width'],
         'OC_NODE_ID' => $oc_nodeid,
         'OC_COOKIE_NAME' => $cookiename.'data',
         //'OCPL_ENABLE_GEOCACHE_ACCESS_LOGS' => isset($enable_cache_access_logs) ? $enable_cache_access_logs : false


### PR DESCRIPTION
Uploading log images via OKAPI is ready to be deployed. It needs these additional settings.