### PR TITLE
Add the Opencaching GPX extension (dont't merge yet)

### DIFF
--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -8,7 +8,7 @@ $nodeDetect = substr($absolute_server_URI, - 3, 2);
 
 $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
 <gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/5 http://www.gsak.net/xmlv1/5/gsak.xsd"
+    xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/5 http://www.gsak.net/xmlv1/5/gsak.xsd https://github.com/opencaching/gpx-extension-v1 https://raw.githubusercontent.com/following5/gpx-extension-v1/oc-logs/schema.xsd"
     xmlns="http://www.topografix.com/GPX/1/0" version="1.0"
     creator="' . convert_string($site_name) . '">
 
@@ -57,12 +57,23 @@ $gpxLine = '
             </groundspeak:long_description>
             <groundspeak:encoded_hints>{hints}</groundspeak:encoded_hints>
             <groundspeak:logs>
-{logs}
+{gs_logs}
             </groundspeak:logs>
             <groundspeak:travelbugs>
 {geokrety}
             </groundspeak:travelbugs>
         </groundspeak:cache>
+        <oc:cache xmlns:oc="https://github.com/opencaching/gpx-extension-v1">
+            <oc:type>{oc_type}</oc:type>
+            <oc:size>{oc_size}</oc:size>
+{oc_trip_time}
+{oc_trip_distance}
+            <oc:requires_password>{oc_password}</oc:requires_password>
+{oc_other_codes}
+            <oc:logs>
+{oc_logs}
+            </oc:logs>
+        </oc:cache>
     </wpt>
 
 {cache_waypoints}
@@ -101,6 +112,15 @@ $gpxWaypoints = '    <wpt lat="{wp_lat}" lon="{wp_lon}">
     </wpt>
 ';
 
+$gpxOcTripTime = '            <oc:trip_time>{time}</oc:trip_time>';
+$gpxOcTripDistance = '            <oc:trip_distance>{distance}</oc:trip_distance>';
+$gpxOcOtherCode = '            <oc:other_code>{code}</oc:other_code>';
+
+$gpxOcLog = '                <oc:log id="{id}" uuid="{uuid}">
+{oc_team_entry}                </oc:log>';
+$gpxOcIsTeamEntry = '                    <oc:site_team_entry>true</oc:site_team_entry>
+';
+
 $gpxFoot = '</gpx>';
 
 $gpxTimeFormat = 'Y-m-d\TH:i:s\Z';
@@ -129,7 +149,6 @@ $gpxArchived[6] = 'True';       // OC: STATUS_BLOCKED
 
 // These strings must not be translated
 // Ref: see http://forum.opencaching.pl/viewtopic.php?p=121737#p121737
-$gpxContainer[0] = 'Unknown';       // OC: UNDEFINED
 $gpxContainer[1] = 'Other';         // OC: SIZE_OTHER
 $gpxContainer[2] = 'Micro';         // OC: SIZE_MICRO
 $gpxContainer[3] = 'Small';         // OC: SIZE_SMALL
@@ -138,6 +157,16 @@ $gpxContainer[5] = 'Large';         // OC: SIZE_LARGE
 $gpxContainer[6] = 'Very Large';    // OC: SIZE_XLARGE
 $gpxContainer[7] = 'No container';  // OC: SIZE_NONE
 $gpxContainer[8] = 'Nano';          // OC: SIZE_NANO
+
+// size strings for oc:size (OC GPX extension)
+$gpxOcSize[1] = 'Other';
+$gpxOcSize[2] = 'Micro';
+$gpxOcSize[3] = 'Small';
+$gpxOcSize[4] = 'Regular';
+$gpxOcSize[5] = 'Large';
+$gpxOcSize[6] = 'Very large';
+$gpxOcSize[7] = 'No container';
+$gpxOcSize[8] = 'Nano';
 
 // ************************************************************************
 // Geocache type
@@ -155,6 +184,18 @@ $gpxType[7] = 'Unknown Cache';      // OC: TYPE_QUIZ
 $gpxType[8] = 'Unknown Cache';      // OC: TYPE_MOVING
 $gpxType[9] = 'Unknown Cache';      // OC: TYPE_GEOPATHFINAL
 $gpxType[10] = 'Unknown Cache';     // OC: TYPE_OWNCACHE
+
+// type strings for oc:type (OC GPX extension)
+$gpxOcType[1] = 'Other Cache';
+$gpxOcType[2] = 'Traditional Cache';
+$gpxOcType[3] = 'Multi-cache';
+$gpxOcType[4] = 'Virtual Cache';
+$gpxOcType[5] = 'Webcam Cache';
+$gpxOcType[6] = 'Event Cache';
+$gpxOcType[7] = 'Quiz Cache';
+$gpxOcType[8] = 'Moving Cache';
+$gpxOcType[9] = 'Podcast Cache';
+$gpxOcType[10] = 'Own Cache';
 
 /* Groundspeak IDs:
 2       Traditional Cache

--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -8,7 +8,7 @@ $nodeDetect = substr($absolute_server_URI, - 3, 2);
 
 $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
 <gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/5 http://www.gsak.net/xmlv1/5/gsak.xsd https://github.com/opencaching/gpx-extension-v1 https://raw.githubusercontent.com/following5/gpx-extension-v1/oc-logs/schema.xsd"
+    xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/5 http://www.gsak.net/xmlv1/5/gsak.xsd https://github.com/opencaching/gpx-extension-v1 https://raw.githubusercontent.com/opencaching/gpx-extension-v1/master/schema.xsd"
     xmlns="http://www.topografix.com/GPX/1/0" version="1.0"
     creator="' . convert_string($site_name) . '">
 

--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -5,6 +5,8 @@ ob_start();
 use Utils\Database\XDb;
 use Utils\Database\OcDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use lib\Objects\GeoCache\GeoCacheLog;
+
 global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 
 require_once($rootpath . 'lib/format.gpx.inc.php');
@@ -230,8 +232,9 @@ if ($usr || ! $hide_coords) {
                 `caches`.`size` `size`, `caches`.`type` `type`, `caches`.`status` `status`,
                 `user`.`username` `username`, `gpxcontent`.`user_id` `owner_id`,
                 `cache_desc`.`desc` `desc`, `cache_desc`.`short_desc` `short_desc`, `cache_desc`.`hint` `hint`,
-                `cache_desc`.`rr_comment`, `caches`.`logpw`,`caches`.`votes` `votes`,`caches`.`score` `score`,
-                `caches`.`topratings` `topratings`
+                `cache_desc`.`rr_comment`, `caches`.`logpw`, `caches`.`votes` `votes`, `caches`.`score` `score`,
+                `caches`.`topratings` `topratings`, `caches`.`search_time`, `caches`.`way_length`,
+                `caches`.`wp_gc`, `caches`.`wp_nc`, `caches`.`wp_ge`, `caches`.`wp_tc`
         FROM `gpxcontent`, `caches`, `user`, `cache_desc`
         WHERE `gpxcontent`.`cache_id`=`caches`.`cache_id`
             AND `caches`.`cache_id`=`cache_desc`.`cache_id`
@@ -417,7 +420,7 @@ if ($usr || ! $hide_coords) {
         if (isset($gpxContainer[$r['size']]))
             $thisline = str_replace('{container}', $gpxContainer[$r['size']], $thisline);
         else
-            $thisline = str_replace('{container}', $gpxContainer[0], $thisline);
+            $thisline = str_replace('{container}', $gpxContainer[1], $thisline);
 
         if (isset($gpxAvailable[$r['status']]))
             $thisline = str_replace('{available}', $gpxAvailable[$r['status']], $thisline);
@@ -440,6 +443,42 @@ if ($usr || ! $hide_coords) {
         $thisline = str_replace('{owner}', xmlentities(convert_string($r['username'])), $thisline);
         $thisline = str_replace('{owner_id}', xmlentities($r['owner_id']), $thisline);
 
+        // OC GPX extension
+        if (isset($gpxOcType[$r['type']]))
+            $thisline = str_replace('{oc_type}', $gpxOcType[$r['type']], $thisline);
+        else
+            $thisline = str_replace('{oc_type}', $gpxOcType[1], $thisline);
+
+        if (isset($gpxOcSize[$r['size']]))
+            $thisline = str_replace('{oc_size}', $gpxOcSize[$r['size']], $thisline);
+        else
+            $thisline = str_replace('{oc_size}', $gpxOcSize[1], $thisline);
+
+        if ($r['search_time'] > 0) {
+            $trip_time = mb_ereg_replace('{time}', $r['search_time'], $gpxOcTripTime);
+        } else {
+            $trip_time = '';
+        }
+        $thisline = mb_ereg_replace('{oc_trip_time}', $trip_time, $thisline);
+
+        if ($r['way_length'] > 0) {
+            $trip_distance = mb_ereg_replace('{distance}', $r['way_length'], $gpxOcTripDistance);
+        } else {
+            $trip_distance = '';
+        }
+        $thisline = mb_ereg_replace('{oc_trip_distance}', $trip_distance, $thisline);
+
+        $thisline = mb_ereg_replace('{oc_password}', $r['logpw'] != '' ? 'true' : 'false', $thisline);
+
+        $other_codes = [];
+        foreach (['GC', 'TC', 'NC', 'GE'] as $platform) {
+            $code = strtoupper($r['wp_'.strtolower($platform)]);
+            if (substr($code, 0, 2) == $platform && strlen($code) >= 4) {
+                $other_codes[] = mb_ereg_replace('{code}', $code, $gpxOcOtherCode);
+            }
+        }
+        $thisline = mb_ereg_replace('{oc_other_codes}', implode("\n", $other_codes), $thisline);
+
         // create log list
         if ($options['gpxLogLimit']) {
             $gpxLogLimit = 'LIMIT ' . (intval($options['gpxLogLimit'])) . ' ';
@@ -447,9 +486,10 @@ if ($usr || ! $hide_coords) {
             $gpxLogLimit = '';
         }
 
-        $logentries = '';
+        $gs_logentries = '';
+        $oc_logentries = '';
         $rsLogs = XDb::xSql(
-            "SELECT `cache_logs`.`id`, `cache_logs`.`type`, `cache_logs`.`date`, `cache_logs`.`text`, `user`.`username`, `cache_logs`.`user_id` `userid`
+            "SELECT `cache_logs`.`id`, `cache_logs`.`uuid`, `cache_logs`.`type`, `cache_logs`.`date`, `cache_logs`.`text`, `user`.`username`, `cache_logs`.`user_id` `userid`
             FROM `cache_logs`, `user`
             WHERE `cache_logs`.`deleted`=0 AND `cache_logs`.`user_id`=`user`.`user_id`
                 AND `cache_logs`.`cache_id`= ?
@@ -457,8 +497,8 @@ if ($usr || ! $hide_coords) {
             $r['cacheid']);
 
         while ($rLog = XDb::xFetchArray($rsLogs)) {
+            // groundspeak:log
             $thislog = $gpxLog;
-
             $thislog = str_replace('{id}', $rLog['id'], $thislog);
             $thislog = str_replace('{date}', date($gpxTimeFormat, strtotime($rLog['date'])), $thislog);
             if (isset($gpxLogType[$rLog['type']]))
@@ -473,9 +513,21 @@ if ($usr || ! $hide_coords) {
             $thislog = str_replace('{finder_id}', xmlentities($rLog['userid']), $thislog);
             $thislog = str_replace('{type}', $logtype, $thislog);
             $thislog = str_replace('{text}', cleanup_text($rLog['text']), $thislog);
-            $logentries .= $thislog . "\n";
+            $gs_logentries .= $thislog . "\n";
+
+            // oc:log
+            $thislog = $gpxOcLog;
+            $thislog = str_replace('{id}', $rLog['id'], $thislog);
+            $thislog = str_replace('{uuid}', $rLog['uuid'], $thislog);
+            if ($rLog['type'] == GeoCacheLog::LOGTYPE_ADMINNOTE) {
+                $thislog = str_Replace('{oc_team_entry}', $gpxOcIsTeamEntry, $thislog);
+            } else {
+                $thislog = str_Replace('{oc_team_entry}', '', $thislog);
+            }
+            $oc_logentries .= $thislog . "\n";
         }
-        $thisline = str_replace('{logs}', $logentries, $thisline);
+        $thisline = str_replace('{gs_logs}', $gs_logentries, $thisline);
+        $thisline = str_replace('{oc_logs}', $oc_logentries, $thisline);
 
         // Travel Bug - GeoKrety
         $waypoint = $r['waypoint'];

--- a/tpl/stdstyle/js/okapiGpxFormatterWidget.js
+++ b/tpl/stdstyle/js/okapiGpxFormatterWidget.js
@@ -89,6 +89,7 @@
     var generateOkapiParamSets = function(cacheCodes, formResponses) {
         var params = {};
         params['ns_ground'] = "true";
+        params['ns_oc'] = "true";
 
         // lpc
         if (formResponses['lpc'] === "all") {


### PR DESCRIPTION
This is a preliminary implementation of the new [Opencaching GPX extension](https://github.com/opencaching/gpx-extension-v1). It is just for review / testing / discussion, so **please don't merge**! Final code should be ready in 1-2 weeks.

This adds an `<oc:cache>` section for each geoache in the GPX files. Any apps which do not know that will ignore it; it is fully backward compatible.

The `<oc:cache>` section contains OC-specific information which otherwise is missing in GPX or not included in a safely machine-readable form:

* OC cache types
* log password requirement
* waypoint codes of other platforms, e.g. GC code
* estimated time and distance for searching
* UUIDs of log entries (this links GPX log entries to Okapi)

More information like OC attributes and OC waypoint types will be added in the future. It takes some time to define them properly.

Two detail notes:

* `<oc:size>` looks redundant to `<groundspeak:container>`. However, this is only the case for native OCPL GPX. Okapi and OCDE convert the sizes "Very large" and "Nano" to Groundspeak-compatible sizes "Large" and Micro". (Putting "Very large" and "Nano" into `<groundspeak:container>` has the drawback that some applications will not recognize it, then the cache as no size at all.) To have the same OC-GPX output on all plattforms, `<oc:size>` is redundantly added for OCPL.

* Similar for `<oc:site_team_entry>`. It is redundant to the log type "OC Team Comment". However, Okapi and OCDE don't have this log type, but a "Team comment" flag which can be set for any type of log entry. Again, to have the same OC-GPX output on all plattforms, `<oc:site_team_entry>` is redundantly added for OCPL.