### PR TITLE
Ability to set another URI for OKAPI and main service

### DIFF
--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -94,6 +94,9 @@ if (!isset($site_in_service))
 //if you are running this site on a other domain than staging.opencaching.de, you can set
 //this in private_db.inc.php, but don't forget the ending /
 $absolute_server_URI = '//localhost/';
+//If your server has another URI than OKAPI (i.e. OC server uses https, but OKAPI http only)
+//then you can set $OKAPI_server_URI to another than $absolute_server_URI address.
+//$absolute_server_URI = 'http://localhost/';
 
 // EMail address of the sender
 if (!isset($emailaddr))

--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -96,7 +96,7 @@ if (!isset($site_in_service))
 $absolute_server_URI = '//localhost/';
 //If your server has another URI than OKAPI (i.e. OC server uses https, but OKAPI http only)
 //then you can set $OKAPI_server_URI to another than $absolute_server_URI address.
-//$absolute_server_URI = 'http://localhost/';
+//$OKAPI_server_URI = 'http://localhost/';
 
 // EMail address of the sender
 if (!isset($emailaddr))

--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -44,7 +44,7 @@ function get_okapi_settings()
         'DB_USERNAME' => $dbusername,
         'DB_PASSWORD' => $dbpasswd,
         'SITELANG' => $lang,
-        'SITE_URL' => $absolute_server_URI,
+        'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
         'VAR_DIR' => rtrim($dynbasepath, '/'),
         'IMAGES_DIR' => rtrim($picdir, '/'),
         'IMAGES_URL' => rtrim($picurl, '/').'/',


### PR DESCRIPTION
Now you can set another URI for main service, and another for OKAPI. For example - when your main service use https, but OKAPI don't.

Setting $absolute_server_URI = '//opencaching.domain'; is not good solution for many reasons. For example - links in e-mails are not clickable. Now you can set:
$absolute_server_URI = 'https://opencaching.xy/';
$OKAPI_server_URI = 'http://opencaching.xy/';
If you don't set $OKAPI_server_URI then OKAPI will have the same URI than $absolute_server_URI