### PR TITLE
fix log text html encoding for new logs

### DIFF
--- a/Controllers/CacheAdoptionController.php
+++ b/Controllers/CacheAdoptionController.php
@@ -151,8 +151,8 @@ class CacheAdoptionController extends BaseController
         // put log into cache logs.
         $logMessage = tr('adopt_32');
 
-        $oldUserName = ' <a href="' . $GLOBALS['absolute_server_URI'] . 'viewprofile.php?userid=' . $oldOwner->getUserId() . '">' . $oldOwner->getUserName() . '</a> ';
-        $newUserName = ' <a href="' . $GLOBALS['absolute_server_URI'] . 'viewprofile.php?userid=' . $this->loggedUser->getUserId() . '">' . $this->loggedUser->getUserName() . '</a>';
+        $oldUserName = ' <a href="' . $GLOBALS['absolute_server_URI'] . 'viewprofile.php?userid=' . $oldOwner->getUserId() . '">' . htmlspecialchars($oldOwner->getUserName()) . '</a> ';
+        $newUserName = ' <a href="' . $GLOBALS['absolute_server_URI'] . 'viewprofile.php?userid=' . $this->loggedUser->getUserId() . '">' . htmlspecialchars($this->loggedUser->getUserName()) . '</a>';
 
         $logMessage = str_replace('{oldUserName}', $oldUserName, $logMessage);
         $logMessage = str_replace('{newUserName}', $newUserName, $logMessage);
@@ -164,7 +164,7 @@ class CacheAdoptionController extends BaseController
                             type = 3,
                             date = NOW(),
                             text= :2,
-                            text_html = 1,
+                            text_html = 2,
                             text_htmledit = 1,
                             date_created = NOW(),
                             last_modified = NOW(),

--- a/cache_titled_add.php
+++ b/cache_titled_add.php
@@ -146,11 +146,11 @@ if ( $dDiff->days < $securityPeriod )
     $SystemUser = -1;
     $LogType = 12; //OCTeam
     $ntitled_cache = $titled_cache_period_prefix.'_titled_cache_congratulations';
-    $msgText = str_replace('{ownerName}', $rec['userName'], tr($ntitled_cache));
+    $msgText = str_replace('{ownerName}', htmlspecialchars($rec['userName']), tr($ntitled_cache));
     $LogUuid = Uuid::create();
 
     $dbc->multiVariableQuery($queryLogI, $rec[ "cacheId" ], $SystemUser, $LogType, $date_alg,
-            $msgText, '1', '1', $date_alg, $date_alg, $LogUuid, '0', '0',
+            $msgText, '2', '1', $date_alg, $date_alg, $LogUuid, '0', '0',
             $date_alg, '0', $oc_nodeid );
 
 unset($dbc);

--- a/docs/database/cache_logs
+++ b/docs/database/cache_logs
@@ -37,7 +37,7 @@ user_id
 type
 date
 text
-text_html
+text_html         0 = plain text, 1 = old HTML, 2 = new HTML (see https://github.com/opencaching/opencaching-pl/issues/1218)
 text_htmledit
 last_modified
 okapi_syncbase

--- a/editlog.php
+++ b/editlog.php
@@ -242,7 +242,7 @@ if ($error == false) {
                             /*1*/$log_type,
                             /*2*/date('Y-m-d H:i:s', mktime($log_date_hour, $log_date_min, 0, $log_date_month, $log_date_day, $log_date_year)),
                             /*3*/userInputFilter::purifyHtmlString(((true) ? $log_text : nl2br($log_text))),
-                            /*4*/1, /*5*/1, $usr['userid'], $log_id);
+                            /*4*/2, /*5*/1, $usr['userid'], $log_id);
                     } else {
                         XDb::xSql(
                             "UPDATE `cache_logs`
@@ -252,7 +252,7 @@ if ($error == false) {
                             /*1*/$log_type,
                             /*2*/date('Y-m-d H:i:s', mktime($log_date_hour, $log_date_min, 0, $log_date_month, $log_date_day, $log_date_year)),
                             /*3*/userInputFilter::purifyHtmlString(((true) ? $log_text : nl2br($log_text))),
-                            /*4*/1, /*5*/1, $usr['userid'], $log_id);
+                            /*4*/2, /*5*/1, $usr['userid'], $log_id);
                     }
 
                     //update user-stat if type changed
@@ -498,7 +498,7 @@ if ($error == false) {
                 tpl_set_var('date_message', ($date_not_ok == true) ? $date_message : '');
                 tpl_set_var('bodyMod', ' onload="chkMoved()"');
 
-                $log_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($log_text);
+                $log_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($log_text, $log_record['text_html']);
                 tpl_set_var('logtext', htmlspecialchars($log_text, ENT_NOQUOTES, 'UTF-8'), true);
 
                 if ($use_log_pw == true && $log_pw != '') {

--- a/getLogEntries.php
+++ b/getLogEntries.php
@@ -170,7 +170,7 @@ foreach ($logEntries as $record) {
         $processed_text = htmlspecialchars($processed_text, ENT_COMPAT, 'UTF-8');
         $processed_text = TextConverter::addHyperlinkToURL($processed_text);
     } else {
-        $processed_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($processed_text);
+        $processed_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($processed_text, $record['text_html']);
     }
 
     $processed_text = SmilesInText::process($processed_text);

--- a/lib/cache_owners.inc.php
+++ b/lib/cache_owners.inc.php
@@ -21,7 +21,7 @@ class OrgCacheOwners
             "SELECT cl.id, cl.cache_id, cl.text
             FROM cache_logs cl join caches c using (cache_id)
             WHERE cl.user_id = -1 AND cl.type = 3
-                AND cl.text_html = 1 AND
+                AND cl.text_html >= 1 AND
                 (
                     cl.text like '%Przeprowadzono procedurę adopcji skrzynki%'
                     OR cl.text like '%The adoption process has been completed%'

--- a/lib/userInputFilters/userInputFilter.php
+++ b/lib/userInputFilters/userInputFilter.php
@@ -120,37 +120,50 @@ class userInputFilter
      * @param string $dirtyHtml
      * @return string
      */
-    public static function purifyHtmlStringAndDecodeHtmlSpecialChars($dirtyHtml)
+    public static function purifyHtmlStringAndDecodeHtmlSpecialChars($dirtyHtml, $htmlMode)
     {
         if (isset($_GET['use_purifier'])) {
             $upo = $_GET['use_purifier'];
             switch ($upo) {
                 case '0':
-                    return self::purifyHtmlStringAndDecodeHtmlSpecialChars_old($dirtyHtml);
+                    return self::purifyHtmlStringAndDecodeHtmlSpecialChars_old($dirtyHtml, $htmlMode);
                 case '1':
                 case '':
-                    return self::purifyHtmlStringAndDecodeHtmlSpecialChars_new($dirtyHtml);
+                    return self::purifyHtmlStringAndDecodeHtmlSpecialChars_new($dirtyHtml, $htmlMode);
             }
         }
 
         // current working implementation - the old way
-        return htmlspecialchars_decode($dirtyHtml);
+        if ($htmlMode < 2) {
+            // see https://github.com/opencaching/opencaching-pl/issues/1218
+            return htmlspecialchars_decode($dirtyHtml);
+        } else {
+            return $dirtyHtml;
+        }
     }
 
     /**
      * the oldest version of the function - for backward compatibility
      */
-    private static function purifyHtmlStringAndDecodeHtmlSpecialChars_old($dirtyHtml)
+    private static function purifyHtmlStringAndDecodeHtmlSpecialChars_old($dirtyHtml, $htmlMode)
     {
-        return htmlspecialchars_decode($dirtyHtml);
+        if ($htmlMode < 2) {
+            // see https://github.com/opencaching/opencaching-pl/issues/1218
+            return htmlspecialchars_decode($dirtyHtml);
+        } else {
+            return $dirtyHtml;
+        }
     }
 
     /**
      * the newest possible version of the function - all the experiments should be done here
      */
-    private static function purifyHtmlStringAndDecodeHtmlSpecialChars_new($dirtyHtml)
+    private static function purifyHtmlStringAndDecodeHtmlSpecialChars_new($dirtyHtml, $htmlMode)
     {
-        $dirtyHtml = htmlspecialchars_decode($dirtyHtml);
+        if ($htmlMode < 2) {
+            // see https://github.com/opencaching/opencaching-pl/issues/1218
+            $dirtyHtml = htmlspecialchars_decode($dirtyHtml);
+        }
         $cleanHtml = self::purifyHtmlString($dirtyHtml);
         return $cleanHtml;
     }

--- a/log.php
+++ b/log.php
@@ -462,8 +462,8 @@ if ($error == false) {
                         /* GeoKretyApi: call method logging selected Geokrets  (by Łza) */
                         processGeoKrety($logDateTime, $user, $geoCache);
 
-                        $dmde_1 = 1;
-                        $dmde_2 = 1;
+                        $text_html = 2;  // see https://github.com/opencaching/opencaching-pl/issues/1218
+                        $text_htmledit = 1;
 
                         // This query INSERT cache_log entry ONLY IF such entry NOT EXISTS
                         XDb::xSql(
@@ -480,7 +480,7 @@ if ($error == false) {
                                     AND `deleted` = '0')
                             LIMIT 1",
                                 $cache_id, $usr['userid'], $log_type, $log_date, $log_text,
-                                $dmde_1, $dmde_2, $log_uuid, $oc_nodeid, $usr['userid'], $cache_id
+                                $text_html, $text_htmledit, $log_uuid, $oc_nodeid, $usr['userid'], $cache_id
                             );
 
                     } else {
@@ -488,7 +488,7 @@ if ($error == false) {
                             "INSERT INTO `cache_logs` (`cache_id`, `user_id`, `type`, `date`, `text`, `text_html`,
                                          `text_htmledit`, `date_created`, `last_modified`, `uuid`, `node`)
                             VALUES ( ?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?, ?)",
-                            $cache_id, $usr['userid'], $log_type, $log_date, $log_text, 1, 1, $log_uuid, $oc_nodeid);
+                            $cache_id, $usr['userid'], $log_type, $log_date, $log_text, 2, 1, $log_uuid, $oc_nodeid);
                     }
 
                     // insert to database.

--- a/myProvince.php
+++ b/myProvince.php
@@ -241,7 +241,6 @@ $rs = $db->simpleQuery(
     "SELECT
         cl.id, cl.cache_id, cl.type AS log_type,
         cl.date AS log_date, cl.text AS log_text,
-        cl.text_html,
 
         c.name AS cache_name,
         c.wp_oc AS wp_name, c.type AS cache_type,

--- a/my_logsFind.php
+++ b/my_logsFind.php
@@ -99,7 +99,7 @@ if ($error == false) {
         if( !empty($log_ids) ){
             $rs = XDb::xSql(
                 "SELECT cache_logs.id, cache_logs.cache_id AS cache_id, cache_logs.type AS log_type,
-                        cache_logs.date AS log_date, cache_logs.text AS log_text, cache_logs.text_html AS text_html,
+                        cache_logs.date AS log_date, cache_logs.text AS log_text,
                         caches.name AS cache_name, caches.user_id AS cache_owner,
                         user.username AS user_name, cache_logs.user_id AS luser_id,
                         caches.wp_oc AS wp_name,

--- a/myn_newlogs.php
+++ b/myn_newlogs.php
@@ -151,7 +151,6 @@ if ($usr == false) {
                             cache_logs.date                             AS log_date,
                             cache_logs.user_id                          AS luser_id,
                             cache_logs.text                             AS log_text,
-                            cache_logs.text_html                        AS text_html,
                             caches.name                                 AS cache_name,
                             caches.user_id                              AS cache_owner,
                             caches.user_id                              AS user_id,

--- a/myneighborhood.php
+++ b/myneighborhood.php
@@ -484,7 +484,6 @@ if ($usr == false) {
                             cache_logs.type            AS log_type,
                             cache_logs.date            AS log_date,
                             cache_logs.text            AS log_text,
-                            cache_logs.text_html       AS text_html,
                             local_caches.name          AS cache_name,
                             user.username              AS user_name,
                             user.user_id               AS luser_id,

--- a/newlogs.php
+++ b/newlogs.php
@@ -82,7 +82,7 @@ if ($error == false) {
             "SELECT cache_logs.id, cache_logs.cache_id AS cache_id,
                     cache_logs.type AS log_type, cache_logs.date AS log_date,
                     cache_logs.user_id AS luser_id, cache_logs.text AS log_text,
-                    cache_logs.text_html AS text_html, caches.name AS cache_name,
+                    caches.name AS cache_name,
                     caches.user_id AS cache_owner, user.username AS user_name,
                     caches.user_id AS user_id, user.user_id AS xuser_id,
                     caches.wp_oc AS wp_name, caches.type AS cache_type,

--- a/util.sec/watchlist/runwatch.php
+++ b/util.sec/watchlist/runwatch.php
@@ -236,7 +236,7 @@ fclose($lock_file);
 function process_owner_log($user_id, $log_id)
 {
     $rsLog = XDb::xSql(
-        "SELECT cache_logs.cache_id cache_id, cache_logs.text text, cache_logs.text_html text_html,
+        "SELECT cache_logs.cache_id cache_id, cache_logs.text text,
                 cache_logs.date logdate, user.username username, user.hidden_count ch, user.founds_count cf,
                 user.notfounds_count cn, caches.wp_oc wp,caches.name cachename, cache_logs.type type,
                 IF(ISNULL(`cache_rating`.`cache_id`), 0, 1) AS `recommended`
@@ -295,7 +295,7 @@ function process_owner_log($user_id, $log_id)
 function process_log_watch($user_id, $log_id)
 {
     $rsLog = XDb::xSql(
-        "SELECT cache_logs.cache_id cache_id, cache_logs.text text, cache_logs.text_html text_html,
+        "SELECT cache_logs.cache_id cache_id, cache_logs.text text,
                 cache_logs.date logdate, user.username username, user.hidden_count ch, user.founds_count cf,
                 user.notfounds_count cn, caches.wp_oc wp,caches.name cachename, cache_logs.type type,
                 IF(ISNULL(`cache_rating`.`cache_id`), 0, 1) AS `recommended`

--- a/viewlogs.php
+++ b/viewlogs.php
@@ -311,7 +311,7 @@ if ($error == false) {
                 $processed_text = htmlspecialchars($processed_text, ENT_COMPAT, 'UTF-8');
                 $processed_text = TextConverter::addHyperlinkToURL($processed_text);
             } else {
-                $processed_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($processed_text);
+                $processed_text = userInputFilter::purifyHtmlStringAndDecodeHtmlSpecialChars($processed_text, $record['text_html']);
             }
             $processed_text = SmilesInText::process($processed_text);
 

--- a/viewpendings.php
+++ b/viewpendings.php
@@ -151,12 +151,12 @@ function notifyOwner($cacheid, $msgType)
         //send email to approver
         mb_send_mail($usr['email'], tr('viewPending_01') . ": " . $cachename, tr('viewPending_02') . ":\n" . $email_content, $email_headers);
         // generate automatic log about status cache
-        $log_text = tr("viewPending_03");
+        $log_text = htmlspecialchars(tr("viewPending_03"));
         $log_uuid = Uuid::create();
         XDb::xSql(
             "INSERT INTO `cache_logs`
                 (`id`, `cache_id`, `user_id`, `type`, `date`, `text`, `text_html`, `text_htmledit`, `date_created`, `last_modified`, `uuid`, `node`)
-            VALUES ('', ?, ?, '12', NOW(), ?, '0', '0', NOW(), NOW(), ?, ?)",
+            VALUES ('', ?, ?, '12', NOW(), ?, '2', '1', NOW(), NOW(), ?, ?)",
             $cacheid, $usr['userid'], $log_text, $log_uuid, $oc_nodeid);
 
     } else {
@@ -166,13 +166,13 @@ function notifyOwner($cacheid, $msgType)
         mb_send_mail($usr['email'], tr('viewPending_04') . ": " . $cachename, tr('viewPending_05') . ":\n" . $email_content, $email_headers);
 
         // generate automatic log about status cache
-        $log_text = tr("viewPending_06");
+        $log_text = htmlspecialchars(tr("viewPending_06"));
         $log_uuid = Uuid::create();
         XDb::xSql(
             "INSERT INTO `cache_logs`
                 (`id`, `cache_id`, `user_id`, `type`, `date`, `text`, `text_html`, `text_htmledit`, `date_created`, `last_modified`, `uuid`, `node`)
             VALUES ('', ?, ?, ?, NOW(), ?, ?, ?, NOW(), NOW(), ?, ?)",
-            $cacheid, $usr['userid'], 12, $log_text, 0, 0, $log_uuid, $oc_nodeid);
+            $cacheid, $usr['userid'], 12, $log_text, 2, 1, $log_uuid, $oc_nodeid);
     }
 }
 


### PR DESCRIPTION
* fixes #1218 security issue for all newly submitted logs
* prepares migration of old logs text (migrated logs will be set to `text_html`=2)
* fixes some minor log HTML encoding issues