### PR TITLE
Buffer large GPX downloads in file, 3rd PR

### DIFF
--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -9,18 +9,34 @@ global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 require_once($rootpath . 'lib/format.gpx.inc.php');
 require_once($rootpath . 'lib/calculation.inc.php');
 
-set_time_limit(1800);
+$timeLimit = 1800;
+set_time_limit($timeLimit);
+
+if ($config['downloadPath'] != '') {
+    $downloadPath = $config['downloadPath'] . '/';
+} else {
+    $downloadPath = $picdir . '/';
+}
 
 // cleanup old temporary files
 
-$downloadPath = $picdir . '/';
 if (is_dir($downloadPath . 'gpx')) {
     $olddirs = glob($downloadPath . 'gpx/*', GLOB_ONLYDIR);
     foreach ($olddirs as $dir) {
         if (substr($dir, 0, 1) != '.') {
-            $stat = stat($dir);
-            if (time() - $stat['atime'] > 60*3) {   // delete after 30  minutes
-               exec('rm -rf ' . $dir);
+            if (file_exists($dir . '/created')) {
+                // Cleanup started downloads.
+                // File reference can be removed as soon as the download has started.
+                $stat = stat($dir . '/created');
+                if (time() - $stat['atime'] > 60*3) {
+                    exec('rm -rf ' . $dir);
+                }
+            } else {
+                // Cleanup aborted downloads.
+                $stat = stat($dir);
+                if (time() - $stat['atime'] > $timeLimit + 60*5) {
+                    exec('rm -rf ' . $dir);
+                }
             }
         }
     }
@@ -576,13 +592,18 @@ if ($usr || ! $hide_coords) {
 
         if (!$dirCreated && ($bUseZip || strlen($gpxData) > $downloadMemoryLimit)) {
             // make new random download dir
-            $path = 'gpx' . '/' . md5(uniqid(mt_rand(), true));
-            if (!is_dir($downloadPath . $path)) {
-                mkdir($downloadPath . $path, 0777, true);
+            $gpxdir = 'gpx' . '/' . md5(uniqid(mt_rand(), true));
+            if (!is_dir($downloadPath . $gpxdir)) {
+                mkdir($downloadPath . $gpxdir, 0777, true);
             }
-            $path .= '/' . $sFilebasename;
-            $file_url = $picurl . '/' . $path;
             $dirCreated = true;
+
+            $path = $gpxdir . '/' . $sFilebasename;
+            if ($config['downloadUrl'] != '') {
+                $file_url = $config['downloadUrl'] . '/' . $path;
+            } else {
+                $file_url = $picurl . '/' . $path;
+            }
         }
         if (!$outfile && strlen($gpxData) > $downloadMemoryLimit) {
             // buffer large GPX data in .gpx file
@@ -600,6 +621,22 @@ if ($usr || ! $hide_coords) {
         fclose($outfile);
     }
 
+    if ($bUseZip || $outfile) {
+        $htaccessPath = $downloadPath . '/gpx/.htaccess';
+        if (!file_exists($htaccessPath)) {
+            $htaccess = '
+                <FilesMatch "\.gpx$">
+                    ForceType application/gpx+xml
+                    Header set Content-Disposition attachment
+                </FilesMatch>
+                <FilesMatch "\.zip$">
+                    ForceType application/zip
+                    Header set Content-Disposition attachment
+                </FilesMatch>';
+            file_put_contents($htaccessPath, $htaccess);
+        }
+    }
+
     if ($bUseZip == true) {
         $zip = new ZipArchive();
         $zip->open($downloadPath . $path . '.zip', ZIPARCHIVE::CREATE);
@@ -615,8 +652,7 @@ if ($usr || ! $hide_coords) {
         header('Location: ' . $file_url. '.zip');
     } else {
         if ($outfile) {
-            // plain data from file;
-            // GPX Content-type and Content-Disposition must be configured in Webserver!
+            // plain data from file
             header('Location: ' . $file_url . '.gpx');
         } else {
             // plain data from string
@@ -625,6 +661,9 @@ if ($usr || ! $hide_coords) {
             echo $gpxData;
         }
     }
+
+    # Mark that the GPX data creation is finished.
+    file_put_contents($downloadPath . $gpxdir . '/created', '');
 }
 
 exit();

--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -12,6 +12,9 @@ require_once($rootpath . 'lib/calculation.inc.php');
 $timeLimit = 1800;
 set_time_limit($timeLimit);
 
+// do allow other sessions while the download is running
+session_write_close();
+
 if ($config['downloadPath'] != '') {
     $downloadPath = $config['downloadPath'] . '/';
 } else {
@@ -172,7 +175,7 @@ if ($usr || ! $hide_coords) {
     else
         $count = $caches_per_page;
 
-    $maxlimit = 1000000000;
+    $maxlimit = 10000;  // see https://github.com/opencaching/opencaching-pl/issues/1006
 
     if ($count == 'max')
         $count = $maxlimit;
@@ -267,7 +270,6 @@ if ($usr || ! $hide_coords) {
             AND `gpxcontent`.`user_id`=`user`.`user_id`');
 
     while ( $r = XDb::xFetchArray($stmt) ) {
-
         if (@$enable_cache_access_logs) {
 
             $dbc = OcDb::instance();

--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -1,16 +1,30 @@
 <?php
 
-ob_start();
-
 use Utils\Database\XDb;
 use Utils\Database\OcDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+
 global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 
 require_once($rootpath . 'lib/format.gpx.inc.php');
 require_once($rootpath . 'lib/calculation.inc.php');
 
 set_time_limit(1800);
+
+// cleanup old temporary files
+
+$downloadPath = $picdir . '/';
+if (is_dir($downloadPath . 'gpx')) {
+    $olddirs = glob($downloadPath . 'gpx/*', GLOB_ONLYDIR);
+    foreach ($olddirs as $dir) {
+        if (substr($dir, 0, 1) != '.') {
+            $stat = stat($dir);
+            if (time() - $stat['atime'] > 60*3) {   // delete after 30  minutes
+               exec('rm -rf ' . $dir);
+            }
+        }
+    }
+}
 
 function getPictures($cacheid, $picturescount)
 {
@@ -197,11 +211,10 @@ if ($usr || ! $hide_coords) {
 
     // Implementation ready, but do not use ZIP for now.
     $bUseZip = false;
-    if ($bUseZip == true) {
-        $content = '';
-        require_once ($rootpath . 'lib/phpzip/ss_zip.class.php');
-        $phpzip = new ss_zip('', 6);
-    }
+
+    $outfile = false;
+    $dirCreated = false;
+    $downloadMemoryLimit = ($config['downloadMemorylimit'] > 0 ? $config['downloadMemorylimit'] : PHP_INT_MAX);
 
     $children = '';
     $time = date($gpxTimeFormat, time());
@@ -217,8 +230,7 @@ if ($usr || ! $hide_coords) {
             $children = "(HasChildren)";
         }
     }
-    $gpxHead = str_replace('{wpchildren}', $children, $gpxHead);
-    echo $gpxHead;
+    $gpxData = str_replace('{wpchildren}', $children, $gpxHead);
 
     $stmt = XDb::xSql(
         'SELECT `gpxcontent`.`cache_id` `cacheid`, `gpxcontent`.`longitude` `longitude`,
@@ -560,27 +572,58 @@ if ($usr || ! $hide_coords) {
         }
         $thisline = str_replace('{cache_waypoints}', $waypoints, $thisline);
 
-        echo $thisline;
-        // DO NOT USE HERE:
-        // ob_flush();
+        $gpxData .= $thisline;
+
+        if (!$dirCreated && ($bUseZip || strlen($gpxData) > $downloadMemoryLimit)) {
+            // make new random download dir
+            $path = 'gpx' . '/' . md5(uniqid(mt_rand(), true));
+            if (!is_dir($downloadPath . $path)) {
+                mkdir($downloadPath . $path, 0777, true);
+            }
+            $path .= '/' . $sFilebasename;
+            $file_url = $picurl . '/' . $path;
+            $dirCreated = true;
+        }
+        if (!$outfile && strlen($gpxData) > $downloadMemoryLimit) {
+            // buffer large GPX data in .gpx file
+            $outfile = fopen($downloadPath . $path . '.gpx', 'w');
+        }
+        if ($outfile) {
+            fwrite($outfile, $gpxData);
+            $gpxData = '';
+        }
     }
 
-    echo $gpxFoot;
+    $gpxData .= $gpxFoot;
+    if ($outfile) {
+        fwrite($outfile, $gpxData);
+        fclose($outfile);
+    }
 
-    // compress using phpzip
     if ($bUseZip == true) {
-        $content = ob_get_clean();
-        $phpzip->add_data($sFilebasename . '.gpx', $content);
-        $out = $phpzip->save($sFilebasename . '.zip', 'b');
-
-        header("content-type: application/zip");
-        header('Content-Disposition: attachment; filename=' . $sFilebasename . '.zip');
-        echo $out;
-        ob_end_flush();
+        $zip = new ZipArchive();
+        $zip->open($downloadPath . $path . '.zip', ZIPARCHIVE::CREATE);
+        if ($outfile) {
+            // zipped data from file
+            $zip->addFile($downloadPath . $path . '.gpx', $sFilebasename . '.gpx');
+        } else {
+            // zipped data from string
+            $zip->addFromString($sFilebasename . '.gpx', $gpxData);
+        }
+        $zip->close();
+        unlink($downloadPath . $path . '.gpx');
+        header('Location: ' . $file_url. '.zip');
     } else {
-        header("Content-type: application/gpx");
-        header("Content-Disposition: attachment; filename=" . $sFilebasename . ".gpx");
-        ob_end_flush();
+        if ($outfile) {
+            // plain data from file;
+            // GPX Content-type and Content-Disposition must be configured in Webserver!
+            header('Location: ' . $file_url . '.gpx');
+        } else {
+            // plain data from string
+            header('Content-Type: application/gpx+xml');
+            header('Content-Disposition: attachment; filename=' . $sFilebasename . '.gpx');
+            echo $gpxData;
+        }
     }
 }
 

--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -126,7 +126,10 @@ if (!isset($maxmp3size))
 if (!isset($mp3extensions))
     $mp3extensions = ';mp3;';
 
-
+// download settings
+$config['downloadMemorylimit'] = 1024 * 1024 * 8;
+$config['downloadPath'] = $dynbasepath . 'download';
+$config['downloadUrl'] = '/download';
 
 // default coordinates for cachemap, set to your country's center of gravity
 $country_coordinates = "52.5,19.2";

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -143,6 +143,10 @@ $config = array(
 
     /** size limit in bytes for buffering downloads in a file, or 0 to disable buffering **/
     'downloadMemorylimit' => 0,
+    /** path for temporary download files, WITHOUT trailing slash **/
+    'downloadPath' => '',
+    /** relative or absolute URL to access the download path, WITHOUT trailing slash **/
+    'downloadUrl' => '',
 );
 
 // *** Repository automatic updates script location

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -139,7 +139,10 @@ $config = array(
      * Common datetime and date format
      */
     'datetimeformat' => '%Y-%m-%d %H:%M:%S',
-    'dateformat' => '%Y-%m-%d'
+    'dateformat' => '%Y-%m-%d',
+
+    /** size limit in bytes for buffering downloads in a file, or 0 to disable buffering **/
+    'downloadMemorylimit' => 0,
 );
 
 // *** Repository automatic updates script location


### PR DESCRIPTION
[fix for #1006]

I have disabled the session blocking here and limited the number of caches to 10000.  I think this is a reasonable limit, which 
* does not allocate too much disk space (~ 150 MB for 10000 caches)
* has some headroom e.g. for the OC GPX extension, which somewhat increases GPX size
* allows to enable Zipping without making the overall GPX generation too slow.

If this works, we could go on for futher fine tuning, optimizations, try to enable zipping, add user interface to split larger downloads in several 10000-blocks, and so on.