### PR TITLE
added optional log tables cleanup; fixes #1200

### DIFF
--- a/Utils/Log/CacheAccessLog.php
+++ b/Utils/Log/CacheAccessLog.php
@@ -11,12 +11,17 @@ use Utils\Database\XDb;
 
 class CacheAccessLog
 {
-
     const SOURCE_BROWSER = "B";
     const SOURCE_MOBILE = "M";
     const SOURCE_OKAPI = "O";
 
-    public static function logCacheAccess($cacheId, $userId, $event, $source){
+    public static function logCacheAccess($cacheId, $userId, $event, $source)
+    {
+        // There are many other places where rows are inserted into CACHE_ACCESS_LOG,
+        // but this probably is the most frequented one. So we do the cleanup just
+        // from here.
+        Log::cleanup('CACHE_ACCESS_LOGS');
+
         $accessLog = @$_SESSION['CACHE_ACCESS_LOG_VC_' . $userId];
         if ($accessLog === null) {
             $_SESSION['CACHE_ACCESS_LOG_VC_' . $userId] = array();

--- a/Utils/Log/Log.php
+++ b/Utils/Log/Log.php
@@ -6,16 +6,50 @@
 
 namespace Utils\Log;
 
+use Exception;
 use Utils\Database\XDb;
+
+$rootpath = __DIR__ . '/../../';
+require_once($rootpath . 'lib/settingsGlue.inc.php');
 
 class Log
 {
-    public static function logentry( $module, $eventid, $userid, $objectid1, $objectid2, $logtext, $details ){
+    public static function logentry($module, $eventid, $userid, $objectid1, $objectid2, $logtext, $details)
+    {
+        self::cleanup('logentries');
 
         XDb::xSql(
             "INSERT INTO logentries (`module`, `eventid`, `userid`, `objectid1`, `objectid2`, `logtext`, `details`, `logtime`)
-        VALUES ( ?, ?, ?, ?, ?, ?, ?, NOW())",
+            VALUES ( ?, ?, ?, ?, ?, ?, ?, NOW())",
             $module, $eventid, $userid, $objectid1, $objectid2, $logtext, serialize($details));
     }
 
+    public static function cleanup($table)
+    {
+        global $config;
+
+        switch ($table) {
+            case 'logentries':
+                $datefield = 'logtime';
+                break;
+            case 'approval_status':
+                $datefield = 'date_approval';
+                break;
+            case 'email_user':
+                $datefield = 'date_generated';
+                break;
+            case 'CACHE_ACCESS_LOGS':
+                $datefield = 'event_date';
+                break;
+            default:
+                throw new Exception('unknown table: ' . $table);
+        }
+        if ($config['logging_cleanup'][$table] > 0) {
+            XDb::xSql(
+                "DELETE FROM ".$table."
+                WHERE DATEDIFF(NOW(), ".$datefield.") > 30 * ?
+                LIMIT 1000",
+                $config['logging_cleanup'][$table]);
+        }
+    }
 }

--- a/lib/Objects/User/UserMessage.php
+++ b/lib/Objects/User/UserMessage.php
@@ -5,12 +5,13 @@ namespace lib\Objects\User;
 use lib\Objects\BaseObject;
 use Utils\Database\XDb;
 use Utils\Email\EmailSender;
-
+use Utils\Log\Log;
 
 class UserMessage extends BaseObject
 {
     public static function SendUserMessage(User $from, User $to, $subject, $text, $attachSenderAddress)
     {
+        Log::cleanup('email_user');
 
         // save email trace
         XDb::xSql(

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -289,3 +289,15 @@ $config['feed']['blog']['showAuthor'] = true;
 
 $subject_prefix_for_site_mails = "OCXX";
 $subject_prefix_for_reviewers_mails = "";
+
+/*
+ * Configuration of automatic cleanup of logging tables
+ * (see https://github.com/opencaching/opencaching-pl/issues/1200).
+ *
+ * Time in MONTHS to keep old entries, or 0 to disable. You may also set
+ * a fraction of a month, e.g. 0.25 for approximately a week.
+ */
+$config['logging_cleanup']['approval_status'] = 0;
+$config['logging_cleanup']['email_user'] = 0;
+$config['logging_cleanup']['logentries'] = 0;
+$config['logging_cleanup']['CACHE_ACCESS_LOGS'] = 0;

--- a/viewpendings.php
+++ b/viewpendings.php
@@ -3,6 +3,7 @@
 use Utils\Database\XDb;
 use lib\Objects\User\AdminNote;
 use Utils\Generators\Uuid;
+use Utils\Log\Log;
 
 global $bgcolor1, $bgcolor2;
 
@@ -103,6 +104,8 @@ function assignUserToCase($userid, $cacheid)
 
         return false;
     }
+
+    Log::cleanup('approval_status');
 
     XDb::xSql(
         "INSERT INTO approval_status (cache_id, user_id, status, date_approval)


### PR DESCRIPTION
By default, nothing changes after deploying this commit. You then can enable the automatic cleanup by adding some settings (see lib/settingsDefault.inc.php, the last four lines). E.g.

`$config['logging_cleanup']['logentries'] = 12;`

will automatically remove entries from `logentries` table that are older than 12 months.

Of course the defaults in lib/settingsDefault.inc.php could be changed, so that there would be some basic cleanup at all OC sites (e.g. delete everything which is older than 24 months).

For **Opencaching.PL** I recommend to do a one-time manual cleanup **before** enabling automatic cleanup. This may take some minutes, but will overall speed things up:

```
delete from logentries where logtime < 'some-date';
delete from approval_status where date_approval < 'some-date';
delete from email_user where date_generated < 'some-date';
delete from CACHE_ACCESS_LOGS where event_date < 'some-date';
```
Instead of the last one, you may also run `util.sec/cleanup_access_logs.php`. It will remove all `CACHE_ACCESS_LOGS` that are older than 5 days.


Btw, I noticed that ALL database method calls in the code break PSR-2. The closing `)` bracket must go onto the start of the next line. I have kept it consistent here and added the database statement in the same non-PSR-2 style.