### PR TITLE
fixed XML sequence error in GPX files

### DIFF
--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -94,9 +94,9 @@ $gpxWaypoints = '    <wpt lat="{wp_lat}" lon="{wp_lon}">
         <type>Waypoint|{wp_type}</type>
         <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/5">
         <gsak:Parent>{waypoint}</gsak:Parent>
-        <gsak:Code>{waypoint} {wp_stage}</gsak:Code>
-        <gsak:Child_Flag>false</gsak:Child_Flag>
         <gsak:Child_ByGSAK>false</gsak:Child_ByGSAK>
+        <gsak:Child_Flag>false</gsak:Child_Flag>
+        <gsak:Code>{waypoint} {wp_stage}</gsak:Code>
         </gsak:wptExtension>
     </wpt>
 ';

--- a/lib/search.gpx.inc.php
+++ b/lib/search.gpx.inc.php
@@ -107,9 +107,9 @@ $gpxWaypoints = '<wpt lat="{wp_lat}" lon="{wp_lon}">
     <type>Waypoint|{wp_type}</type>
     <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/5">
     <gsak:Parent>{waypoint}</gsak:Parent>
-    <gsak:Code>{waypoint} {wp_stage}</gsak:Code>
-    <gsak:Child_Flag>false</gsak:Child_Flag>
     <gsak:Child_ByGSAK>false</gsak:Child_ByGSAK>
+    <gsak:Child_Flag>false</gsak:Child_Flag>
+    <gsak:Code>{waypoint} {wp_stage}</gsak:Code>
     </gsak:wptExtension>
   </wpt>
 ';


### PR DESCRIPTION
This puts some GPX lines into the right oder, to get rid of this XML validation error (tested with https://www.freeformatter.com/xml-validator-xsd.html):

`Cvc-complex-type.2.4.a: Invalid Content Was Found Starting With Element 'gsak:Child_Flag'. One Of '{"http://www.gsak.net/xmlv1/5":Resolution}' Is Expected.`

See definition in http://www.gsak.net/xmlv1/5/gsak.xsd..

For search.gpx it won't really matter, it has a bigger issue with the `<attributes>`. But search.gpxgc otherwise produces clean XML.