### PR TITLE
buffer large GPX downloads in file; use built-in Zip; fixes #1006

### DIFF
--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -139,7 +139,10 @@ $config = array(
      * Common datetime and date format
      */
     'datetimeformat' => '%Y-%m-%d %H:%M:%S',
-    'dateformat' => '%Y-%m-%d'
+    'dateformat' => '%Y-%m-%d',
+
+    /** size limit in bytes for buffering downloads in a file, or 0 to disable buffering **/
+    'downloadMemorylimit' => 0,
 );
 
 // *** Repository automatic updates script location


### PR DESCRIPTION
After deploying this change, everything should be like before.

To fix issue #1006, you then must add two settings. The first one goes into the Apache config:

```
<FilesMatch "\.gpx$">
    ForceType application/gpx+xml
    Header set Content-Disposition attachment
</FilesMatch>
```

If you have separate config files for http and https, you may need to add it twice. Then restart the webserver (e.g. `systemctl restart httpd.service`) and add this to lib/settings.inc.php:

`$config['downloadMemorylimit'] = 1024 * 1024 * 8;`

This will buffer all GPX data larger than 8 MB in a file, and then redirect to this file. (You may chose some other limit than 8 MB).