### PR TITLE
sql alter for GK processing fix (#1003)

### DIFF
--- a/sqlAlters/2017-05-06_GK_processing.sql
+++ b/sqlAlters/2017-05-06_GK_processing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `geokret_log` ADD `last_try` DATETIME NULL DEFAULT NULL AFTER `geokret_name`, ADD INDEX `last_try_index` (`last_try`);


### PR DESCRIPTION
We have an issue in GK log processing (which is called from cron). Now at oc.pl it hangs because of too many broken GK log records. To fix it I need a new column in gk_log table.

@harrieklomp, @andrixnet, @deg-pl - please apply db update and give me know here it is ready.
Thanks!

BTW. This is called from cron and shouldn't affect user activity so let's push it during the weekend.