### PR TITLE
buffer large GPX downloads in file; use built-in Zip; fixes #1006

### DIFF
--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -126,7 +126,10 @@ if (!isset($maxmp3size))
 if (!isset($mp3extensions))
     $mp3extensions = ';mp3;';
 
-
+// download settings
+$config['downloadMemorylimit'] = 1024 * 1024 * 8;
+$config['downloadPath'] = $dynbasepath . 'download';
+$config['downloadUrl'] = '/download';
 
 // default coordinates for cachemap, set to your country's center of gravity
 $country_coordinates = "52.5,19.2";

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -143,6 +143,10 @@ $config = array(
 
     /** size limit in bytes for buffering downloads in a file, or 0 to disable buffering **/
     'downloadMemorylimit' => 0,
+    /** path for temporary download files, WITHOUT trailing slash **/
+    'downloadPath' => '',
+    /** relative or absolute URL to access the download path, WITHOUT trailing slash **/
+    'downloadUrl' => '',
 );
 
 // *** Repository automatic updates script location

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -139,7 +139,10 @@ $config = array(
      * Common datetime and date format
      */
     'datetimeformat' => '%Y-%m-%d %H:%M:%S',
-    'dateformat' => '%Y-%m-%d'
+    'dateformat' => '%Y-%m-%d',
+
+    /** size limit in bytes for buffering downloads in a file, or 0 to disable buffering **/
+    'downloadMemorylimit' => 0,
 );
 
 // *** Repository automatic updates script location


### PR DESCRIPTION
(followup to #1247)

After deploying this change, everything should be as before. To fix issue #1006, you then must add this configuration setting:

`$config['downloadMemorylimit'] = 1024 * 1024 * 8;`

This will buffer all GPX data larger than 8 MB in a file, and then redirect to this file. (You may chose some other limit than 8 MB).

By default, those temporary GPX files will be located in a "gpx" subdirectory below the image upload directory. You _may_ move this gpx directory to somewhere else by adding the two settings

* `$config['downloadPath']`
* `$config['downloadUrl']`

See settingsDefault.inc.php and settings-examples.inc.php for more instructions on that.

I have also rewritten the Zipping, which currently is disabled because it was too slow for large downloads. It may worth to give it a new try (later).