### PR TITLE
dynamicMap improvements

### DIFF
--- a/Controllers/TestController.php
+++ b/Controllers/TestController.php
@@ -18,6 +18,7 @@ use lib\Objects\GeoCache\MultiLogStats;
 use lib\Objects\User\User;
 use lib\Objects\User\MultiUserQueries;
 use lib\Objects\GeoCache\GeoCacheLog;
+use Utils\Text\Formatter;
 
 class TestController extends BaseController
 {
@@ -223,6 +224,7 @@ class TestController extends BaseController
 
                 $markerModel->wp = $row['wp_oc'];
                 $markerModel->name = $row['name'];
+                $markerModel->username = $row['username'];
                 $markerModel->link = GeoCache::GetCacheUrlByWp($row['wp_oc']);
                 $markerModel->icon = GeoCache::CacheIconByType(
                     $row['type'], $row['status']);
@@ -271,11 +273,11 @@ class TestController extends BaseController
                 $markerModel->lat = $row['latitude'];
 
                 $markerModel->log_icon = GeoCacheLog::GetIconForType($row['log_type']);
-                $markerModel->log_text = $row['text'];
-                $markerModel->log_userLink = User::GetUserProfileUrl($row['log_user_id']);
+                $markerModel->log_text = strip_tags($row['text'], '<br><p>');
                 $markerModel->log_username = $row['log_username'];
                 $markerModel->log_typeName = tr(GeoCacheLog::typeTranslationKey($row['type']));
                 $markerModel->log_link = GeoCacheLog::getLogUrlByLogId($row['log_id']);
+                $markerModel->log_date = Formatter::date($row['date']);
 
                 return $markerModel;
             });

--- a/Controllers/UserWatchedCachesController.php
+++ b/Controllers/UserWatchedCachesController.php
@@ -16,6 +16,7 @@ use lib\Objects\ChunkModels\DynamicMap\CacheWithLogMarkerModel;
 use lib\Objects\GeoCache\GeoCacheLog;
 use lib\Objects\User\User;
 use lib\Objects\GeoCache\GeoCache;
+use Utils\Text\Formatter;
 
 class UserWatchedCachesController extends BaseController
 {
@@ -75,11 +76,11 @@ class UserWatchedCachesController extends BaseController
                 $m->link = GeoCache::GetCacheUrlByWp($row['wp_oc']);
                 $m->icon = $iconFile;
                 $m->log_icon = $logIconFile;
-                $m->log_text = strip_tags($row['llog_text']);
+                $m->log_text = strip_tags($row['llog_text'], '<br><p>');
                 $m->log_link = GeoCacheLog::getLogUrlByLogId($row['llog_id']);
                 $m->log_typeName = $logTypeName;
-                $m->log_userLink = User::GetUserProfileUrl($row['llog_user_id']);
                 $m->log_username = $row['llog_username'];
+                $m->log_date = Formatter::date($row['llog_date']);
                 return $m;
         });
 

--- a/lib/Objects/ChunkModels/DynamicMap/CacheMarkerModel.php
+++ b/lib/Objects/ChunkModels/DynamicMap/CacheMarkerModel.php
@@ -58,7 +58,7 @@ class CacheMarkerModel extends AbstractMarkerModelBase
         $marker->name = $c->getCacheName();
         $marker->icon = $c->getCacheIcon($user);
         $marker->lon = $c->getCoordinates()->getLongitude();
-        $marker->lat = $c->getCoordinates()->getLongitude();
+        $marker->lat = $c->getCoordinates()->getLatitude();
         return $marker;
     }
 

--- a/lib/Objects/ChunkModels/DynamicMap/CacheMarkerModel.php
+++ b/lib/Objects/ChunkModels/DynamicMap/CacheMarkerModel.php
@@ -13,6 +13,7 @@ class CacheMarkerModel extends AbstractMarkerModelBase
     public $wp;
     public $link;
     public $name;
+    public $username = null;
     public $icon;
     public $lon;
     public $lat;
@@ -56,6 +57,7 @@ class CacheMarkerModel extends AbstractMarkerModelBase
         $marker->wp = $c->getGeocacheWaypointId();
         $marker->link = $c->getCacheUrl();
         $marker->name = $c->getCacheName();
+        $marker->username = $c->getOwner()->getUserName();
         $marker->icon = $c->getCacheIcon($user);
         $marker->lon = $c->getCoordinates()->getLongitude();
         $marker->lat = $c->getCoordinates()->getLatitude();

--- a/lib/Objects/ChunkModels/DynamicMap/CacheWithLogMarkerModel.php
+++ b/lib/Objects/ChunkModels/DynamicMap/CacheWithLogMarkerModel.php
@@ -1,12 +1,23 @@
 <?php
 namespace lib\Objects\ChunkModels\DynamicMap;
 
+use lib\Objects\GeoCache\GeoCacheLog;
+use lib\Objects\User\User;
+use Utils\Text\Formatter;
+
 /**
  * This is map marker which has log information in infowindow
  * Cache properties are inherited from CacheMarkerModel
  */
 class CacheWithLogMarkerModel extends CacheMarkerModel
 {
+    public $log_link = null; // if there is no link there is no log :)
+    public $log_text;
+    public $log_icon;
+    public $log_typeName;
+    public $log_username;
+    public $log_date;
+
     public function getKey()
     {
         return 'CacheWithLogMarker';
@@ -23,12 +34,30 @@ class CacheWithLogMarkerModel extends CacheMarkerModel
         return '/cacheWithLogMarkerInfoWindow.tpl.php';
     }
 
-    public $log_link = null; // if there is no link there is no log :)
-    public $log_userLink;
-    public $log_text;
-    public $log_icon;
-    public $log_typeName;
-    public $log_username;
+    public static function fromGeoCacheLogFactory(GeoCacheLog $log, User $user = null)
+    {
+        $marker = new self();
+        $marker->wp = $log->getGeoCache()->getGeocacheWaypointId();
+        $marker->link = $log->getGeoCache()->getCacheUrl();
+        $marker->name = $log->getGeoCache()->getCacheName();
+        $marker->username = $log->getGeoCache()->getOwner()->getUserName();
+        $marker->icon = $log->getGeoCache()->getCacheIcon($user);
+        $marker->lon = $log->getGeoCache()->getCoordinates()->getLongitude();
+        $marker->lat = $log->getGeoCache()->getCoordinates()->getLatitude();
+        $marker->log_link = $log->getLogUrl();
+        $text = strip_tags($log->getText(),'<br><p>');
+        $textLen = mb_strlen($text);
+        if ($textLen > 200) {
+            $text = mb_strcut($text, 0, 200);
+            $text .= '...';
+        }
+        $marker->log_text = $text;
+        $marker->log_icon = $log->getLogIcon();
+        $marker->log_typeName = tr(GeoCacheLog::typeTranslationKey($log->getType()));
+        $marker->log_username = $log->getUser()->getUserName();
+        $marker->log_date = Formatter::date($log->getDateCreated());
+        return $marker;
+    }
 
 }
 

--- a/lib/Objects/ChunkModels/DynamicMap/DynamicMapModel.php
+++ b/lib/Objects/ChunkModels/DynamicMap/DynamicMapModel.php
@@ -109,5 +109,10 @@ class DynamicMapModel
         return $this->mapTypeName;
     }
 
+    public function setZoom($zoom)
+    {
+        $this->zoom = $zoom;
+    }
+
 }
 

--- a/lib/Objects/ChunkModels/DynamicMap/LogMarkerModel.php
+++ b/lib/Objects/ChunkModels/DynamicMap/LogMarkerModel.php
@@ -1,0 +1,63 @@
+<?php
+namespace lib\Objects\ChunkModels\DynamicMap;
+
+use lib\Objects\GeoCache\GeoCacheLog;
+use lib\Objects\User\User;
+use Utils\Text\Formatter;
+
+/**
+ * This is map marker which has log information in infowindow
+ * Cache properties are inherited from CacheMarkerModel
+ */
+class LogMarkerModel extends CacheMarkerModel
+{
+    public $log_link = null; // if there is no link there is no log :)
+    public $log_text;
+    public $log_icon;
+    public $log_typeName;
+    public $log_username;
+    public $log_date;
+    
+    public function getKey()
+    {
+        return 'LogMarker';
+    }
+    
+    public function getJSMarkersMgr()
+    {
+        return self::CHUNK_DIR.'/logMarkerMgr';
+        
+    }
+    
+    public function getInfoWinTpl()
+    {
+        return '/logMarkerInfoWindow.tpl.php';
+    }
+    
+    public static function fromGeoCacheLogFactory(GeoCacheLog $log, User $user = null)
+    {
+        $marker = new self();
+        $marker->wp = $log->getGeoCache()->getGeocacheWaypointId();
+        $marker->link = $log->getGeoCache()->getCacheUrl();
+        $marker->name = $log->getGeoCache()->getCacheName();
+        $marker->username = $log->getGeoCache()->getOwner()->getUserName();
+        $marker->icon = $log->getGeoCache()->getCacheIcon($user);
+        $marker->lon = $log->getGeoCache()->getCoordinates()->getLongitude();
+        $marker->lat = $log->getGeoCache()->getCoordinates()->getLatitude();
+        $marker->log_link = $log->getLogUrl();
+        $text = strip_tags($log->getText(),'<br><p>');
+        $textLen = mb_strlen($text);
+        if ($textLen > 200) {
+            $text = mb_strcut($text, 0, 200);
+            $text .= '...';
+        }
+        $marker->log_text = $text;
+        $marker->log_icon = $log->getLogIcon();
+        $marker->log_typeName = tr(GeoCacheLog::typeTranslationKey($log->getType()));
+        $marker->log_username = $log->getUser()->getUserName();
+        $marker->log_date = Formatter::date($log->getDateCreated());
+        return $marker;
+    }
+    
+}
+

--- a/lib/Objects/GeoCache/GeoCacheLog.php
+++ b/lib/Objects/GeoCache/GeoCacheLog.php
@@ -169,6 +169,15 @@ class GeoCacheLog extends GeoCacheLogCommons
     }
 
     /**
+     * Returns URL of the log icon
+     * @return string
+     */
+    public function getLogIcon()
+    {
+        return parent::GetIconForType($this->getType());
+    }
+
+    /**
      * Returns true if $userid recommended cache related with log
      * @param integer $userid
      * @return boolean

--- a/tpl/stdstyle/chunks/dynamicMap/cacheMarkerInfoWindow.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/cacheMarkerInfoWindow.tpl.php
@@ -1,9 +1,8 @@
 <?php //This is handlebars-js template - see https://handlebarsjs.com/ for format details ?>
 
 <div class="iw-container">
-    <a href="{{link}}" class="links" target="_blank">
-      <img class="iw-icon" src="{{icon}}">
-      <span class="iw-wp">{{wp}}:</span>
-      <span class="iw-name">{{name}}</span>
-    </a>
+  <img class="iw-icon" src="{{icon}}" alt="{{wp}}" title="{{wp}}">
+  <a href="{{link}}" class="links" target="_blank">
+    <span class="iw-name">{{name}}</span></a>
+  {{#if username}}({{username}}){{/if}}
 </div>

--- a/tpl/stdstyle/chunks/dynamicMap/cacheMarkerMgr.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/cacheMarkerMgr.tpl.php
@@ -43,6 +43,7 @@ return function (array $markersData){
         icon:         markerModel.icon,
         link:         markerModel.link,
         name:         markerModel.name,
+        username:     markerModel.username,
         wp:           markerModel.wp,
       };
 

--- a/tpl/stdstyle/chunks/dynamicMap/cacheWithLogMarkerInfoWindow.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/cacheWithLogMarkerInfoWindow.tpl.php
@@ -2,24 +2,21 @@
 
 <div class="iw-container">
   <div class="iw-title">
+    <img class="iw-icon" src="{{icon}}" alt="{{wp}}" title="{{wp}}">
     <a href="{{link}}" target="_blank">
-      <img class="iw-icon" src="{{icon}}">
-      <span class="iw-wp">{{wp}}:</span>
-      <span class="iw-name">{{name}}</span>
-    </a>
+      <span class="iw-name">{{name}}</span></a>
+    {{#if username}}({{username}}){{/if}}
   </div>
 
   {{#if log_link}}
   <div class="iw-log">
+    <a href="{{log_link}}" target="_blank">
+      <img src="{{log_icon}}" title="{{log_typeName}}" alt="{{log_typeName}}">
+      <strong>{{log_username}}</strong> ({{log_date}})
       {{#if log_text}}
-        <img src="{{log_icon}}" title="{{log_typeName}}" alt="{{log_typeName}}">
-        <a class="iw-logUsername" target="_blank" href="{{log_userLink}}">
-          {{log_username}}
-        </a>:
-        <span class="iw-logText">{{log_text}}</span>
-      {{else}}
-        <?=tr('usrWatch_noLogs')?>
+        <div class="iw-logText">{{{log_text}}}</div>
       {{/if}}
+    </a>
   </div>
   {{/if}}
 </div>

--- a/tpl/stdstyle/chunks/dynamicMap/cacheWithLogMarkerMgr.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/cacheWithLogMarkerMgr.tpl.php
@@ -18,8 +18,8 @@ return function (array $markersData){
       return new google.maps.Marker({
         position: new google.maps.LatLng(markerModel.lat, markerModel.lon),
         icon: {
-          url: markerModel.icon,
-          scaledSize: new google.maps.Size(20, 20),
+          url: markerModel.log_icon,
+          scaledSize: new google.maps.Size(16, 16),
         },
         title: markerModel.wp +': '+ markerModel.name,
       });
@@ -43,13 +43,14 @@ return function (array $markersData){
         icon:         markerModel.icon,
         link:         markerModel.link,
         name:         markerModel.name,
+        username:     markerModel.username,
         wp:           markerModel.wp,
         log_link:     markerModel.log_link,
         log_text:     markerModel.log_text,
         log_username: markerModel.log_username,
         log_icon:     markerModel.log_icon,
         log_typeName: markerModel.log_typeName,
-        log_userLink: markerModel.log_userLink,
+        log_date:     markerModel.log_date,
       };
 
       return this.__infoWindowCompiled(context);

--- a/tpl/stdstyle/chunks/dynamicMap/dynamicMap.css
+++ b/tpl/stdstyle/chunks/dynamicMap/dynamicMap.css
@@ -32,5 +32,5 @@
 
 .iw-icon {
   width: 18px;
-  heigth: 18px;
+  max-height: 18px;
 }

--- a/tpl/stdstyle/chunks/dynamicMap/logMarkerInfoWindow.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/logMarkerInfoWindow.tpl.php
@@ -1,0 +1,22 @@
+<?php //This is handlebars-js template - see https://handlebarsjs.com/ for format details ?>
+
+<div class="iw-container">
+  <div class="iw-title">
+    <img class="iw-icon" src="{{icon}}" alt="{{wp}}" title="{{wp}}">
+    <a href="{{link}}" target="_blank">
+      <span class="iw-name">{{name}}</span></a>
+    {{#if username}}({{username}}){{/if}}
+  </div>
+
+  {{#if log_link}}
+  <div class="iw-log">
+    <a href="{{log_link}}" target="_blank">
+      <img src="{{log_icon}}" title="{{log_typeName}}" alt="{{log_typeName}}">
+      <strong>{{log_username}}</strong> ({{log_date}})
+      {{#if log_text}}
+        <div class="iw-logText">{{{log_text}}}</div>
+      {{/if}}
+    </a>
+  </div>
+  {{/if}}
+</div>

--- a/tpl/stdstyle/chunks/dynamicMap/logMarkerMgr.tpl.php
+++ b/tpl/stdstyle/chunks/dynamicMap/logMarkerMgr.tpl.php
@@ -8,9 +8,9 @@
  * All functions are used from within dynamic map.
  */
 return function (array $markersData){
-
+    
     $markerInstance = $markersData[0];
-?>
+    ?>
 
 {
     markerFactory: function( markerModel ){
@@ -18,8 +18,8 @@ return function (array $markersData){
       return new google.maps.Marker({
         position: new google.maps.LatLng(markerModel.lat, markerModel.lon),
         icon: {
-          url: markerModel.icon,
-          scaledSize: new google.maps.Size(20, 20),
+          url: markerModel.log_icon,
+          scaledSize: new google.maps.Size(16, 16),
         },
         title: markerModel.wp +': '+ markerModel.name,
       });

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -77,22 +77,22 @@ global $tpl_subtitle;
 
       <!-- Site slogan -->
                 <div class="site-slogan-container">
-                    <form method="get" action="search.php" name="search_form" id="search_form">
+                    <form method="get" action="/search.php" name="search_form" id="search_form">
                         <div class="site-slogan">
                             <div>
                                 <p class="search">
-                                    <input type="radio" onclick="chname('waypointname','search.php');" name="searchto" id="st_1" value="searchbywaypointname" class="radio" checked="checked">
+                                    <input type="radio" onclick="chname('waypointname','/search.php');" name="searchto" id="st_1" value="searchbywaypointname" class="radio" checked="checked">
                                     <label for="st_1">{{waypointname_label}}</label>&nbsp;&nbsp;
                                     <?php if ($config['quick_search']['byowner']) { ?>
-                                      <input type="radio" onclick="chname('owner','search.php');" name="searchto" id="st_2" value="searchbyowner" class="radio">
+                                      <input type="radio" onclick="chname('owner','/search.php');" name="searchto" id="st_2" value="searchbyowner" class="radio">
                                       <label for="st_2">{{owner_label}}</label>&nbsp;&nbsp;
                                     <?php } ?>
                                     <?php if ($config['quick_search']['byfinder']) { ?>
-                                      <input type="radio" onclick="chname('finder','search.php');" name="searchto" id="st_3" value="searchbyfinder" class="radio">
+                                      <input type="radio" onclick="chname('finder','/search.php');" name="searchto" id="st_3" value="searchbyfinder" class="radio">
                                       <label for="st_3">{{finder_label}}</label>&nbsp;&nbsp;
                                     <?php } ?>
                                     <?php if ($config['quick_search']['byuser']) { ?>
-                                      <input type="radio" onclick="chname('username','searchuser.php');" name="searchto" id="st_4" value="searchbyuser" class="radio">
+                                      <input type="radio" onclick="chname('username','/searchuser.php');" name="searchto" id="st_4" value="searchbyuser" class="radio">
                                       <label for="st_4">{{user}}</label>&nbsp;&nbsp;
                                     <?php } ?>
                                     <input type="hidden" name="showresult" value="1">


### PR DESCRIPTION
@kojoty zerknij na to, bo zrobiłem trochę zmian. Dorzuciłem do markerów username dla właściciela kesza - to potencjalnie ważniejsza informacja niż waypoint:
![image](https://user-images.githubusercontent.com/13884863/36754720-267a7016-1c0a-11e8-8e31-53138644ee2f.png)
Waypoint też jest - po najechaniu na ikonkę kesza zarówno na mapie jak i w "dymku". Chciałem Ci dorzucić to do mapy obserwowanych keszy, ale zapytanie SQL w UserWatchedCache::getWatchedCachesWithLastLogs() zdecydowanie mnie przerosło ;)

W markerach z logami dorzuciłem datę logu:
![image](https://user-images.githubusercontent.com/13884863/36754826-7813fb36-1c0a-11e8-858f-c667213433df.png)
Jak pewnie widzisz - trochę inaczej sformatowałem, zmniejszyłem ilość linków (username usera wrzucającego log), zwiększyłem pola reagujące na link i trochę innych usprawnień.

Username właściciela kesza jest opcjonalne - nie pojawi się jeśli nie jest ustawione.

Zerknij na to i możesz mergnąć.