### PR TITLE
fix in view->getLang() function

### DIFF
--- a/Utils/Debug/Debug.php
+++ b/Utils/Debug/Debug.php
@@ -26,11 +26,9 @@ class Debug {
     public static function errorLog($message, $addStackTrace=true){
 
         if($addStackTrace){
-            $stackTrace = self::getTraceStr();
-        }else{
-            $stackTrace = "";
+            $message .= " \n| STACKTRACE:".self::getTraceStr();
         }
 
-        error_log($message." \n| STACKTRACE:".$stackTrace);
+        error_log($message);
     }
 }

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -2,13 +2,15 @@
 namespace Utils\View;
 
 use Utils\DateTime\Year;
+use lib\Objects\ApplicationContainer;
 
 class View {
 
     const CHUNK_DIR = __DIR__.'/../../tpl/stdstyle/chunks/';
 
     //NOTE: local View vars should be prefixed by "_"
-    private $_googleAnalyticsKey = '';              // GA key loaded from config
+    
+    private $_googleAnalyticsKey = '';      // GA key loaded from config
 
     private $_loadJQuery = false;
     private $_loadJQueryUI = false;
@@ -16,16 +18,15 @@ class View {
     private $_loadGMapApi = false;
     private $_loadLightBox = false;
 
-    private $currentLang = ''; // curent language of site
-    private $_localCss = [];                        // page-local css styles loaded from controller
+    private $_localCss = [];                // page-local css styles loaded from controller
 
     public function __construct(){
 
         // load google analytics key from the config
-        $this->_googleAnalyticsKey = isset($GLOBALS['googleAnalytics_key']) ? $GLOBALS['googleAnalytics_key'] : '';
-        $this->loadChunk('googleAnalytics'); // load GA chunk for all pages
+        $this->_googleAnalyticsKey = isset($GLOBALS['googleAnalytics_key']) ?
+                $GLOBALS['googleAnalytics_key'] : '';
 
-        $this->currentLang = $GLOBALS['lang'];
+        $this->loadChunk('googleAnalytics'); // load GA chunk for all pages
 
     }
 
@@ -159,7 +160,7 @@ class View {
 
     public function getLang()
     {
-        return $this->currentLang;
+        return ApplicationContainer::Instance()->getLang();
     }
 
     /**

--- a/lib/Objects/ApplicationContainer.php
+++ b/lib/Objects/ApplicationContainer.php
@@ -59,5 +59,9 @@ final class ApplicationContainer
     }
 
 
+    public function getLang()
+    {
+        return $GLOBALS['lang'];
+    }
 }
 

--- a/tpl/stdstyle/chunks/googleMapsApi.tpl.php
+++ b/tpl/stdstyle/chunks/googleMapsApi.tpl.php
@@ -14,7 +14,7 @@ return function ($gMapKey, $lang){
 ?>
 
     <!-- Google Maps API chunk -->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.27&amp;key=<?=$gMapKey?>&amp;language=<?=$GLOBALS['lang']?>"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&amp;key=<?=$gMapKey?>&amp;language=<?=$lang?>"></script>
     <!-- End of Google Maps API chunk -->
 
 <?php

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -3,6 +3,7 @@
 use Utils\Database\OcDb;
 use lib\Objects\GeoCache\PrintList;
 use Utils\DateTime\Year;
+use Utils\Debug\Debug;
 
 // load menu
 global $mnu_selmenuitem, $tpl_subtitle, $absolute_server_URI, $mnu_siteid /* which menu item should be highlighted */, $site_name;
@@ -87,7 +88,8 @@ if (date('m') == 12 || date('m') == 1) {
             }
             if( $view->isGMapApiEnabled() ){
                 if( !isset($GLOBALS['googlemap_key']) || empty($GLOBALS['googlemap_key']) ){
-                    error_log("Key: googlemap_key is not set in settings?! Maps can't be loaded!");
+                    Debug::errorLog("There is no googlemap_key value in site settings?!".
+                                "Map can't be loaded!");
                 }else{
                     $view->callChunk('googleMapsApi', $GLOBALS['googlemap_key'], $view->getLang());
                 }


### PR DESCRIPTION
@deg-pl - to powinno poprawic problem z lang - tak na marginesie - uwazam, ze powinnismy uciekac od wszelkich GLOBALI wiec nie nalzey uzywac GLOBALS nigdzie - chyba ze to konieczne - i stopniowo usuwać takie kwiatki

w widokach aktualny jezyk moim zdaniem powinien byc czytany przez $view->getLang()
