### PR TITLE
Adding date_default_timezone_set() to settings-example.inc.php

### DIFF
--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -3,6 +3,10 @@
 require __DIR__ . '/settingsDefault.inc.php';
 
 //Replace localhost to you own domain site
+
+// define timezone (newer versions of PHP require it)
+date_default_timezone_set('Europe/Warsaw');
+
 //relative path to the root directory
 if (!isset($rootpath))
     $rootpath = './';


### PR DESCRIPTION
Required by newer PHP versions.

This statement must go into settings.inc.php. 
