### PR TITLE
Minimal geoPath percent value

### DIFF
--- a/lib/Controllers/PowerTrailController.php
+++ b/lib/Controllers/PowerTrailController.php
@@ -10,7 +10,7 @@ use Utils\Database\OcDb;
 class PowerTrailController
 {
 
-    const MINIMUM_PERCENT_REQUIRED = 66.6;
+    const MINIMUM_PERCENT_REQUIRED = 67;
 
     private $config;
     private $serverUrl;

--- a/powerTrail/powerTrailController.php
+++ b/powerTrail/powerTrailController.php
@@ -200,6 +200,9 @@ class powerTrailController {
         {
             $query = "INSERT INTO `PowerTrail`(`name`, `type`, `status`, `dateCreated`, `cacheCount`, `description`, `perccentRequired`) VALUES (:1,:2,:3,NOW(),0,:4,:5)";
             $db = OcDb::instance();
+            if ($_POST['dPercent'] < \lib\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED) {
+                $_POST['dPercent'] = \lib\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED;
+            }
             $db->multiVariableQuery($query, strip_tags($_POST['powerTrailName']),(int) $_POST['type'], (int) $_POST['status'], htmlspecialchars($_POST['description']), (int) $_POST['dPercent']);
             $newProjectId = $db->lastInsertId();
             // exit;

--- a/tpl/stdstyle/powerTrail.tpl.php
+++ b/tpl/stdstyle/powerTrail.tpl.php
@@ -1359,7 +1359,7 @@ $( document ).ready(function() {
                             <br><a class="tooltip" href="javascript:void(0);">{{pt087}}?<span class="custom help"><img src="tpl/stdstyle/images/toltipsImages/Help.png" alt="Help" height="48" width="48" /><em>{{pt088}}</em>{{pt086}}</span></a>
                         </td>
                         <td>
-                            <input name="dPercent" onkeypress="return isNumberKey(event)" type="number" min="10" max="100" value="50">
+                            <input name="dPercent" onkeypress="return isNumberKey(event)" type="number" min="67" max="100" value="90">
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Value is changed from 66.6 to 67 because we parsing value to int in the backend. Also in wiki rules is 67% 
https://wiki.opencaching.pl/index.php/Geo%C5%9Bcie%C5%BCka#Wymagana_ilo.C5.9B.C4.87_skrzynek_czyli_.22WIS.22

After merging it I will change WIS manually in database (for geopathes with wrong values)  (after communication with COG and owners).