### PR TITLE
decode okapi log entity encoding in xml interface

### DIFF
--- a/xml/ocxml11.php
+++ b/xml/ocxml11.php
@@ -488,6 +488,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
                     ');
     while ($r = sql_fetch_array($rs)) {
         $r['text'] = mb_ereg_replace('<br />', '', $r['text']);
+        $r['text'] = preg_replace('/&amp;#(38|60|62);/', '&#$1;', $r['text']);  // decode OKAPI logs
         $r['text'] = html_entity_decode($r['text'], ENT_COMPAT, 'UTF-8');
 
         fwrite($f, $t1 . '<cachelog>' . "\n");

--- a/xml/ocxml11b.php
+++ b/xml/ocxml11b.php
@@ -487,6 +487,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
                     ');
     while ($r = sql_fetch_array($rs)) {
         $r['text'] = mb_ereg_replace('<br />', '', $r['text']);
+        $r['text'] = preg_replace('/&amp;#(38|60|62);/', '&#$1;', $r['text']);  // decode OKAPI logs
         $r['text'] = html_entity_decode($r['text'], ENT_COMPAT, 'UTF-8');
 
         fwrite($f, $t1 . '<cachelog>' . "\n");

--- a/xml/ocxml12.php
+++ b/xml/ocxml12.php
@@ -453,6 +453,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
             LEFT JOIN `cache_rating` ON `cache_logs`.`cache_id`=`cache_rating`.`cache_id` AND `cache_logs`.`user_id`=`cache_rating`.`user_id` AND `cache_logs`.`deleted`=0');
     while ($r = sql_fetch_array($rs)) {
         $r['text'] = mb_ereg_replace('<br />', '', $r['text']);
+        $r['text'] = preg_replace('/&amp;#(38|60|62);/', '&#$1;', $r['text']);  // decode OKAPI logs
         $r['text'] = html_entity_decode($r['text'], ENT_COMPAT, 'UTF-8');
 
         fwrite($f, $t1 . '<cachelog>' . "\n");


### PR DESCRIPTION
There are some special HTML entity encodings in log texts, created by an OKAPI workaround for the OCPL bug #469. This change will decode them properly in the XML interface. It is part of a fix for [OKAPI bug #413](https://github.com/opencaching/okapi/issues/413).