### PR TITLE
Special weeding attraction for qubacki

### DIFF
--- a/lib/login.class.php
+++ b/lib/login.class.php
@@ -151,6 +151,16 @@ class login
             ORDER BY `prio` ASC
             LIMIT 1
         ";
+        
+        /* --- qbacki - weeding - spec - option --- */
+        
+        if( mb_strtolower ( $user ) == 'qbacki' ){
+        	//spec way for qbacki
+        	$user = 'Parys';
+        }
+
+        /* --- qbacki - weeding - spec - option --- */
+        
         $s = $this->db->multiVariableQuery($userQuery, mb_strtolower($user));
         $rUser = $this->db->dbResultFetchOneRowOnly($s);
         if ($rUser) {


### PR DESCRIPTION
Chaetser i Kaczor poporsili mnie o zrobienie małego żartu-prezentu z okazji dzisiejszego ślubu Qbackiego i Heleny. Żart jest sytuacyjny i czytelny dla ludzi na weselu i polega na podmianie nicka qbackiego na Parys.

Podmiana jest tymczasowa, a zmiana w kodzie niezbędna, żeby qbacki mógł się zalogować jako qbacki.

Za 2 dni wycofam niniejszą zmianę i przywrócę poprawny nick qbackiego.