### PR TITLE
OcDb methods for handling with strict-mode in session

### DIFF
--- a/Utils/Database/OcPdo.php
+++ b/Utils/Database/OcPdo.php
@@ -136,7 +136,7 @@ class OcPdo extends PDO
      *
      * @return OcDb object
      */
-    public static function instance()
+    protected static function instance()
     {
         static $instance = null;
         if ($instance === null) {

--- a/Utils/Debug/Debug.php
+++ b/Utils/Debug/Debug.php
@@ -1,0 +1,23 @@
+<?php
+namespace Utils\Debug;
+
+
+class Debug {
+
+    /**
+     * Returns backtrace in simple form:
+     * file:line | file:line | ...
+     *
+     * @return string
+     */
+    public static function getTraceStr()
+    {
+        $backtrace = debug_backtrace();
+        foreach($backtrace as $trace){
+            $traceStr.= ' | '.$trace['file'].':'.$trace['line'];
+        }
+        return $traceStr;
+    }
+
+
+}

--- a/lib/passwordManager.php
+++ b/lib/passwordManager.php
@@ -1,6 +1,6 @@
 <?php
 
-use Utils\Database\OcPdo;
+use Utils\Database\OcDb;
 class PasswordManager
 {
 
@@ -40,7 +40,7 @@ class PasswordManager
 
         /* Get the database handle. */
 
-        $db = OcPdo::instance();
+        $db = OcDb::instance();
 
         /* Fetch current password state */
 
@@ -158,7 +158,7 @@ class PasswordManager
             $this->hash = $this->computeHash($this->correctPassword);
         }
 
-        $db = OcPdo::instance();
+        $db = OcDb::instance();
         $c = $db->prepare("
             update `user`
             set


### PR DESCRIPTION
There are simple changes which allow to enable sql strict-mode for current session (I believe it allows us to start background works on switching to strict-mode in future - we need to fix a lot of code :) )

@deg-pl, 
Ja to widzę tak (droga do stopniowego dojścia do strict-moda w całym kodzie):
- dodajemy wyłączenie strict-moda jako pierwszą linię we wszystkich głównych skryptach (tych naszych kontrolerach z głownego katalogu)
- włączamy strict mode w funkcji OcDb::instance() - nowo utworzona instancja działa by-default w strict-modzie
- stopniowo w kolejnych skryptach (po testach/ew.poprawkach) usuwamy to "wyłączenie-strict-moda"
- pilnujemy, by każdy nowy kod działał zgodnie ze strict-mode i nie wyłączał strict-moda!
- docelowo wszytko działa nam pod strict-mode :)

co ty o tym myślisz?





