### PR TITLE
New layout

### DIFF
--- a/Controllers/Cron/OnlineUsersController.php
+++ b/Controllers/Cron/OnlineUsersController.php
@@ -1,0 +1,63 @@
+<?php
+namespace Controllers\Cron;
+
+use Controllers\BaseController;
+use lib\Objects\User\UserAuthorization;
+use Utils\Debug\Debug;
+
+class OnlineUsersController extends BaseController
+{
+
+    public function __construct(){
+        parent::__construct();
+    }
+
+    public function index()
+    {}
+
+    private static function getOnlineUsersDumpFile(){
+       global $config;
+       return $config['path']['dynamicFilesDir'].'onlineUsers.txt';
+    }
+
+    public static function dumpOnlineUsers()
+    {
+        $obj = new \stdClass();
+        $obj->onlineUsers = UserAuthorization::getOnlineUsersFromDb();
+        $obj->dumpTs = time();
+
+        file_put_contents(self::getOnlineUsersDumpFile(), json_encode($obj));
+    }
+
+    /**
+     * Returns the array of objects
+     * @return NULL|array
+     */
+    public static function getOnlineUsers()
+    {
+        $str = file_get_contents ( self::getOnlineUsersDumpFile() );
+        if(empty($str)){
+            //read error?!
+            // Debug::errorLog(__METHOD__.": ERROR: Can't read file with list of online users: ".
+            //    self::getOnlineUsersDumpFile());
+            return null;
+        }
+
+        $obj = json_decode($str);
+        if(empty($obj)){
+            // Debug::errorLog(__METHOD__.": ERROR: Can't decode list of online users.");
+            return null;
+        }
+
+        $dumpTs = $obj->dumpTs;
+        if(time() > $dumpTs + 60*60){
+            // this dump is obsolete (older than 1 hour)
+            // Debug::errorLog(__METHOD__.": ERROR: Obsolete list of online users.");
+            return null;
+        }
+
+        return $obj->onlineUsers;
+    }
+
+}
+

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Controllers\PageLayout;
+
+use Controllers\BaseController;
+use Controllers\Cron\OnlineUsersController;
+use Utils\DateTime\Year;
+use Utils\I18n\I18n;
+use Utils\Uri\Uri;
+
+class MainLayoutController extends BaseController
+{
+
+    const MAIN_TEMPLATE = 'common/mainLayout';
+
+    public static function init()
+    {
+        $main = new self();
+        $main->initMainLayout();
+    }
+
+    public function __construct(){
+        parent::__construct();
+    }
+
+    public function index()
+    {}
+
+    private function initMainLayout()
+    {
+        global $config; //TODO: refactor
+
+
+        if($this->isUserLogged()){
+            $this->view->setVar('_isUserLogged', true);
+            $this->view->setVar('_username', $this->loggedUser->getUserName());
+        }else{
+            $this->view->setVar('_isUserLogged', false);
+            $this->view->setVar('_target',Uri::getCurrentUri(true));
+        }
+
+
+        $this->view->setVar('_siteName', $config['siteName']);
+        $this->view->setVar('_keywords', $config['header']['keywords']);
+        $this->view->setVar('_favicon', '/images/'.$config['headerFavicon']);
+        $this->view->setVar('_appleLogo', $config['header']['appleLogo']);
+
+        $this->view->setVar('_title', "TODO-title"); //TODO!
+        $this->view->setVar('_backgroundSeason', $this->view->getSeasonCssName());
+
+        $this->view->addLocalCss(Uri::getLinkWithModificationTime(
+            '/tpl/stdstyle/common/mainLayout.css'));
+
+        if(Year::isPrimaAprilisToday()){
+            $logo = $config['headerLogo1stApril'];
+            $logoTitle = tr('oc_on_all_pages_top_1A');
+            $logoSubtitle = tr('oc_subtitle_on_all_pages_1A');
+        }else if(date('m') == 12 || date('m') == 1){
+            $logo = $config['headerLogoWinter'];
+            $logoTitle = tr('oc_on_all_pages_top_' . $config['ocNode']);
+            $logoSubtitle = tr('oc_subtitle_on_all_pages_' . $config['ocNode']);
+        }else{
+            $logo = $config['headerLogo'];
+            $logoTitle = tr('oc_on_all_pages_top_' . $config['ocNode']);
+            $logoSubtitle = tr('oc_subtitle_on_all_pages_' . $config['ocNode']);
+        }
+
+        $this->view->setVar('_mainLogo', '/images/'.$logo);
+        $this->view->setVar('_logoTitle', $logoTitle);
+        $this->view->setVar('_logoSubtitle', $logoSubtitle);
+
+        $this->view->setVar('_languageFlags',
+            I18n::getLanguagesFlagsData($this->view->getLang()));
+
+
+        $this->view->setVar('_qSearchByOwnerEnabled', $config['quick_search']['byowner']);
+        $this->view->setVar('_qSearchByFinderEnabled', $config['quick_search']['byfinder']);
+        $this->view->setVar('_qSearchByUserEnabled', $config['quick_search']['byuser']);
+
+        $onlineUsers = OnlineUsersController::getOnlineUsers();
+        if(!empty($onlineUsers)){
+            $this->view->setVar('_displayOnlineUsers', $config['mainLayout']['displayOnlineUsers']);
+            $this->view->setVar('_onlineUsers', OnlineUsersController::getOnlineUsers());
+        }else{
+            $this->view->setVar('_displayOnlineUsers', false);
+        }
+
+    }
+
+}

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -13,7 +13,7 @@ class MainLayoutController extends BaseController
 
     const MAIN_TEMPLATE = 'common/mainLayout';
 
-    private $lagacyLayout = false;
+    private $legacyLayout = false;
 
     public static function init()
     {
@@ -24,7 +24,7 @@ class MainLayoutController extends BaseController
     public static function initLegacy()
     {
         $main = new self();
-        $main->lagacyLayout = true;
+        $main->legacyLayout = true;
         $main->initMainLayout();
     }
 
@@ -58,7 +58,7 @@ class MainLayoutController extends BaseController
         $this->view->setVar('_title', "TODO-title"); //TODO!
         $this->view->setVar('_backgroundSeason', $this->view->getSeasonCssName());
 
-        if(!$this->lagacyLayout){
+        if(!$this->legacyLayout){
             $this->view->addLocalCss(Uri::getLinkWithModificationTime(
                 '/tpl/stdstyle/common/mainLayout.css'));
         }

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -13,9 +13,18 @@ class MainLayoutController extends BaseController
 
     const MAIN_TEMPLATE = 'common/mainLayout';
 
+    private $lagacyLayout = false;
+
     public static function init()
     {
         $main = new self();
+        $main->initMainLayout();
+    }
+
+    public static function initLegacy()
+    {
+        $main = new self();
+        $main->lagacyLayout = true;
         $main->initMainLayout();
     }
 
@@ -25,6 +34,7 @@ class MainLayoutController extends BaseController
 
     public function index()
     {}
+
 
     private function initMainLayout()
     {
@@ -48,8 +58,10 @@ class MainLayoutController extends BaseController
         $this->view->setVar('_title', "TODO-title"); //TODO!
         $this->view->setVar('_backgroundSeason', $this->view->getSeasonCssName());
 
-        $this->view->addLocalCss(Uri::getLinkWithModificationTime(
-            '/tpl/stdstyle/common/mainLayout.css'));
+        if(!$this->lagacyLayout){
+            $this->view->addLocalCss(Uri::getLinkWithModificationTime(
+                '/tpl/stdstyle/common/mainLayout.css'));
+        }
 
         if(Year::isPrimaAprilisToday()){
             $logo = $config['headerLogo1stApril'];

--- a/Controllers/TestController.php
+++ b/Controllers/TestController.php
@@ -1,0 +1,26 @@
+<?php
+namespace Controllers;
+
+class TestController extends BaseController
+{
+    public function __construct(){
+        parent::__construct();
+    }
+
+    public function index()
+    {
+
+        $this->view->setTemplate('test/testTemplate');
+
+        $this->view->buildView();
+    }
+
+    public function newLayout()
+    {
+        $this->view->setTemplate('test/testTemplate');
+
+        $this->view->display();
+    }
+
+}
+

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -4,8 +4,7 @@ namespace Utils\View;
 use Utils\DateTime\Year;
 use lib\Objects\ApplicationContainer;
 use Utils\Debug\Debug;
-use Utils\I18n\I18n;
-use Utils\Uri\Uri;
+use Controllers\PageLayout\MainLayoutController;
 
 class View {
 
@@ -220,7 +219,9 @@ class View {
     }
 
     /**
-     * TODO
+     * Wrapper for obsolate template system.
+     * Use display() instead!
+     *
      */
     public function buildView()
     {
@@ -228,15 +229,15 @@ class View {
     }
 
     /**
-     * TODO
-     * @param unknown $layoutTemplate
+     * Build template and display page.
+     * @param string|cont $layoutTemplate - base template to use
      */
     public function display($layoutTemplate=null)
     {
 
         if(is_null($layoutTemplate)){
-            $layoutTemplate = 'common/mainLayout';
-            $this->initMainLayout();
+            $layoutTemplate = MainLayoutController::MAIN_TEMPLATE;
+            MainLayoutController::init(); // init vars for main-layout
         }
 
         $this->_callTemplate($layoutTemplate);
@@ -266,52 +267,5 @@ class View {
         require_once(self::TPL_DIR . $template . '.tpl.php');
 
     }
-
-    /**
-     * This function inits vars used by main-layout
-     */
-    public function initMainLayout()
-    {
-        global $config; //TODO: refactor
-
-        $this->setVar('_siteName', $config['siteName']);
-        $this->setVar('_keywords', $config['header']['keywords']);
-        $this->setVar('_favicon', '/images/'.$config['headerFavicon']);
-        $this->setVar('_appleLogo', $config['header']['appleLogo']);
-
-        $this->setVar('_title', "TODO-title"); //TODO!
-        $this->setVar('_backgroundSeason', $this->getSeasonCssName());
-
-        $this->addLocalCss(Uri::getLinkWithModificationTime(
-            '/tpl/stdstyle/common/mainLayout.css'));
-
-        if(Year::isPrimaAprilisToday()){
-            $logo = $config['headerLogo1stApril'];
-            $logoTitle = tr('oc_on_all_pages_top_1A');
-            $logoSubtitle = tr('oc_subtitle_on_all_pages_1A');
-        }else if(date('m') == 12 || date('m') == 1){
-            $logo = $config['headerLogoWinter'];
-            $logoTitle = tr('oc_on_all_pages_top_' . $config['ocNode']);
-            $logoSubtitle = tr('oc_subtitle_on_all_pages_' . $config['ocNode']);
-        }else{
-            $logo = $config['headerLogo'];
-            $logoTitle = tr('oc_on_all_pages_top_' . $config['ocNode']);
-            $logoSubtitle = tr('oc_subtitle_on_all_pages_' . $config['ocNode']);
-        }
-
-        $this->setVar('_mainLogo', '/images/'.$logo);
-        $this->setVar('_logoTitle', $logoTitle);
-        $this->setVar('_logoSubtitle', $logoSubtitle);
-
-        $this->setVar('_languageFlags',
-            I18n::getLanguagesFlagsData($this->getLang()));
-
-
-        $this->setVar('_qSearchByOwnerEnabled', $config['quick_search']['byowner']);
-        $this->setVar('_qSearchByFinderEnabled', $config['quick_search']['byfinder']);
-        $this->setVar('_qSearchByUserEnabled', $config['quick_search']['byuser']);
-
-    }
-
 
 }

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -219,7 +219,7 @@ class View {
     }
 
     /**
-     * Wrapper for obsolate template system.
+     * Wrapper for obsolete template system.
      * Use display() instead!
      *
      */

--- a/index.php
+++ b/index.php
@@ -41,8 +41,7 @@ tpl_set_var('display_news', $newscontent);
 include ($dynstylepath . "totalstats.inc.php");
 
 // diffrent oc server handling: display proper info depend on server running the code
-$nodeDetect = substr($absolute_server_URI, - 3, 2);
-tpl_set_var('what_do_you_find_intro', tr('what_do_you_find_intro_' . $nodeDetect));
+tpl_set_var('what_do_you_find_intro', tr('what_do_you_find_intro_' . $config['ocNode']));
 
 if ($powerTrailModuleSwitchOn)
     tpl_set_var('ptDisplay', 'block');
@@ -95,9 +94,9 @@ $pattern = "<img src='{cacheIcon}' class='icon16' alt='Cache' title='Cache'>
         </div>";
 
 while ($rec = $dbc->dbResultFetch($s)) {
-    
+
     $line = $pattern;
-    
+
     $line = mb_ereg_replace('{cacheIcon}', myninc::checkCacheStatusByUser($rec, $usrid), $line);
     $line = mb_ereg_replace('{dateAlg}', $rec["date_alg"], $line);
     $line = mb_ereg_replace('{cacheName}', $rec["cacheName"], $line);
@@ -108,12 +107,12 @@ while ($rec = $dbc->dbResultFetch($s)) {
     $line = mb_ereg_replace('{region}', $rec["cacheRegion"], $line);
     $line = mb_ereg_replace('{logUserId}', $rec["logUserId"], $line);
     $line = mb_ereg_replace('{logUserName}', $rec["logUserName"], $line);
-    
+
     $text = mb_ereg_replace('<p>', '', $rec["text"]);
     $text = mb_ereg_replace('</p>', '<br>', $text);
-    
+
     $line = mb_ereg_replace('{logText}', $text, $line);
-    
+
     $TitledCaches .= $line;
 }
 

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -64,33 +64,11 @@ if (php_sapi_name() != "cli") { // this is not neccesarry for command-line scrip
         die($page_content);
     }
 
+    UserAuthorization::verify();
+
     initTemplateSystem();
-
-    processAuthentication();
-
     loadTranslation();
 
-}
-
-function processAuthentication(){
-
-    $view = tpl_getView();
-
-    if ($user = UserAuthorization::verify()) {   //user already logged in
-
-        //set view vars used by main template
-        //TODO: remove it from here!
-        $view->setVar('_isUserLogged', true);
-        $view->setVar('_username', $user->getUserName());
-
-    } else {
-
-        //set view vars used by main template
-        //TODO: remove it from here!
-        $view->setVar('_isUserLogged', false);
-        $view->setVar('_target',Uri::getCurrentUri(true));
-
-    }
 }
 
 function initTemplateSystem(){
@@ -173,10 +151,7 @@ function loadTranslation(){
 }
 
 
-
-
 //TODO: Remove all functions below from here!
-
 
 // decimal longitude to string E/W hhh°mm.mmm
 function help_lonToDegreeStr($lon, $type = 1)

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -41,9 +41,9 @@ $GLOBALS['contact_mail'] = $contact_mail;
 $GLOBALS['wikiLinks'] = $wikiLinks;
 $GLOBALS['pagetitle'] = $pagetitle;
 
+require_once($rootpath . 'lib/language.inc.php');     // main translation funcs
 require_once($rootpath . 'lib/common_tpl_funcs.php'); // template engine
 require_once($rootpath . 'lib/cookie.class.php');     // class used to deal with cookies
-require_once($rootpath . 'lib/language.inc.php');     // main translation funcs
 
 // yepp, we will use UTF-8
 mb_internal_encoding('UTF-8');

--- a/lib/common_tpl_funcs.php
+++ b/lib/common_tpl_funcs.php
@@ -3,6 +3,7 @@
 use Utils\View\View;
 use Utils\Uri\Uri;
 use Utils\I18n\I18n;
+use Controllers\PageLayout\MainLayoutController;
 
 //set the global template-name variable
 function tpl_set_tplname($local_tpl_name){
@@ -154,7 +155,7 @@ function tpl_BuildTemplate($dbdisconnect = true, $minitpl = false, $noCommonTemp
     /** @var View $view */
     global $view;
 
-    $view->initMainLayout(); // init vars for main-layout
+    MainLayoutController::init(); // init vars for main-layout
 
     //load main template
     if ($minitpl){

--- a/lib/common_tpl_funcs.php
+++ b/lib/common_tpl_funcs.php
@@ -155,7 +155,7 @@ function tpl_BuildTemplate($dbdisconnect = true, $minitpl = false, $noCommonTemp
     /** @var View $view */
     global $view;
 
-    MainLayoutController::init(); // init vars for main-layout
+    MainLayoutController::initLegacy(); // init vars for main-layout
 
     //load main template
     if ($minitpl){

--- a/lib/common_tpl_funcs.php
+++ b/lib/common_tpl_funcs.php
@@ -154,8 +154,7 @@ function tpl_BuildTemplate($dbdisconnect = true, $minitpl = false, $noCommonTemp
     /** @var View $view */
     global $view;
 
-
-    $view->setVar('languageFlags', I18n::getLanguagesFlagsData($lang));
+    $view->initMainLayout(); // init vars for main-layout
 
     //load main template
     if ($minitpl){

--- a/lib/format.gpx.inc.php
+++ b/lib/format.gpx.inc.php
@@ -3,9 +3,6 @@
 global $rootpath;
 require_once($rootpath . 'lib/common.inc.php');
 
-// sitename and slogan international handling
-$nodeDetect = substr($absolute_server_URI, - 3, 2);
-
 $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
 <gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/5 http://www.gsak.net/xmlv1/5/gsak.xsd"
@@ -17,7 +14,7 @@ $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
     <author>' . convert_string($site_name) . '</author>
     <email>' . $mail_oc . '</email>
     <url>' . $absolute_server_URI . '</url>
-    <urlname>' . convert_string($site_name) . ' - ' . convert_string(tr('oc_subtitle_on_all_pages_' . $nodeDetect)) . '</urlname>
+    <urlname>' . convert_string($site_name) . ' - ' . convert_string(tr('oc_subtitle_on_all_pages_' . $config['ocNode'])) . '</urlname>
     <time>{time}</time>
     <keywords>cache, geocache</keywords>
 ';

--- a/lib/format.kml.inc.php
+++ b/lib/format.kml.inc.php
@@ -3,9 +3,6 @@
 global $rootpath;
 require_once($rootpath . 'lib/common.inc.php');
 
-// sitename and slogan international handling
-$nodeDetect = substr($absolute_server_URI, - 3, 2);
-
 $kmlHead = '<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://earth.google.com/kml/2.0">
     <Document>

--- a/lib/search.gpx.inc.php
+++ b/lib/search.gpx.inc.php
@@ -33,8 +33,6 @@ function getPictures($cacheid, $picturescount)
     return $retval;
 }
 
-// sitename and slogan international handling
-$nodeDetect = substr($absolute_server_URI, - 3, 2);
 
 $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
 <gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -43,7 +41,7 @@ $gpxHead = '<?xml version="1.0" encoding="utf-8"?>
   <desc>Cache Listing Generated from ' . convert_string($site_name) . ' {wpchildren}</desc>
   <author>' . convert_string($site_name) . '</author>
   <url>' . $absolute_server_URI . '</url>
-  <urlname>' . convert_string($site_name) . ' - ' . convert_string(tr('oc_subtitle_on_all_pages_' . $nodeDetect)) . '</urlname>
+  <urlname>' . convert_string($site_name) . ' - ' . convert_string(tr('oc_subtitle_on_all_pages_' . $config['ocNode'])) . '</urlname>
   <time>{time}</time>
 ';
 

--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -11,6 +11,9 @@ date_default_timezone_set('Europe/Warsaw');
 if (!isset($rootpath))
     $rootpath = './';
 
+// country-id of the running node: pl|ro|nl...
+$config['ocNode'] = 'pl';
+
 //default used language
 if (!isset($lang))
     $lang = 'pl';

--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -60,8 +60,8 @@ $config['cookie']['domain'] = '.localhost';
 global $hide_coords;
 $hide_coords = false;
 
-// display online users on footer pages off=0 on=1
-$onlineusers = 1;
+// display online users in page footer
+$config['mainLayout']['displayOnlineUsers'] = true;
 
 //block register new cache before first find xx nuber caches value -1 off this feature
 $NEED_FIND_LIMIT = 10;
@@ -92,6 +92,8 @@ if (!isset($emailaddr))
 
 // location for dynamically generated files
 $dynbasepath = '/var/www/ocpl-data/';
+$config['path']['dynamicFilesDir'] = '/var/www/ocpl-data/';
+
 $dynstylepath = $dynbasepath . 'tpl/stdstyle/html/';
 
 // location of cache images

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -19,6 +19,12 @@ $enable_cache_access_logs = false;
 
 $config = array(
     /**
+     * country-id of the running node: pl|ro|nl...
+     */
+    'ocNode' => 'pl', // pl is a default
+
+
+    /**
      *Add button to a shop. Set true otherwise false
      *Add link to the shop of choise.
      */
@@ -289,3 +295,19 @@ $config['feed']['blog']['showAuthor'] = true;
 
 $subject_prefix_for_site_mails = "OCXX";
 $subject_prefix_for_reviewers_mails = "";
+
+
+// keywords in every header
+$config['header']['keywords'] = 'geocaching, opencaching, skarby,'.
+                                'poszukiwania, geocashing, longitude, latitude,'.
+                                'utm, coordinates, treasure hunting, treasure,'.
+                                'GPS, global positioning system, garmin, '.
+                                'magellan, mapping, geo, hiking, outdoors, '.
+                                'sport, hunt, stash, cache, geocaching, geocache,'.
+                                'cache, treasure, hunting, satellite, navigation,'.
+                                'tracking, bugs, travel bugs';
+
+// logo displayed as apple-touch-icon-precomposed
+$config['header']['appleLogo'] = '/images/oc_logo_144.png';
+
+

--- a/lib/settingsGlue.inc.php
+++ b/lib/settingsGlue.inc.php
@@ -72,6 +72,15 @@ if (isset($site_name)){
     $config['siteName'] = $site_name;
 }
 
+if (isset($onlineusers)){
+    $config['mainLayout']['displayOnlineUsers'] = ($onlineusers == 1);
+}
+
+if (isset($dynstylepath)){
+    $config['path']['dynamicFilesDir'] = $dynbasepath;
+}
+
+
 if ( isset($opt['cookie']['name']) ){
     $config['cookie']['name'] = $opt['cookie']['name'];
 }

--- a/lib/settingsGlue.inc.php
+++ b/lib/settingsGlue.inc.php
@@ -68,6 +68,10 @@ if (isset($opt['db']['password']))
 /* *** END sample code **************************************************** */
 
 
+if (isset($site_name)){
+    $config['siteName'] = $site_name;
+}
+
 if ( isset($opt['cookie']['name']) ){
     $config['cookie']['name'] = $opt['cookie']['name'];
 }

--- a/test.php
+++ b/test.php
@@ -1,10 +1,26 @@
 <?php
 
+use Controllers\TestController;
+
 require_once 'lib/common.inc.php';
 
-echo "TEST:<hr/>";
+
+$ctrl = new TestController();
+
+if(isset($_GET['action'])){
+    $action = $_GET['action'];
+}else{
+    $action = '';
+}
+
+switch($action){
+    case 'newLayout':
+        $ctrl->newLayout();
+        break;
+    default:
+        $ctrl->index();
+}
 
 
-
-echo "<hr/>END!";
+exit;
 

--- a/test.php
+++ b/test.php
@@ -1,6 +1,7 @@
 <?php
 
 use Controllers\TestController;
+use Controllers\Cron\OnlineUsersController;
 
 require_once 'lib/common.inc.php';
 
@@ -16,6 +17,9 @@ if(isset($_GET['action'])){
 switch($action){
     case 'newLayout':
         $ctrl->newLayout();
+        break;
+    case 'onlineUsers':
+        OnlineUsersController::dumpOnlineUsers();
         break;
     default:
         $ctrl->index();

--- a/tpl/stdstyle/chunks/bootstrapCss.tpl.php
+++ b/tpl/stdstyle/chunks/bootstrapCss.tpl.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This chunk is used to load bootstrap css to templates (main.tpl/mini.tpl etc.),
+ * so there is no need to call it in ordinary content templates.
+ *
+ * This chunk should be load to all new common layouts templates
+ *
+ */
+return function (){
+    //start of chunk
+?>
+
+<!-- bootstrap CSS -->
+
+<link rel="stylesheet"
+  href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css"
+  integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M"
+  crossorigin="anonymous">
+
+<!-- / bootstrap CSS -->
+
+<?php
+}; //end of chunk

--- a/tpl/stdstyle/chunks/bootstrapJs.tpl.php
+++ b/tpl/stdstyle/chunks/bootstrapJs.tpl.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This chunk is used to load bootstrap JS to templates (main.tpl/mini.tpl etc.),
+ * so there is no need to call it in ordinary content templates.
+ *
+ * This chunk should be load to all new common layouts templates
+ *
+ */
+return function (){
+    //start of chunk
+?>
+
+<!-- bootstrap JS -->
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"
+    integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4"
+    crossorigin="anonymous"></script>
+
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js"
+    integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1"
+    crossorigin="anonymous"></script>
+
+<!-- / bootstrap JS -->
+
+<?php
+}; //end of chunk

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -299,20 +299,30 @@ if ($tplname != 'start'){
                 <!-- FOOTER -->
                 <div id="footer">
 
-                    <?php
-                    global $usr, $onlineusers, $dynstylepath;
-                    if ($usr == true && $onlineusers == 1) { ?>
+                    <?php if ($view->_isUserLogged && $view->_displayOnlineUsers) { ?>
                         <p>
                           <span class="txt-black">{{online_users}}: </span>
-                          <span class="txt-white"><?php include ($dynstylepath . "nonlusers.txt"); ?></span>
+                          <span class="txt-white">
+
+                              <?php foreach($view->_onlineUsers as $userId=>$username){ ?>
+                                <a class="links-onlusers" href="/viewprofile.php?userid=<?=$userId?>">
+                                  <?=$username?>&nbsp;
+                                </a>
+                              <?php } //foreach ?>
+
+                          </span>
                           <span class="txt-black"> ({{online_users_info}}):</span>
                         </p>
-                        <p><?php include ($dynstylepath . "onlineusers.html"); ?></p>
+                        <p><?=count($view->_onlineUsers)?></p>
                         <div class="spacer">&nbsp;</div>
-                    <?php }
+                    <?php } // user-logged && displayOnlineUsers ?>
+
+
+                    <?php
                     $bottomMenuResult = buildBottomMenu($config['bottom_menu']);
                     echo $bottomMenuResult;
                     ?>
+
                 </div>
                 <!-- (C) The Opencaching Project 2017 -->
             </div>

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -24,26 +24,9 @@ if ($tplname != 'start'){
     $tpl_subtitle .= htmlspecialchars($mnu_selmenuitem['title'] . ' - ', ENT_COMPAT, 'UTF-8');
 }
 
-//detect OC node to handle logo translation
-$nodeDetect = substr($absolute_server_URI, -3, 2);
-$logo1 = tr('oc_on_all_pages_top_' . $nodeDetect);
-$logo2 = tr('oc_subtitle_on_all_pages_' . $nodeDetect);
-$logo3 = $config['headerLogo'];
-
-if (Year::isPrimaAprilisToday()) {
-    $logo1 = tr('oc_on_all_pages_top_1A');
-    $logo2 = tr('oc_subtitle_on_all_pages_1A');
-    $logo3 = $config['headerLogo1stApril'];
-}
-
-if (date('m') == 12 || date('m') == 1) {
-    $logo3 = $config['headerLogoWinter'];
-}
-
-
 ?>
 <!DOCTYPE html>
-<html lang="<?=$GLOBALS['lang']?>" xml:lang="<?=$GLOBALS['lang']?>">
+<html lang="<?=$view->getLang()?>" xml:lang="<?=$view->getLang()?>">
     <head>
         <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
@@ -121,17 +104,19 @@ if (date('m') == 12 || date('m') == 1) {
 
                 <!-- HEADER -->
                 <!-- OC-Logo -->
-                <div><img src="/images/<?=$logo3?>" alt="OC logo" style="margin-top:5px; margin-left:3px;"></div>
+                <div><img src="<?=$view->_mainLogo?>" alt="OC logo" style="margin-top:5px; margin-left:3px;"></div>
+
                 <!-- Sitename -->
                 <div class="site-name">
-                    <p class="title"><a href="index.php"><?=$logo1?></a></p>
-                    <p class="subtitle"><a href="index.php"><?=$logo2?></a></p>
+                    <p class="title"><a href="index.php"><?=$view->_logoTitle?></a></p>
+                    <p class="subtitle"><a href="index.php"><?=$view->_logoSubtitle?></a></p>
                 </div>
+
                 <!-- Flag navigations -->
                 <div class="navflag-container">
                     <div class="navflag">
                         <ul>
-                            <?php foreach($view->languageFlags as $langFlag){ ?>
+                            <?php foreach($view->_languageFlags as $langFlag){ ?>
                                 <li>
                                     <a rel="nofollow" href="<?=$langFlag['link']?>">
                                         <img class="img-navflag" src="<?=$langFlag['img']?>" alt="<?=$langFlag['name']?> version"
@@ -207,7 +192,9 @@ if (date('m') == 12 || date('m') == 1) {
 
                 <!-- Header banner     -->
                 <div class="header">
-                    <div style="width:970px; padding-top:1px;"><img src="/images/head/rotator.php" alt="Banner" style="border:0px;"></div>
+                    <div style="width:970px; padding-top:1px;">
+                      <img src="/images/head/rotator.php" alt="Banner" style="border:0px;">
+                    </div>
                 </div>
 
                 <!-- Navigation - horizontal menu bar -->

--- a/tpl/stdstyle/common/mainLayout.css
+++ b/tpl/stdstyle/common/mainLayout.css
@@ -1,0 +1,94 @@
+
+/* reference font-size for all docs */
+html { font-size: 13px; }
+
+
+.page-wrapper {
+  background-color: brown;
+  position: relative;
+  max-width: 960px; margin: 0px auto; padding: 0px;
+}
+
+
+/* # Seasonal background images */
+
+body.summer { background-color: #feec98; }
+body.autumn { background-color: #e0ed9d; }
+body.winter { background-color: #ddebf5; }
+body.spring { background-color: #feec98; }
+
+div.seasonalBackground {
+  display: block; 
+  position: absolute; 
+  width: 330px; 
+  height: 100%; 
+  top: 0px;
+  background-repeat: no-repeat;
+  z-index: -1;
+}
+
+div.seasonalBackground.left{ left: -330px; }
+div.seasonalBackground.right{ right: -329px; }
+
+div.seasonalBackground.summer{ background-image: url(/images/css/summer.jpg);}
+div.seasonalBackground.autumn{ background-image: url(/images/css/autumn.jpg);}
+div.seasonalBackground.winter{ background-image: url(/images/css/winter.jpg);}
+div.seasonalBackground.spring{ background-image: url(/images/css/spring.jpg);}
+
+/* /# Seasonal background images */
+
+/* # Header */
+#header { font-size: 10px; background-color: white; }
+
+#headerOcLogo { padding: 3px 0px 3px 5px; }
+#headerOcLogo a, a:hover { text-decoration: none; }
+#headerOcLogo div { 
+  font-family: "trebuchet ms", arial, sans serif;
+  /*overflow: hidden;*/
+  color: #323232;
+}
+#headerOcLogo img { height: 68px; width: 68px; float: left; margin-right: 7px; }
+#headerOcLogo .title { font-size: 24px; font-weight: bold; margin-top: 10px; }
+#headerOcLogo .subtitle { font-size: 12px; margin-top: -10px; }
+
+
+#headerFlags {  }
+#headerFlags img { width: 23px; height: 15px; }
+
+
+#headerLoginBox {}
+
+#headerBanner { 
+  background: url(/images/head/rotator.php) no-repeat; 
+  background-size: cover;
+}
+
+#qSearchForm {
+  
+  background-color:rgba(0, 0, 0, 0.5);
+}
+
+/* /# Header */
+
+
+
+
+
+
+
+
+.sidebar {
+  background-color: red;
+}
+
+.content {
+    background-color: green;
+}
+
+.footer {
+    background-color: pink;
+}
+
+.margin {
+  background-color: orange;
+}

--- a/tpl/stdstyle/common/mainLayout.css
+++ b/tpl/stdstyle/common/mainLayout.css
@@ -2,9 +2,8 @@
 /* reference font-size for all docs */
 html { font-size: 13px; }
 
-
 .page-wrapper {
-  background-color: brown;
+  background-color: #fff;
   position: relative;
   max-width: 960px; margin: 0px auto; padding: 0px;
 }
@@ -38,7 +37,7 @@ div.seasonalBackground.spring{ background-image: url(/images/css/spring.jpg);}
 /* /# Seasonal background images */
 
 /* # Header */
-#header { font-size: 10px; background-color: white; }
+#header { font-size: 10px; }
 
 #headerOcLogo { padding: 3px 0px 3px 5px; }
 #headerOcLogo a, a:hover { text-decoration: none; }
@@ -75,18 +74,16 @@ div.seasonalBackground.spring{ background-image: url(/images/css/spring.jpg);}
 
 
 
-
-
 .sidebar {
-  background-color: red;
+  border: 2px solid red;  
 }
 
 .content {
-    background-color: green;
+  border: 2px solid blue; 
 }
 
 .footer {
-    background-color: pink;
+  border: 2px solid green;
 }
 
 .margin {

--- a/tpl/stdstyle/common/mainLayout.tpl.php
+++ b/tpl/stdstyle/common/mainLayout.tpl.php
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="<?=$view->getLang()?>">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <meta name="keywords" content="<?=$view->_keywords?>">
+    <meta name="author" content="<?=$view->_siteName?>">
+
+    <title><?=$view->_title?></title>
+
+    <link rel="shortcut icon" href="<?=$view->_favicon?>">
+    <link rel="apple-touch-icon-precomposed" href="<?=$view->_appleLogo?>">
+
+    <?php foreach( $view->getLocalCss() as $css ) { ?>
+      <link rel="stylesheet" type="text/css" href="<?=$css?>">
+    <?php } //foreach-css ?>
+
+
+    <?php
+
+        $view->callChunk('bootstrapCss'); // always load bootstrap
+
+        if( $view->isGoogleAnalyticsEnabled() ){
+            $view->callChunkOnce( 'googleAnalytics', $view->getGoogleAnalyticsKey() );
+        }
+        if( $view->isjQueryUIEnabled()){
+            $view->callChunk('jQueryUI');
+        }
+        if( $view->isTimepickerEnabled()){
+            $view->callChunk('timepicker');
+        }
+        if( $view->isLightBoxEnabled()){
+            $view->callChunk('lightBoxLoader', true, false);
+        }
+        if( $view->isGMapApiEnabled() ){
+            if( !isset($GLOBALS['googlemap_key']) || empty($GLOBALS['googlemap_key']) ){
+                $view->errorLog("There is no googlemap_key value in site settings?!".
+                            "Map can't be loaded!");
+            }else{
+                $callback = isset($view->GMapApiCallback)?$view->GMapApiCallback:null;
+                $view->callChunk('googleMapsApi',
+                    $GLOBALS['googlemap_key'], $view->getLang(), $callback);
+            }
+        }
+    ?>
+
+
+<!-- (C) The Opencaching Project 2017 -->
+
+</head>
+
+<body class="<?=$view->_backgroundSeason?>">
+
+      <div class="page-wrapper">
+        <div class="d-none d-lg-block left seasonalBackground <?=$view->_backgroundSeason?>"></div>
+        <div class="d-none d-lg-block right seasonalBackground <?=$view->_backgroundSeason?>"></div>
+
+        <div class="container-fluid">
+
+          <div class="row">
+            <div id="header" class="col">
+
+              <div class="row">
+<!-- logo -->
+                <div id="headerOcLogo" class="col-5">
+                    <a href="/index.php">
+                      <img src="<?=$view->_mainLogo?>" alt="Opencaching logo" />
+                      <div class="title"><?=$view->_logoTitle?></div>
+                      <div class="subtitle"><?=$view->_logoSubtitle?></div>
+                    </a>
+                </div>
+<!-- / logo -->
+                <div class="col-7 text-right">
+<!-- flags -->
+                  <div id="headerFlags" class="my-2 d-print-none">
+                    <?php foreach($view->_languageFlags as $langFlag){ ?>
+                      <a rel="nofollow" href="<?=$langFlag['link']?>">
+                        <img src="<?=$langFlag['img']?>"
+                             alt="<?=$langFlag['name']?> version"
+                             title="<?=$langFlag['name']?> version">
+                      </a>
+                    <?php } //forach-lang-flags ?>
+                  </div>
+<!-- / flags -->
+<!-- login-box -->
+                  <div id="headerLoginBox d-print-none">
+                    <?php if($view->_isUserLogged){ //if-user-logged ?>
+                      <?=$tr('logged_as')?>
+                      <a href="/viewprofile.php"><?=$view->_username?></a>
+                      <a href="/logout.php?token=<?=$view->_logoutCookie?>"
+                         class="btn btn btn-outline-primary btn-sm ml-1">
+                        <?=tr('logout')?>
+                      </a>
+
+                    <?php } else { //user-not-logged ?>
+
+                      <form action="login.php?action=login" method="post"
+                            class="form-inline justify-content-end">
+
+                        <input name="email" type="text"
+                          class="form-control form-control-sm mr-1" value=""
+                          placeholder="<?=$tr('user_or_email')?>" />
+
+                        <input name="password" type="password"
+                          class="form-control form-control-sm mr-1" value=""
+                          placeholder="<?=$tr('password')?>" />
+
+                        <input type="hidden" name="target" value="<?=$view->_target?>" />
+                        <input type="submit" value="<?=$tr('login')?>"
+                               class="btn btn-primary btn-sm" />
+
+                      </form>
+
+                    <?php } //user-not-logged ?>
+                  </div>
+<!-- / login-box -->
+                </div><!-- col -->
+              </div><!-- row -->
+
+
+              <div id="headerBanner" class="row d-print-none justify-content-end">
+
+                <div class="col py-2 pr-0 text-right">
+<!-- quick search -->
+                    <script type="text/javascript">
+                      // this is used by search widget below
+                      function qSearch_setMode(newName,searchPage) {
+                        $("#qSearchText").attr("name", newName);
+                        $("#qSearchForm").attr("action",searchPage);
+                        return false;
+                      }
+                    </script>
+
+                    <form method="get" action="/search.php" name="search_form" id="qSearchForm"
+                          class="d-inline-block px-3 py-2 text-light">
+
+                      <div class="form-row">
+                        <div class="col text-right">
+                          <div class="form-check form-check-inline">
+                            <label class="form-check-label">
+                              <input class="form-check-input" type="radio" name="searchto"
+                                     value="searchbywaypointname" checked
+                                     onclick="qSearch_setMode('waypointname','search.php');">
+
+                              <?=$tr('waypointname_label')?>
+                            </label>
+                          </div>
+
+                          <?php if ($view->_qSearchByOwnerEnabled) { ?>
+                          <div class="form-check form-check-inline">
+                            <label class="form-check-label">
+                              <input class="form-check-input" type="radio" name="searchto"
+                                     value="searchbyowner"
+                                     onclick="qSearch_setMode('owner','search.php');">
+
+                              <?=$tr('owner_label')?>
+                            </label>
+                          </div>
+                          <?php } ?>
+
+                          <?php if ($view->_qSearchByFinderEnabled) { ?>
+                          <div class="form-check form-check-inline">
+                            <label class="form-check-label">
+                              <input class="form-check-input" type="radio" name="searchto"
+                                     value="searchbyfinder"
+                                     onclick="qSearch_setMode('finder','search.php');">
+
+                              <?=$tr('finder_label')?>
+                            </label>
+                          </div>
+                          <?php } ?>
+
+                          <?php if ($view->_qSearchByUserEnabled) { ?>
+                          <div class="form-check form-check-inline">
+                            <label class="form-check-label">
+                              <input class="form-check-input" type="radio" name="searchto"
+                                     value="searchbyuser"
+                                     onclick="qSearch_setMode('username','searchuser.php');">
+
+                              <?=$tr('user')?>
+                            </label>
+                          </div>
+                          <?php } ?>
+
+                        </div>
+                      </div>
+
+                      <div class="form-row justify-content-end text-right">
+                          <div class="col">
+                            <input id="qSearchText" type="text" name="waypointname"
+                                   class="form-control-sm d-inline-block">
+
+                            <input type="submit" name="submit" value="<?=$tr('search')?>"
+                                   class="btn btn-light btn-sm d-inline-block">
+                          </div>
+                      </div>
+
+                      <input type="hidden" name="showresult" value="1">
+                      <input type="hidden" name="expert" value="0">
+                      <input type="hidden" name="output" value="HTML">
+                      <input type="hidden" name="sort" value="bydistance">
+                      <input type="hidden" name="f_inactive" value="0">
+                      <input type="hidden" name="f_ignored" value="0">
+                      <input type="hidden" name="f_userfound" value="0">
+                      <input type="hidden" name="f_userowner" value="0">
+                      <input type="hidden" name="f_watched" value="0">
+                      <input type="hidden" name="f_geokret" value="0">
+
+                    </form>
+<!-- / quick search -->
+                </div><!-- col -->
+
+              </div>
+              <div class="row">
+<!-- horizontal nav-bar -->
+
+                <ul class="nav nav-pills">
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+                  <span class="navbar-toggler-icon"></span>
+                </button>
+                  <li class="nav-item">
+                    <a class="nav-link active" href="#">Active</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="#">Link</a>
+                  </li>
+                </ul>
+
+<!-- / horizontal nav-bar -->
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-lg-2 d-none d-lg-block sidebar">
+              ### SIDEBAR ###
+            </div>
+            <div class="col-lg-10 ">
+              <?php $view-> _callTemplate(); ?>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col footer">
+              ### FOOTER ###
+            </div>
+          </div>
+
+        </div><!--/ container -->
+
+      </div><!-- / page-wrapper -->
+
+
+
+
+    <?php
+        // JS scripts to loaded at the end
+        $view->callChunk('jQuery');      // always load jQuery
+        $view->callChunk('bootstrapJs'); // always load bootstrap
+
+        if( $view->isLightBoxEnabled()){
+            $view->callChunk('lightBoxLoader', false, true);
+        }
+    ?>
+</body>
+
+</html>
+

--- a/tpl/stdstyle/common/mainLayout.tpl.php
+++ b/tpl/stdstyle/common/mainLayout.tpl.php
@@ -89,7 +89,7 @@
                     <?php if($view->_isUserLogged){ //if-user-logged ?>
                       <?=$tr('logged_as')?>
                       <a href="/viewprofile.php"><?=$view->_username?></a>
-                      <a href="/logout.php?token=<?=$view->_logoutCookie?>"
+                      <a href="/login.php?action=logout"
                          class="btn btn btn-outline-primary btn-sm ml-1">
                         <?=tr('logout')?>
                       </a>
@@ -211,9 +211,9 @@
                     </form>
 <!-- / quick search -->
                 </div><!-- col -->
+              </div><!-- row-banner -->
 
-              </div>
-              <div class="row">
+              <div class="row"><!-- horiznotal-nav -->
 <!-- horizontal nav-bar -->
 
                 <ul class="nav nav-pills">
@@ -229,24 +229,52 @@
                 </ul>
 
 <!-- / horizontal nav-bar -->
-              </div>
+              </div><!-- row-horizontal-nav -->
             </div>
           </div>
 
           <div class="row">
             <div class="col-lg-2 d-none d-lg-block sidebar">
-              ### SIDEBAR ###
+
+
+                <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist">
+                  <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill" href="#v-pills-home" role="tab" aria-controls="v-pills-home" aria-expanded="true">Home</a>
+                  <a class="nav-link" id="v-pills-profile-tab" data-toggle="pill" href="#v-pills-profile" role="tab" aria-controls="v-pills-profile" aria-expanded="true">Profile</a>
+                  <a class="nav-link" id="v-pills-messages-tab" data-toggle="pill" href="#v-pills-messages" role="tab" aria-controls="v-pills-messages" aria-expanded="true">Messages</a>
+                  <a class="nav-link" id="v-pills-settings-tab" data-toggle="pill" href="#v-pills-settings" role="tab" aria-controls="v-pills-settings" aria-expanded="true">Settings</a>
+                </div>
+                <div class="tab-content" id="v-pills-tabContent">
+                  <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel" aria-labelledby="v-pills-home-tab">...</div>
+                  <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab">...</div>
+                  <div class="tab-pane fade" id="v-pills-messages" role="tabpanel" aria-labelledby="v-pills-messages-tab">...</div>
+                  <div class="tab-pane fade" id="v-pills-settings" role="tabpanel" aria-labelledby="v-pills-settings-tab">...</div>
+                </div>
+
+
             </div>
-            <div class="col-lg-10 ">
+            <div class="col-lg-10 content">
               <?php $view-> _callTemplate(); ?>
             </div>
-          </div>
+          </div> <!-- row-mainArea -->
+
 
           <div class="row">
-            <div class="col footer">
-              ### FOOTER ###
+            <div class="col footer text-center">
+
+              <?php if($view->_isUserLogged && $view->_displayOnlineUsers){ ?>
+                <h6>
+                <?=$tr('online_users')?>:
+                <?=count($view->_onlineUsers)?>
+
+                <?=$tr('online_users_info')?>:
+                <?php foreach($view->_onlineUsers as $userId=>$username){ ?>
+                <a href="/viewprofile.php?userid=<?=$userId?>"><?=$username?></a>
+                <?php } //foreach ?>
+                </h6>
+              <?php } // user-logged && displayOnlineUsers ?>
+
             </div>
-          </div>
+          </div><!-- row-container -->
 
         </div><!--/ container -->
 

--- a/tpl/stdstyle/css/style_screen.css
+++ b/tpl/stdstyle/css/style_screen.css
@@ -55,14 +55,25 @@ tr.highlighted > td {border-width:2px;}
 /*-----------------------------------*/
 /* 2.1 - Sitename, slogan and banner */
 /*-----------------------------------*/
-.header                     { height:80px;width: 970px;}
+.header                     { height:80px; width: 970px;}
 
-.site-name                  { width: 300px; height: 45px; top: 12px; position: absolute; z-index: 4; overflow: hidden; margin: 0px; padding-left: 80px;}
-.site-name p.title          { margin: 0px; padding: 0px; font-family: "trebuchet ms", arial, sans serif; font-weight: bold; font-size: 24px;}
+.site-name                  { width: 300px; height: 45px; top: 12px; 
+                              position: absolute; z-index: 4; overflow: hidden; 
+                              margin: 0px; padding-left: 80px;}
+                              
+.site-name p.title          { margin: 0px; padding: 0px; 
+                              font-family: "trebuchet ms", arial, sans serif; 
+                              font-weight: bold; font-size: 24px;}
+                              
 .site-name p.subtitle       { clear: both; width: 300px; margin: -6px 0px 0px 0px; padding: 0px; 
-                              background-color: transparent; font-family: "trebuchet ms", arial, sans serif; font-size: 12px;}
+                              background-color: transparent; 
+                              font-family: "trebuchet ms", arial, sans serif; font-size: 12px;}
+                              
 .site-name a                { margin: 0px; padding: 0px; text-decoration: none; color: #323232;}
+
 .site-name a:hover          { text-decoration: none;}
+
+
 
 
 .site-slogan-container      { text-align:right; width: 970px; top: 83px; position: absolute; z-index: 1; overflow: hidden; background-color: transparent;}

--- a/tpl/stdstyle/etc/write_onlusers.inc.php
+++ b/tpl/stdstyle/etc/write_onlusers.inc.php
@@ -1,32 +1,8 @@
 <?php
 
-use Utils\Database\OcDb;
+use Controllers\Cron\OnlineUsersController;
 
-//include template handling
 $rootpath = '../../../';
 require_once($rootpath . 'lib/common.inc.php');
 
-// add check users id who want to by username hidden
-$db = OcDb::instance();
-$stmt = $db->simpleQuery(
-    "SELECT DISTINCT `sys_sessions`.`user_id` AS `user_id`, `user`.`username` AS `username`
-        FROM `sys_sessions`
-        LEFT JOIN `user`
-        ON `user`.`user_id` = `sys_sessions`.`user_id`
-        WHERE `sys_sessions`.`user_id` != 1 AND `sys_sessions`.`last_login` > (NOW() - INTERVAL 10 MINUTE) ");
-
-$n_file = fopen($dynstylepath . "nonlusers.txt", 'w');
-fwrite($n_file, $db->rowCount($stmt));
-fclose($n_file);
-
-$n_file = fopen($dynstylepath . "onlineusers.html", 'w');
-$first = true;
-while ($record = $db->dbResultFetch($stmt)) {
-    if ($first) {
-        $first = false;
-    } else {
-        fwrite($n_file, ', ');
-    }
-    fwrite($n_file, '<a class="links-onlusers" href="viewprofile.php?userid=' . $record['user_id'] . '">' . $record['username'] . '</a>');
-}
-fclose($n_file);
+OnlineUsersController::dumpOnlineUsers();

--- a/tpl/stdstyle/test/testTemplate.tpl.php
+++ b/tpl/stdstyle/test/testTemplate.tpl.php
@@ -1,0 +1,70 @@
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!
+This is test template!


### PR DESCRIPTION
This PR contains the proposition of the new layout - this is not ready yet - this is only an early stage of works. This not affect current pages - it can be seen by test.php only. There is still lack of menu-handling code - I'm working on it now.

Like I wrote in emails - the main idea is to create the similar layout to current common/main.tpl.php but with bootstrap css. This is a step on a way for further responsive design. We will be able to migrate pages to the bootstrap-like styles.

This is little in context of  #1075. 

@deg-pl, @andrixnet, @harrieklomp: 
I need config change (before commit this PR):
please add to your settings.inc.php line: `$config['ocNode'] = "<your-node-id>";`
For example for OCPL it should be `$config['ocNode'] = "pl";` 'ro' for OCRO, and so on...

It is replacement of node detection by domain which was used before in many places in the code.

If you want to look at this there is also my proposition of the "new" template's subsystem. TestController doesn't use old templates and eval - there are two simple methods which allow to build view-template file. Template contains only pure php injections to html. All values used in template have to be injected by $view->var, translations are done by $tr() function - everything is (in my opinion simple, clear and useful) - the only disadvantages is that var injection needs a little more chars - <?=...?> instead of {} - but there is huge advantage of this solution - there is no need of any parsing and rewriting of template file - this is just php file which is just included in the right place and time. Please take a look.

   
