### PR TITLE
sqlalter with uuid for geocache log(comment)

### DIFF
--- a/sqlAlters/2017-06-15_geopath_log_uuid.sql
+++ b/sqlAlters/2017-06-15_geopath_log_uuid.sql
@@ -1,0 +1,9 @@
+
+-- 14.06.2017, kojoty
+--
+
+-- uuids for poweerTrail/geopaths/cachesets :) logs
+--
+ALTER TABLE `PowerTrail_comments` ADD `uuid` VARCHAR(36) NULL DEFAULT NULL AFTER `deleted`;
+ALTER TABLE `PowerTrail_comments` ADD INDEX(`uuid`);
+


### PR DESCRIPTION
@harrieklomp, @deg-pl, @andrixnet 

This PR contains sqlalter which needs to be run on DB - it adds the uuid column for powertrail log.

powertrails uuids support is necessary to finish works around powertrail (cacheset) implementation in OKAPI.

Please give me know here when your nodes are ready.

Thanks. 
