### PR TITLE
Get rid of hackers in mobile version and some other fixes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,4 +9,6 @@ RewriteRule ^/statpics/([0-9]+)\.jpg$ ocstats.php?userid=$1 [R,L]
 
 RewriteRule ^(O[A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z])$ viewcache.php?wp=$1 [R=301,L,NC]
 
+RedirectMatch 403 ^/mobile/$
+
 FileETag None

--- a/Controllers/ViewCacheController.php
+++ b/Controllers/ViewCacheController.php
@@ -3,7 +3,6 @@
 namespace Controllers;
 
 use lib\Objects\GeoCache\GeoCache;
-use lib\Objects\OcConfig\OcConfig;
 use lib\Objects\GeoCache\Waypoint;
 use Utils\Gis\Gis;
 use Utils\Log\CacheAccessLog;
@@ -12,7 +11,6 @@ use lib\Objects\GeoCache\OpenChecker;
 use lib\Objects\Coordinates\Coordinates;
 use lib\Objects\GeoCache\PrintList;
 use lib\Controllers\MeritBadgeController;
-use Controllers\ViewCacheController;
 use Utils\Uri\Uri;
 use Utils\Text\Rot13;
 

--- a/Utils/Log/CacheAccessLog.php
+++ b/Utils/Log/CacheAccessLog.php
@@ -13,7 +13,7 @@ class CacheAccessLog
 {
 
     const SOURCE_BROWSER = "B";
-    const SOURCE_MOBILE = "B";
+    const SOURCE_MOBILE = "M";
     const SOURCE_OKAPI = "O";
 
     public static function logCacheAccess($cacheId, $userId, $event, $source){

--- a/cacheguides.php
+++ b/cacheguides.php
@@ -15,9 +15,6 @@ if ($error == false) {
 
         $tplname = 'cacheguides';
 
-        global $usr;
-        global $get_userid;
-
         $uLat = XDb::xSimpleQueryValue("SELECT `user`.`latitude`  FROM `user` WHERE `user_id`='" . XDb::xEscape($usr['userid']) . "'", 0);
         $uLon = XDb::xSimpleQueryValue("SELECT `user`.`longitude`  FROM `user` WHERE `user_id`='" . XDb::xEscape($usr['userid']) . "'", 0);
 
@@ -42,7 +39,7 @@ if ($error == false) {
                     )
                     OR user.user_id IN (
                         SELECT caches.user_id FROM caches
-                        WHERE (`caches`.`status`=1 OR `caches`.`status`=2 OR `caches`.`status`=3)
+                        WHERE `caches`.`status` IN (1, 2, 3)
                             AND `caches`.`date_created`>DATE_ADD(NOW(), INTERVAL -90 DAY)
                     )
                 )
@@ -58,9 +55,8 @@ if ($error == false) {
             $x = $record['latitude'];
 
             $nrec = XDb::xSql("SELECT COUNT('cache_id') as ncaches, SUM(topratings) as nrecom
-                               FROM caches WHERE `caches`.`type` <> 6 AND caches.status<>4
-                                    AND caches.status<>5
-                                    AND caches.status<>6
+                               FROM caches WHERE `caches`.`type` <> 6
+                                    AND caches.status NOT IN (4, 5, 6)
                                     AND `caches`.`user_id`= ? ", $record['userid']);
             $nr = XDb::xFetchArray($nrec);
             if ($nr['nrecom'] != NULL && $nr['nrecom'] >= 20) {
@@ -74,8 +70,7 @@ if ($error == false) {
 
         XDb::xFreeResults($rscp);
 
-        /* SET YOUR MAP CODE HERE */
-        tpl_set_var('cachemap_header', '<script src="https://maps.googleapis.com/maps/api/js?key=' . $googlemap_key . '&amp;language=' . $lang . '" type="text/javascript"></script>');
+        $view->loadGMapApi();
     }
 }
 

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -50,6 +50,7 @@ final class OcConfig
     private $cogEmailAddress;
     private $mailSubjectPrefixForSite;
     private $mailSubjectPrefixForReviewers;
+    private $enableCacheAccessLogs;
 
     // db config
     private $dbUser;
@@ -108,6 +109,7 @@ final class OcConfig
         $this->needFindLimit = $NEED_FIND_LIMIT;
         $this->mailSubjectPrefixForSite = $subject_prefix_for_site_mails;
         $this->mailSubjectPrefixForReviewers = $subject_prefix_for_reviewers_mails;
+        $this->enableCacheAccessLogs = $enable_cache_access_logs;
 
         if( isset($config['mapsConfig']) && is_array( $config['mapsConfig'] ) ){
             $this->mapsConfig = $config['mapsConfig'];
@@ -236,6 +238,11 @@ final class OcConfig
     public function isGoogleTranslationEnabled()
     {
         return $this->isGoogleTranslationEnabled;
+    }
+
+    public function isCacheAccesLogEnabled()
+    {
+        return $this->enableCacheAccessLogs;
     }
 
     protected function getMapsConfig()

--- a/mobile/lib/findalgo.inc.php
+++ b/mobile/lib/findalgo.inc.php
@@ -181,6 +181,7 @@ if (isSet($_GET['nazwa']) && !empty($_GET['nazwa']) ||
     }
 }
 
+$tpl->assign('oc_waypoint', $GLOBALS['oc_waypoint']);
 $tpl->assign('action', $action);
 $tpl->display('tpl/find.tpl');
 ?>

--- a/mobile/logs.php
+++ b/mobile/logs.php
@@ -1,112 +1,71 @@
 <?php
-use Utils\Database\XDb;
-use Utils\Database\OcDb;
 
-require_once("./lib/common.inc.php");
+use Utils\Log\CacheAccessLog;
+use lib\Controllers\LogEnteryController;
+use lib\Objects\GeoCache\GeoCache;
+use lib\Objects\OcConfig\OcConfig;
 
-function find_news($start, $end)
+const LOGS_PER_PAGE = 10;
+
+require_once ("./lib/common.inc.php");
+
+function find_news($start, $limit)
 {
+    global $tpl, $znalezione, $cache;
 
-    global $tpl;
-    global $lang;
-    global $znalezione;
-
-    $wp = XDb::xEscape($_GET['wp']);
-
-    $query = "select id,type,user_id,date,text,deleted from cache_logs where cache_id = (select cache_id from caches where wp_oc = '" . $wp . "') order by date desc limit " . $start . "," . $end;
-    $wynik = XDb::xSql($query);
-
-    $query = "select name,cache_id from caches where cache_id = (select cache_id from caches where wp_oc = '" . $wp . "');";
-    $wynik2 = XDb::xSql($query);
-    $caches = XDb::xFetchArray($wynik2);
-
-    $tpl->assign("name", $caches['name']);
+    $logEnteryController = new LogEnteryController();
+    $logs = $logEnteryController->loadLogsFromDb($cache->getCacheId(), false, $start, $limit);
 
     // detailed cache access logging
-    global $enable_cache_access_logs;
-    if (@$enable_cache_access_logs) {
-
-        $dbc = OcDb::instance();
-
-        $cache_id = $caches['cache_id'];
+    if (OcConfig::instance()->isCacheAccesLogEnabled()) {
         $user_id = @$_SESSION['user_id'] > 0 ? $_SESSION['user_id'] : null;
-        $access_log = @$_SESSION['CACHE_ACCESS_LOG_VL_' . $user_id];
-        if ($access_log === null) {
-            $_SESSION['CACHE_ACCESS_LOG_VL_' . $user_id] = array();
-            $access_log = $_SESSION['CACHE_ACCESS_LOG_VL_' . $user_id];
-        }
-        if (@$access_log[$cache_id] !== true) {
-            $dbc->multiVariableQuery(
-                    'INSERT INTO CACHE_ACCESS_LOGS
-                        (event_date, cache_id, user_id, source, event, ip_addr, user_agent, forwarded_for)
-                     VALUES
-                        (NOW(), :1, :2, \'M\', \'view_logs\', :3, :4, :5)',
-                     $cache_id, $user_id, $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'],
-                     ( isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : '' )
-            );
-            $access_log[$cache_id] = true;
-            $_SESSION['CACHE_ACCESS_LOG_VL_' . $user_id] = $access_log;
-        }
+        CacheAccessLog::logCacheAccess($cache->getCacheId(), $user_id, 'view_logs', CacheAccessLog::SOURCE_MOBILE);
     }
-
 
     $znalezione = array();
-
-    while ($logs = XDb::xFetchArray($wynik)) {
-
-        if ($logs['deleted'] == 0) {
-
-            $query = "select username from user where user_id = '" . $logs['user_id'] . "';";
-            $wynik3 = XDb::xSql($query);
-            $user = XDb::xFetchArray($wynik3);
-
-            $logs2['id'] = $logs['id'];
-            $logs2['user_id'] = $logs['user_id'];
-            $logs2['newtype'] = $logs['type'];
-            $logs2['newdate'] = date('j.m.Y', strtotime($logs['date']));
-            $logs2['username'] = $user[0];
-            $logs2['newtext'] = html2log($logs['text']);
-
-            $znalezione [] = $logs2;
-        }
+    foreach ($logs as $log) {
+        $tmplog = array();
+        $tmplog['id'] = $log['logid'];
+        $tmplog['user_id'] = $log['user_id'];
+        $tmplog['newtype'] = $log['type'];
+        $tmplog['newdate'] = date(OcConfig::instance()->getDateFormat(), strtotime($log['date']));
+        $tmplog['username'] = $log['username'];
+        $tmplog['newtext'] = html2log($log['text']);
+        $znalezione[] = $tmplog;
     }
 
-    $tpl->assign("wp_oc", $wp);
+    $tpl->assign("name", $cache->getCacheName());
+    $tpl->assign("wp_oc", $cache->getWaypointId());
     $tpl->assign("logs", $znalezione);
 }
 
-if (isSet($_GET['wp']) && !empty($_GET['wp']) && $_GET['wp'] != "OP") {
-
-
-
-    $wp = XDb::xEscape($_GET['wp']);
-
-    $na_stronie = 10;
-
-    $query = "select count(*) from cache_logs where cache_id = (select cache_id from caches where wp_oc = '" . $wp . "') and deleted='0' order by date desc;";
-    $wynik = XDb::xSql($query);
-    $ile = XDb::xFetchArray($wynik);
-    $ile = $ile[0];
-
-    $url = $_SERVER['REQUEST_URI'];
+if (isset($_GET['wp']) && strlen($_GET['wp']) == 6) {
+    try {
+        $cache = new GeoCache(['cacheWp' => $_GET['wp']]);
+    } catch (\Exception $e) {
+        header('Location: ./index.php');
+        exit();
+    }
+    $ile = $cache->getLogEntriesCount(false);
+    $na_stronie = LOGS_PER_PAGE;
+    $max = ceil($ile / $na_stronie);
+    if ($max == 0) {
+        $max = 1;
+    }
 
     $tpl->assign("ile", $ile);
-
-    $max = ceil($ile / $na_stronie);
-
-    if ($max == '0')
-        $max = '1';
-
     $tpl->assign('max', $max);
 
-    require_once("./lib/paging.inc.php");
+    $next_page = null;
+    $prev_page = null;
+
+    require_once ("./lib/paging.inc.php");
 
     $tpl->assign('next_page', $next_page);
     $tpl->assign('prev_page', $prev_page);
-}else {
+} else {
     header('Location: ./index.php');
-    exit;
+    exit();
 }
 
 $tpl->display('tpl/logs.tpl');
-?>

--- a/mobile/tpl/find.tpl
+++ b/mobile/tpl/find.tpl
@@ -25,7 +25,7 @@
 
     <form action=".{$action}" method="get" name="form2">
         {$wpt}<br/>
-        <input type="text" name="wp" value="OP"/><br/><br/>
+        <input type="text" name="wp" value="{$oc_waypoint}"/><br/><br/>
         <div class='menu'>
             <div class='button'>
                 <a href='javascript: document.form2.submit()'>{$seek_button}</a>

--- a/mobile/tpl/logs.tpl
+++ b/mobile/tpl/logs.tpl
@@ -7,7 +7,7 @@
 
 
     <div class="big infotitle"><b>{$name}</b></div>
-    {$page} {if $smarty.get.page}{$smarty.get.page}/{$max}{else}1/{$max}{/if}
+    {$page} {if isset($smarty.get.page)}{$smarty.get.page}/{$max}{else}1/{$max}{/if}
 
     {section name=i loop=$logs}
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,8 @@
 User-agent: *
 Disallow: /ocpl*
-Disallow: /old/
-Disallow: /search.php*
-Disallow: /login.php*
-Disallow: /lib/xmlmap.php*
-Disallow: /lib/mapper_okapi.php*
+Disallow: /search.php
+Disallow: /login.php
+Disallow: /lib/xmlmap.php
+Disallow: /lib/mapper_okapi.php
+Disallow: /util.sec/
+Disallow: /mobile/


### PR DESCRIPTION
We have many logs like this:

```
78.110.50.105 - - [18/Aug/2017:09:14:01 +0200] "GET /mobile/logs.php?wp=OP389499
999%22%20union%20select%20unhex(hex(version()))%20--%20%22x%22=%22x HTTP/1.1" 20
0 4293 "-" "-"
78.110.50.105 - - [18/Aug/2017:09:14:01 +0200] "GET /mobile/logs.php?wp=OP3894%2
0or%20(1,2)=(select*from(select%20name_const(CHAR(111,108,111,108,111,115,104,10
1,114),1),name_const(CHAR(111,108,111,108,111,115,104,101,114),1))a)%20--%20and%
201%3D1 HTTP/1.1" 301 903 "-" "-"
```

on NOT mobile version! But only till now ;)