### PR TITLE
show unpublished own caches in search result; fixes #186

### DIFF
--- a/lib/search.html.inc.php
+++ b/lib/search.html.inc.php
@@ -532,6 +532,7 @@ for ($i = 0; $i < $dbcSearch->rowCount($s); $i ++) {
     $tmpline = str_replace('{username}', htmlspecialchars($caches_record['username'], ENT_COMPAT, 'UTF-8'), $tmpline);
     $tmpline = str_replace('{usernameBIG}', strtoupper(trChar(htmlspecialchars($caches_record['username'], ENT_COMPAT, 'UTF-8'))), $tmpline);
     $tmpline = str_replace('{CacheID}', $caches_record['cache_id'], $tmpline);
+    $tmpline = str_replace('{style}', $caches_record['status'] >= 4 ? $unpublished_cache_style : '', $tmpline);
 
     if ($CalcDistance) {
         if ($usr || ! $hide_coords) {

--- a/search.php
+++ b/search.php
@@ -478,9 +478,9 @@ if ($usr == false) {
                 $sql_group = array();
 
                 // show only published caches
-                $sql_where[] = '`caches`.`status` != 4';
-                $sql_where[] = '`caches`.`status` != 5';
-                if(!$usr['admin'])
+                $sql_where[] = '(`caches`.`status` != 4 OR `caches`.`user_id`=' . XDb::xEscape($usr['userid']) . ')';
+                $sql_where[] = '(`caches`.`status` != 5 OR `caches`.`user_id`=' . XDb::xEscape($usr['userid']) . ')';
+                if (!$usr['admin'])
                 {
                     $sql_where[] = '`caches`.`status` != 6';
                 }

--- a/tpl/stdstyle/search.inc.php
+++ b/tpl/stdstyle/search.inc.php
@@ -56,6 +56,8 @@
     $cache_attrib_jsarray_line = "new Array('{id}', {state}, '{text_long}', '{icon}', '{icon_no}', '{icon_undef}', '{category}')";
     $cache_attrib_img_line = '<img id="attrimg{id}" src="{icon}" title="{text_long}" alt="{text_long}" onmousedown="switchAttribute({id})" style="cursor: pointer;" /> ';
 
+    $unpublished_cache_style = 'color:red';
+
 function dateDiff($interval, $dateTimeBegin, $dateTimeEnd)
 {
   //Parse about any English textual datetime

--- a/tpl/stdstyle/search.result.caches.row.tpl.php
+++ b/tpl/stdstyle/search.result.caches.row.tpl.php
@@ -2,7 +2,7 @@
 gct.addEmptyRow();
 gct.addToLastRow( 0, "{CacheID}" );
 gct.addToLastRow( 1, "<img span='{cachetype}' src='tpl/stdstyle/images/{icon_large}' alt='{cachetype}' title='{cachetype}' height='16' width='16' />" );
-gct.addToLastRow( 2, "<a span='{cachenameBIG}' href='viewcache.php?cacheid={urlencode_cacheid}' target='_blank' class='links'>{cachename}</a>" );
+gct.addToLastRow( 2, "<a span='{cachenameBIG}' href='viewcache.php?cacheid={urlencode_cacheid}' target='_blank' class='links' style='{style}'>{cachename}</a>" );
 gct.addToLastRow( 3, "{short_desc}" );
 gct.addToLastRow( 4, "<a span='{usernameBIG}' href='viewprofile.php?userid={urlencode_userid}' target='_blank'  class='links'>{username}</a>" );
 gct.addToLastRow( 5, "<span {date_created_sort} />{date_created}" );


### PR DESCRIPTION
To avoid the effort of drawing lots of new icons, the name of unpublished caches is displayed in red color. This color also applies to blocked caches which are visible for admins.