### PR TITLE
error log fix: OKAPI maxZoom=21

### DIFF
--- a/lib/cachemap3.js
+++ b/lib/cachemap3.js
@@ -101,6 +101,8 @@ function loadOcMap(params) {
         clickableIcons: false,  // POI on the map doesn't open balons on clicks
         gestureHandling: 'greedy', //disable ctrl+ zooming
 
+        maxZoom: 21,            // maxZoom:21 because of OKAPI-mapper max-zoom
+
         draggableCursor: 'crosshair',
         draggingCursor: 'pointer',
 
@@ -233,6 +235,10 @@ function addOCOverlay(map, params)
                 var y = coord.y;
                 if (y < 0 || y >= scale)
                     return null;
+
+                if ( zoom > 21 ){
+                  return null;
+                }
 
                 var url = params.cachemap_mapper +
                     "?userid=" + params.userid +

--- a/lib/mapper_okapi.php
+++ b/lib/mapper_okapi.php
@@ -38,7 +38,7 @@ $force_result_empty = false;
 
 $params['x'] = $_GET['x'];
 $params['y'] = $_GET['y'];
-$params['z'] = $_GET['z'];
+$params['z'] = $_GET['z']; //zoom
 
 # userid - we will simulate an OAuth call in the name of this user.
 #


### PR DESCRIPTION
Google ROAD map has max-zoom=22 and every request for OKAPI tail at zoom 22 generates log error.