### PR TITLE
Improvements in user table

### DIFF
--- a/sqlAlters/2018-02-24_user_table_impr.sql
+++ b/sqlAlters/2018-02-24_user_table_impr.sql
@@ -1,0 +1,8 @@
+-- 2018-02-24
+-- @author: deg-pl
+
+ALTER TABLE `user` CHANGE `new_pw_code` `new_pw_code` TINYTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'Code to change password';
+ALTER TABLE `user` CHANGE `new_email_code` `new_email_code` TINYTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'Code to change email';
+
+ALTER TABLE `user` ADD `new_pw_exp` DATETIME NULL DEFAULT NULL COMMENT 'new_pw_code expiration date' AFTER `new_pw_code`;
+ALTER TABLE `user` ADD `new_email_exp` DATETIME NULL DEFAULT NULL COMMENT 'new_email_code expiration date' AFTER `new_email_code`;


### PR DESCRIPTION
@andrixnet @harrieklomp There is only sqlalter to do in this PR.
I'm working on refactoring password reminder page. Now we store only 13-char's "security string" during change password or e-mail - it is insecure. Additionaly, expiration date we store in... int(11)! In this sqlalter I added 2 additional datetime fields. new_pw_date and new_email_date will be dropped after refactoring.

So - please do this small sql.