### PR TITLE
GPX attribute mapping overhaul; fixes #1242

### DIFF
--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -213,17 +213,18 @@ $gpxLogType[11] = 'Temporarily Disable Listing';        // OC: XXX_TEMPORARILY_U
 $gpxLogType[12] = 'OC Team Comment';                    // OC: XXX_OC_TEAM_COMMENT
 // Note: log types implementation incomplete.
 
-// ************************************************************************
-// Attributes
+/************************************************************************
+Attributes
 
-// GPX ID mapping of all attributes of OC.PL .NL .RO .UK. .US, as of 3 October 2017.
-// If there is a matching DE attribute with other ID, the DE ID is given in the "DE" column.
-//
-// IDs < 100 are original GC.com, 101-199 are pseudo-GC IDs for special Opencaching attributes.
-// Appended ".0" means inc="0".
-//
-// Note that there are some redundant IDs, e.h. UK/RO 46 and NL/PL/US 83 both map to
-// GC 51 "Special tool required".
+GPX ID mapping of all attributes of OC.PL .NL .RO .UK. .US, as of 3 October 2017.
+If there is a matching DE attribute with other ID, the DE ID is given in the "DE" column.
+
+IDs < 100 are original GC.com, 101-199 are pseudo-GC IDs for special Opencaching attributes.
+Appended ".0" means inc="0".
+
+Note that there are some redundant IDs, e.h. UK/RO 46 and NL/PL/US 83 both map to
+GC 51 "Special tool required".
+*/
 
 // common assignments
 $gpxAttribID[1] = '52';     $gpxAttribName[1] = 'Night cache';                // DE UK
@@ -301,6 +302,27 @@ $gpxAttribID[155] = '47';   $gpxAttribName[155] = 'Field puzzle';             //
 $gpxAttribID[156] = '153';  $gpxAttribName[156] = 'Aircraft required';        // 53 UK
 $gpxAttribID[157] = '125';  $gpxAttribName[157] = 'Rated on Handicaching.com';//    UK
 $gpxAttribID[158] = '126';  $gpxAttribName[158] = 'Contains a Munzee';        //    UK
+
+/*
+ATTENTION:
+
+If you add a new attribute to your OC site, follow these steps to assign a GPX ID:
+
+1. Try to map it to an existing Groundspeak attribute. Consult the table in the
+   upper section of okapi/services/attrs/attribute-definitions.xml for all known
+   GS attribs. If no GS attribute is available:
+
+2. Try to map it to an existing OCDE attribute. You will find all OCDE attributes here:
+   https://github.com/OpencachingDeutschland/oc-server3/blob/development/sql/static-data/cache_attrib.sql
+   The column "gc_id" contains the GPX ID for the attribute, and the column "gc_inc"
+   the inc-value. If no OCDE attribute is available:
+
+3. Use the first number from this list of unassigned GPX IDs, and remove if from the list:
+   128, 129, 136, 138, 139, 140, 142, 144, 146, 148, 149, 151, 152, 155, 159, 160.
+
+4. Inform the Okapi project about your new attribute, so that it will be added to
+   okapi/services/attrs/attribute-definitions.
+*/
 
 // special UK assignemnts
 $gpxAI['UK'][40] = '14.0';  $gpxAInm['UK'][40] = 'Not recommended at night';  // DE UK

--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -68,7 +68,7 @@ $gpxLine = '
 {cache_waypoints}
 ';
 
-$gpxAttributes = '                <groundspeak:attribute id="{attrib_id}" inc="{attrib_inc}">{attrib_text_long}</groundspeak:attribute>';
+$gpxAttribute = '                <groundspeak:attribute id="{attrib_id}" inc="{attrib_inc}">{attrib_text_long}</groundspeak:attribute>';
 
 $gpxLog = '                <groundspeak:log id="{id}">
                     <groundspeak:date>{date}</groundspeak:date>
@@ -216,87 +216,126 @@ $gpxLogType[12] = 'OC Team Comment';                    // OC: XXX_OC_TEAM_COMME
 // ************************************************************************
 // Attributes
 
-// 1st set of attributes - attributes that are Groundspeak equivalent
-$gpxAttribID[1] = '52';     $gpxAttribName[1] = 'Night Cache';
-$gpxAttribID[9] = '23';     $gpxAttribName[9] = 'Dangerous area';
-$gpxAttribID[11] = '21';    $gpxAttribName[11] = 'Cliff / falling rocks';
-$gpxAttribID[12] = '22';    $gpxAttribName[12] = 'Hunting';
-$gpxAttribID[13] = '39';    $gpxAttribName[13] = 'Thorns';
-$gpxAttribID[14] = '19';    $gpxAttribName[14] = 'Ticks';
-$gpxAttribID[15] = '20';    $gpxAttribName[15] = 'Abandoned mines';
-$gpxAttribID[16] = '17';    $gpxAttribName[16] = 'Poisonous plants';
-$gpxAttribID[17] = '18';    $gpxAttribName[17] = 'Dangerous animals';
-$gpxAttribID[18] = '25';    $gpxAttribName[18] = 'Parking available';
-$gpxAttribID[19] = '26';    $gpxAttribName[19] = 'Public transportation';
-$gpxAttribID[20] = '27';    $gpxAttribName[20] = 'Drinking water nearby';
-$gpxAttribID[21] = '28';    $gpxAttribName[21] = 'Public restrooms nearby';
-$gpxAttribID[22] = '29';    $gpxAttribName[22] = 'Telephone nearby';
-$gpxAttribID[24] = '53';    $gpxAttribName[53] = 'Park and grab';
-$gpxAttribID[25] = '9';     $gpxAttribName[25] = 'Significant Hike';
-$gpxAttribID[26] = '11';    $gpxAttribName[26] = 'May require wading';
-$gpxAttribID[28] = '10';    $gpxAttribName[28] = 'Difficult climbing';
-$gpxAttribID[29] = '12';    $gpxAttribName[29] = 'May require swimming';
-$gpxAttribID[36] = '2';     $gpxAttribName[36] = 'Access or parking fee';
-$gpxAttribID[38] = '13';    $gpxAttribName[38] = 'Available at all times';
-$gpxAttribID[39] = '13';    $gpxAttribName[39] = 'Available at all times';          $gptAttribInc[39] = '0';
-//$gpxAttribID[40] = '14';    $gpxAttribName[40] = 'Recommended at night';            $gptAttribInc[39] = '0'; // OCUK mapping overlap
-$gpxAttribID[41] = '6';     $gpxAttribName[41] = 'Recommended for kids';
-$gpxAttribID[42] = '62';    $gpxAttribName[42] = 'Seasonal access';                 $gptAttribInc[39] = '0';
-$gpxAttribID[44] = '24';    $gpxAttribName[44] = 'Wheelchair accessible';
-//$gpxAttribID[44] = '15';    $gpxAttribName[44] = 'Available during winter'; // OCUK mapping overlap
-$gpxAttribID[45] = '40';    $gpxAttribName[45] = 'Stealth required';
-$gpxAttribID[46] = '51';    $gpxAttribName[46] = 'Special tool required';
-//$gpxAttribID[49] = '3';     $gpxAttribName[49] = 'Climbing gear required'; // OCUK mapping overlap
-//$gpxAttribID[51] = '5';     $gpxAttribName[51] = 'Scuba gear required'; // OCUK mapping overlap
-$gpxAttribID[52] = '60';    $gpxAttribName[52] = 'Wireless Beacon';
-$gpxAttribID[59] = '6';     $gpxAttribName[59] = 'Recommended for kids';
-$gpxAttribID[80] = '13';    $gpxAttribName[80] = 'Available at all times';          $gptAttribInc[39] = '0';
-$gpxAttribID[82] = '44';    $gpxAttribName[82] = 'Flashlignt required';
-$gpxAttribID[83] = '51';    $gpxAttribName[83] = 'Special tool required';
-$gpxAttribID[85] = '32';    $gpxAttribName[85] = 'Bicycles';
-$gpxAttribID[86] = '4';     $gpxAttribName[86] = 'Boat required';
-$gpxAttribID[90] = '23';    $gpxAttribName[90] = 'Dangerous area';
-$gpxAttribID[91] = '14';    $gpxAttribName[91] = 'Recommended at night';
-$gpxAttribID[155] = '47';   $gpxAttribName[155] = 'Field puzzle';
+// GPX ID mapping of all attributes of OC.PL .NL .RO .UK. .US, as of 3 October 2017.
+// If there is a matching DE attribute with other ID, the DE ID is given in the "DE" column.
+//
+// IDs < 100 are original GC.com, 101-199 are pseudo-GC IDs for special Opencaching attributes.
+// Appended ".0" means inc="0".
+//
+// Note that there are some redundant IDs, e.h. UK/RO 46 and NL/PL/US 83 both map to
+// GC 51 "Special tool required".
 
-// 2nd set of attributes - OC only attributes, changed ID (+100) to be safe in OC-GC-mixed environments
-$gpxAttribID[8] = '156';     $gpxAttribName[8] = 'Letterbox cache';
-$gpxAttribID[10] = '110';    $gpxAttribName[10] = 'Active railway nearby';
-$gpxAttribID[23] = '123';    $gpxAttribName[23] = 'First aid available';
-$gpxAttribID[27] = '127';    $gpxAttribName[27] = 'Hilly area';
-$gpxAttribID[30] = '130';    $gpxAttribName[30] = 'Point of interest';
-$gpxAttribID[31] = '131';    $gpxAttribName[31] = 'Has a moving target';
-$gpxAttribID[32] = '132';    $gpxAttribName[32] = 'A webcam is involved';
-$gpxAttribID[33] = '133';    $gpxAttribName[33] = 'Hidden wihin enclosed rooms (caves, buildings etc.)';
-$gpxAttribID[34] = '134';    $gpxAttribName[34] = 'Hidden under water';
-$gpxAttribID[35] = '135';    $gpxAttribName[35] = 'No GPS required';
-$gpxAttribID[37] = '137';    $gpxAttribName[37] = 'Overnight stay necessary';
-$gpxAttribID[40] = '140';    $gpxAttribName[40] = 'GeoHotel';
-//$gpxAttribID[41] = '141';    $gpxAttribName[41] = 'Not available during high tide'; // OCUK mapping overlap
-$gpxAttribID[43] = '143';    $gpxAttribName[43] = 'Quick cache';
-//$gpxAttribID[43] = '143';    $gpxAttribName[43] = 'Nature preserve / Breeding season'; // OCUK mapping overlap
-$gpxAttribID[49] = '149';    $gpxAttribName[49] = 'Magnetic';
-$gpxAttribID[47] = '147';    $gpxAttribName[47] = 'Compass required';
-$gpxAttribID[48] = '148';    $gpxAttribName[48] = 'Bring your own pen';
-$gpxAttribID[50] = '150';    $gpxAttribName[50] = 'Audio file';
-//$gpxAttribID[50] = '150';    $gpxAttribName[50] = 'Cave equipment required'; // OCUK mapping overlap
-$gpxAttribID[51] = '151';    $gpxAttribName[51] = 'Offset cache';
-$gpxAttribID[53] = '153';    $gpxAttribName[53] = 'USB Dead Drop cache';
-$gpxAttribID[54] = '154';    $gpxAttribName[54] = 'Near a Survey Marker';
-//$gpxAttribID[54] = '154';    $gpxAttribName[54] = 'Investigation required'; // OCUK mapping overlap
-$gpxAttribID[55] = '155';    $gpxAttribName[55] = 'Wherigo cache';
-$gpxAttribID[56] = '156';    $gpxAttribName[56] = 'Letterbox cache';
-//$gpxAttribID[56] = '156';    $gpxAttribName[56] = 'Mathematical problem'; // OCUK mapping overlap
-$gpxAttribID[57] = '157';    $gpxAttribName[57] = 'Other cache type';
-$gpxAttribID[58] = '158';    $gpxAttribName[58] = 'Ask owner for start conditions';
-$gpxAttribID[60] = '160';    $gpxAttribName[60] = 'Hidden in natural surroundings (forests, mountains, etc.)';
-$gpxAttribID[61] = '161';    $gpxAttribName[61] = 'Historic site';
-$gpxAttribID[81] = '181';    $gpxAttribName[81] = 'You may need a shovel';
-$gpxAttribID[84] = '184';    $gpxAttribName[84] = 'Access only on foot';
-$gpxAttribID[106] = '106';   $gpxAttribName[106] = 'OC-only cache';
-$gpxAttribID[156] = '156';   $gpxAttribName[156] = 'Aircraft required';
-$gpxAttribID[157] = '157';   $gpxAttribName[157] = 'Rated on Handicaching.com';
-$gpxAttribID[158] = '158';   $gpxAttribName[158] = 'Contains a Munzee';
+// common assignments
+$gpxAttribID[1] = '52';     $gpxAttribName[1] = 'Night cache';                // DE UK
+$gpxAttribID[6] = '106';    $gpxAttribName[6] = 'OC-only cache';              // DE UK RO NL
+$gpxAttribID[8] = '108';    $gpxAttribName[8] = 'Letterbox cache';            // DE UK RO
+$gpxAttribID[9] = '23';     $gpxAttribName[9] = 'Dangerous area';             // DE UK RO
+$gpxAttribID[10] = '110';   $gpxAttribName[10] = 'Active railway nearby';     // DE UK
+$gpxAttribID[11] = '21';    $gpxAttribName[11] = 'Cliff / falling rocks';     // DE UK
+$gpxAttribID[12] = '22';    $gpxAttribName[12] = 'Hunting';                   // DE UK RO NL
+$gpxAttribID[13] = '39';    $gpxAttribName[13] = 'Thorns';                    // DE UK RO NL
+$gpxAttribID[14] = '19';    $gpxAttribName[14] = 'Ticks';                     // DE UK RO NL
+$gpxAttribID[15] = '20';    $gpxAttribName[15] = 'Abandoned mines';           // DE UK
+$gpxAttribID[16] = '17';    $gpxAttribName[16] = 'Poisonous plants';          // DE UK
+$gpxAttribID[17] = '18';    $gpxAttribName[17] = 'Dangerous animals';         // DE UK
+$gpxAttribID[18] = '25';    $gpxAttribName[18] = 'Parking available';         // DE UK RO NL
+$gpxAttribID[19] = '26';    $gpxAttribName[19] = 'Public transportation';     // DE UK
+$gpxAttribID[20] = '27';    $gpxAttribName[20] = 'Drinking water nearby';     // DE UK RO
+$gpxAttribID[21] = '28';    $gpxAttribName[21] = 'Public restrooms nearby';   // DE UK
+$gpxAttribID[22] = '29';    $gpxAttribName[22] = 'Telephone nearby';          // DE UK
+$gpxAttribID[23] = '123';   $gpxAttribName[23] = 'First aid available';       // DE UK
+$gpxAttribID[24] = '53';    $gpxAttribName[24] = 'Park and grab';             // DE UK
+$gpxAttribID[25] = '9';     $gpxAttribName[25] = 'Significant Hike';          // DE UK RO NL
+$gpxAttribID[26] = '11';    $gpxAttribName[26] = 'May require wading';        // DE UK
+$gpxAttribID[27] = '127';   $gpxAttribName[27] = 'Hilly area';                // DE UK
+$gpxAttribID[28] = '10';    $gpxAttribName[28] = 'Difficult climbing';        // DE UK
+$gpxAttribID[29] = '12';    $gpxAttribName[29] = 'May require swimming';      // DE UK
+$gpxAttribID[30] = '130';   $gpxAttribName[30] = 'Point of interest';         // DE UK
+$gpxAttribID[31] = '131';   $gpxAttribName[31] = 'Has a moving target';       // DE UK
+$gpxAttribID[32] = '132';   $gpxAttribName[32] = 'A webcam is involved';      // DE UK
+$gpxAttribID[33] = '133';   $gpxAttribName[33] = 'Hidden wihin enclosed room';// DE UK
+$gpxAttribID[34] = '134';   $gpxAttribName[34] = 'Hidden under water';        // DE UK
+$gpxAttribID[35] = '135';   $gpxAttribName[35] = 'No GPS required';           // DE UK
+$gpxAttribID[36] = '2';     $gpxAttribName[36] = 'Access or parking fee';     // DE UK
+$gpxAttribID[37] = '137';   $gpxAttribName[37] = 'Overnight stay necessary';  // DE UK
+$gpxAttribID[38] = '13';    $gpxAttribName[38] = 'Available at all times';    // DE UK
+$gpxAttribID[39] = '13.0';  $gpxAttribName[39] = 'Only available at specified times';
+                                                                              // DE UK
+$gpxAttribID[40] = '111';   $gpxAttribName[40] = 'Quick cache';               //       RO NL PL US
+$gpxAttribID[41] = '6';     $gpxAttribName[41] = 'Recommended for kids';      // (59)     NL PL US
+$gpxAttribID[42] = '62.0';  $gpxAttribName[42] = 'All seasons';               // DE UK
+$gpxAttribID[43] = '112';   $gpxAttribName[43] = 'GeoHotel';                  //       RO NL PL
+                                                                              // DE UK
+$gpxAttribID[44] = '24';    $gpxAttribName[44] = 'Wheelchair accessible';     //       RO NL PL US
+$gpxAttribID[45] = '40';    $gpxAttribName[45] = 'Stealth required';          //       RO NL
+$gpxAttribID[46] = '51';    $gpxAttribName[46] = 'Special tool required';     // UK    RO         
+$gpxAttribID[47] = '147';   $gpxAttribName[47] = 'Compass required';          // DE UK RO NL PL
+$gpxAttribID[48] = '113';   $gpxAttribName[48] = 'Bring your own pen';        //       RO NL PL US
+$gpxAttribID[49] = '149';   $gpxAttribName[49] = 'Magnetic';                  //       RO NL PL US       
+$gpxAttribID[50] = '114';   $gpxAttribName[50] = 'Audio file';                //       RO NL PL       
+$gpxAttribID[51] = '115';   $gpxAttribName[51] = 'Offset cache';              //       RO    PL US
+$gpxAttribID[52] = '60';    $gpxAttribName[52] = 'Wireless Beacon';           //       RO NL PL US
+$gpxAttribID[53] = '116';   $gpxAttribName[53] = 'USB Dead Drop cache';       //       RO NL PL
+$gpxAttribID[54] = '117';   $gpxAttribName[54] = 'Near a Survey Marker';      //       RO NL PL
+$gpxAttribID[55] = '118';   $gpxAttribName[55] = 'Wherigo cache';             //       RO    PL
+$gpxAttribID[56] = '108';   $gpxAttribName[56] = 'Letterbox cache';           // 8        NL PL
+$gpxAttribID[57] = '157';   $gpxAttribName[57] = 'Other cache type';          // DE UK
+$gpxAttribID[58] = '158';   $gpxAttribName[58] = 'Ask owner for start conditions';
+$gpxAttribID[59] = '6';     $gpxAttribName[59] = 'Recommended for kids';      // DE UK RO NL
+$gpxAttribID[60] = '119';   $gpxAttribName[60] = 'Hidden in natural surroundings';
+                                                                              //       RO NL PL US
+$gpxAttribID[61] = '120';   $gpxAttribName[61] = 'Historic site';             //       RO NL PL US
+$gpxAttribID[62] = '54';    $gpxAttribName[62] = 'Abandoned structure';       //          NL
+$gpxAttribID[80] = '13.0';  $gpxAttribName[80] = 'Only available at specified times';
+                                                                              // 39          PL US
+$gpxAttribID[81] = '121';   $gpxAttribName[81] = 'You may need a shovel';     //       RO NL PL
+$gpxAttribID[82] = '44';    $gpxAttribName[82] = 'Flashlignt required';       // 48 UK RO NL PL US
+$gpxAttribID[83] = '51';    $gpxAttribName[83] = 'Special tool required';     // 46       NL PL US
+$gpxAttribID[84] = '122';   $gpxAttribName[84] = 'Access only on foot';       //       RO NL PL
+$gpxAttribID[85] = '32';    $gpxAttribName[85] = 'Bicycles';                  //       RO NL PL
+    // TODO: https://github.com/opencaching/opencaching-pl/issues/1244
+$gpxAttribID[86] = '4';     $gpxAttribName[86] = 'Boat required';             // 52 UK RO NL PL
+$gpxAttribID[90] = '23';    $gpxAttribName[90] = 'Dangerous area';            //       RO NL PL US
+$gpxAttribID[91] = '14';    $gpxAttribName[91] = 'Recommended at night';      // 9     RO NL PL
+$gpxAttribID[155] = '47';   $gpxAttribName[155] = 'Field puzzle';             //    UK RO
+$gpxAttribID[156] = '153';  $gpxAttribName[156] = 'Aircraft required';        // 53 UK
+$gpxAttribID[157] = '125';  $gpxAttribName[157] = 'Rated on Handicaching.com';//    UK
+$gpxAttribID[158] = '126';  $gpxAttribName[158] = 'Contains a Munzee';        //    UK
+
+// special UK assignemnts
+$gpxAI['UK'][40] = '14.0';  $gpxAInm['UK'][40] = 'Not recommended at night';  // DE UK
+$gpxAI['UK'][41] = '142';   $gpxAInm['UK'][41] = 'Not available during high tide';
+    // Due to a typo in OCDE code, #41 maps to #142 instead of #141.             DE UK
+    // It has inc="1" in spite of "negative logic", because there is
+    // not matching positive attribute.
+$gpxAI['UK'][43] = '143';   $gpxAInm['UK'][43] = 'Neature reserve / Breeding season';
+$gpxAI['UK'][44] = '15';    $gpxAInm['UK'][44] = 'Available during winter';   // DE UK
+$gpxAI['UK'][49] = '3';     $gpxAInm['UK'][49] = 'Climbing gear required';    // DE UK
+$gpxAI['UK'][50] = '150';   $gpxAInm['UK'][50] = 'Cave equipment required';   // DE UK
+$gpxAI['UK'][51] = '5';     $gpxAInm['UK'][51] = 'Scuba gear required';       // DE UK
+$gpxAI['UK'][54] = '154';   $gpxAInm['UK'][54] = 'Investigation required';    // DE UK
+$gpxAI['UK'][56] = '156';   $gpxAInm['UK'][56] = 'Mathematical problem';      // DE UK
+
+// special US assignments
+$gpxAI['US'][42] = '46';    $gpxAInm['US'][42] = 'Big rig friendly';          //                US
+$gpxAI['US'][43] = '2';     $gpxAInm['US'][43] = 'Access fee';                // 36             US
+$gpxAI['US'][45] = '19';    $gpxAInm['US'][45] = 'Ticks';                     // 14             US
+$gpxAI['US'][46] = '18';    $gpxAInm['US'][46] = 'Snakes';                    // (17)           US
+$gpxAI['US'][47] = '39';    $gpxAInm['US'][47] = 'Thorns';                    // 13             US
+$gpxAI['US'][50] = '15';    $gpxAInm['US'][50] = 'Available during winter';   // 44             US
+$gpxAI['US'][53] = '112';   $gpxAInm['US'][53] = 'GeoHotel';                  //                US
+$gpxAI['US'][54] = '17';    $gpxAInm['US'][54] = 'Poisonous plants';          // 16             US
+$gpxAI['US'][55] = '117';   $gpxAInm['US'][55] = 'Near a Survey Marker';      //                US
+$gpxAI['US'][56] = '126';   $gpxAInm['US'][56] = 'Munzee';                    //                US
+$gpxAI['US'][81] = '108';   $gpxAInm['US'][81] = 'Letterbox cache';           // 8              US
+$gpxAI['US'][91] = '52';    $gpxAInm['US'][91] = 'Night cache';               // 1              US
+$gpxAI['US'][92] = '106';   $gpxAInm['US'][92] = 'OC-only cache';             // 6              US
+$gpxAI['US'][94] = '40';    $gpxAInm['US'][94] = 'Stealth required';          //                US
+$gpxAI['US'][95] = '124';   $gpxAInm['US'][95] = 'Contains advertising';      //                US
+$gpxAI['US'][96] = '147';   $gpxAInm['US'][96] = 'Compass required';          // 47             US
+
+// node map
+$gpxNodemap = [2 => 'PL', 4 => 'DEVEL', 6 => 'UK', 10 => 'US', 14 => 'NL', 16 => 'RO'];
 
 // ************************************************************************
 // Waypoints

--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -318,17 +318,34 @@ if ($usr || ! $hide_coords) {
             $r['cacheid']);
 
         $attribentries = '';
+        if (isset($gpxNodemap[$oc_nodeid]) && isset($gpxAI[$gpxNodemap[$oc_nodeid]])) {
+            $nodeCode = $gpxNodemap[$oc_nodeid];
+        } else {
+            $nodeCode = '';
+        }
+
         while ($rAttrib = XDb::xFetchArray($rsAttributes)) {
-            if (isset($gpxAttribID[$rAttrib['attrib_id']])) {
-                $thisattribute = $gpxAttributes;
+            $attrib_id = $rAttrib['attrib_id'];
+            if ($nodeCode !== '' && isset($gpxAI[$nodeCode][$attrib_id])) {
+                # special attribute definition of one OC site
+                $gpx_id = (int) $gpxAI[$nodeCode][$attrib_id];
+                $gpx_inc = (substr($gpxAI[$nodeCode][$attrib_id], -2) == '.0' ? '0' : '1');
+                $gpx_name = $gpxAInm[$nodeCode][$attrib_id];
+            } elseif (isset($gpxAttribID[$attrib_id])) {
+                # common attribute definition
+                $gpx_id = (int) $gpxAttribID[$attrib_id];
+                $gpx_inc = (substr($gpxAttribID[$attrib_id], -2) == '.0' ? '0' : '1');
+                $gpx_name = $gpxAttribName[$attrib_id];
+            } else {
+                # definition is missing
+                $gpx_id = 0;
+            }
 
-                $thisattribute = mb_ereg_replace('{attrib_id}', $gpxAttribID[$rAttrib['attrib_id']], $thisattribute);
-                $thisattribute = mb_ereg_replace('{attrib_text_long}', $gpxAttribName[$rAttrib['attrib_id']], $thisattribute);
-                if (isset($gpxAttribInc[$rAttrib['attrib_id']]))
-                    $thisattribute = mb_ereg_replace('{attrib_id}', $gpxAttribInc[$rAttrib['attrib_id']], $thisattribute);
-                else
-                    $thisattribute = mb_ereg_replace('{attrib_inc}', 1, $thisattribute);
-
+            if ($gpx_id > 0) {
+                $thisattribute = $gpxAttribute;
+                $thisattribute = mb_ereg_replace('{attrib_id}', $gpx_id, $thisattribute);
+                $thisattribute = mb_ereg_replace('{attrib_inc}', $gpx_inc, $thisattribute);
+                $thisattribute = mb_ereg_replace('{attrib_text_long}', $gpx_name, $thisattribute);
                 $attribentries .= $thisattribute . "\n";
             }
         }


### PR DESCRIPTION
This implements a clean mapping of virtually ALL attributes used on OCPL-based sites to GPX attributes. Including the special attributes of Opencache.UK and Opencaching.US.

For the NL "Lost place" (see https://github.com/opencaching/okapi/issues/515) I have assumed that it is moved from ID 61 to 62. So this change retains the assignment of NL ID 61 to "Historic place" and adds 62 for "Lost place".

For the NL and RO "Bicycle" attribute (see https://github.com/opencaching/opencaching-pl/issues/1244) I have assumed that they mean "Accessible by bike" like at PL. This may need to be changed to a new attribute "Bicycle recommended", especially for RO which defined it as "Bicycle recommended" in native language.

Next step would be to add this mappings to Okapi, so that Okapi can produce the same GPX attribute IDs. Finally the mapping table here in format.gpx.inc.php may be replaced by a call to Okapi, so that all the mappings are kept only in one place.

(_Fun fact: The only attribute which is the same over all the sites - PL NL UK US RO - is "Flashlight required"._ :-)