### PR TITLE
add index for caches.date_hidden

### DIFF
--- a/docs/database/caches
+++ b/docs/database/caches
@@ -146,6 +146,7 @@ Create Table: CREATE TABLE `caches` (
   PRIMARY KEY (`cache_id`),
   UNIQUE KEY `wp_oc` (`wp_oc`),
   KEY `date_created` (`date_created`),
+  KEY `date_hidden` (`date_hidden`),
   KEY `latitude` (`latitude`),
   KEY `country` (`country`),
   KEY `status` (`status`,`date_activate`),
@@ -167,3 +168,4 @@ Create Table: CREATE TABLE `caches` (
 
 Changelog
 ---------
+2017-09-08  added key `date_created`

--- a/sqlAlters/2017-09-08_add_date_hidden_index.sql
+++ b/sqlAlters/2017-09-08_add_date_hidden_index.sql
@@ -1,0 +1,4 @@
+-- 2017-09-07: OKAPI optimization (https://github.com/opencaching/okapi/issues/476)
+-- @author: following5
+
+ALTER TABLE `caches` ADD INDEX (`date_hidden`);


### PR DESCRIPTION
There are new ordering options for `date_created` and `date_hidden` in OKAPI search methods. Wrygiel has [recommended](https://github.com/opencaching/okapi/issues/476) to use indexes for that.

`date_created` index already exists; this change adds the other one. (It may also be used automatically for ordering the events list on the start page.)