### PR TITLE
Fixes a problem with selecting languages of cache description.

### DIFF
--- a/viewcache.php
+++ b/viewcache.php
@@ -989,7 +989,7 @@ if ($error == false) {
         }
 
         // check if user requests other lang of cache desc...
-        if ( isset($_REQUEST['desclang']) && array_search($_REQUEST['desclang'], $desclangs) ) {
+        if ( isset($_REQUEST['desclang']) && (array_search($_REQUEST['desclang'], $desclangs) !== false)) {
             $desclang = $_REQUEST['desclang'];
             $enable_google_translation = false; //user wants this lang - disable translations
         }


### PR DESCRIPTION
Quoting http://php.net/manual/en/function.array-search.php:

> Warning: This function may return Boolean FALSE, but may also return a non-Boolean value which evaluates to FALSE. (...) Use the === operator for testing the return value of this function.