### PR TITLE
add indexes to optimize logging table cleanup

### DIFF
--- a/docs/database/approval_status
+++ b/docs/database/approval_status
@@ -26,7 +26,8 @@ Create Table: CREATE TABLE `approval_status` (
   `user_id` int(11) NOT NULL,
   `status` int(11) NOT NULL,
   `date_approval` datetime DEFAULT NULL,
-  PRIMARY KEY (`cache_id`)
+  PRIMARY KEY (`cache_id`),
+  KEY `date_approval` (`date_approval`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8
 
 Changelog

--- a/docs/database/email_user
+++ b/docs/database/email_user
@@ -28,9 +28,7 @@ from_email
 to_user_id
 to_email
 mail_subject
-mail_text
 send_emailaddress
-date_sent
 
 
 *************************** 1. row ***************************
@@ -44,12 +42,10 @@ Create Table: CREATE TABLE `email_user` (
   `to_user_id` int(11) NOT NULL DEFAULT '0',
   `to_email` varchar(60) NOT NULL,
   `mail_subject` varchar(255) NOT NULL,
-  `mail_text` text NOT NULL,
   `send_emailaddress` int(1) NOT NULL DEFAULT '0',
-  `date_sent` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`id`),
-  KEY `date_sent` (`date_sent`),
-  KEY `from_user_id` (`from_user_id`)
+  KEY `from_user_id` (`from_user_id`),
+  KEY `date_generated` (`date_generated`)
 ) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8
 
 Changelog

--- a/docs/database/logentries
+++ b/docs/database/logentries
@@ -41,7 +41,8 @@ Create Table: CREATE TABLE `logentries` (
   `logtext` mediumtext NOT NULL,
   `details` blob NOT NULL,
   `logtime` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `logtime` (`logtime`)
 ) ENGINE=MyISAM AUTO_INCREMENT=778 DEFAULT CHARSET=utf8
 
 Changelog

--- a/sqlAlters/2017-10-03_add_log_indexes.sql
+++ b/sqlAlters/2017-10-03_add_log_indexes.sql
@@ -1,0 +1,7 @@
+-- 2017-09-07: add indexes for truncating logs; see https://github.com/opencaching/opencaching-pl/issues/1200
+-- @author: following5
+
+ALTER TABLE `approval_status` ADD INDEX (`date_approval`);
+ALTER TABLE `logentries` ADD INDEX (`logtime`);
+ALTER TABLE `email_user` ADD INDEX (`date_generated`);
+ALTER TABLE `CACHE_ACCESS_LOGS` ADD INDEX (`event_date`);


### PR DESCRIPTION
Whith these additional indexes, #1200 can be implemented without a new cronjob: Table cleanup will be fast enough to do it on-the-fly, by the same functions that insert new entries.

I would write the cleanup code for the tables then in a second step.

(table docs for `email_user` were outdated, have fixed that)