### PR TITLE
OKAPI docs update and workaround for OC.pl cache note problem

### DIFF
--- a/okapi/services/caches/save_personal_notes/WebService.php
+++ b/okapi/services/caches/save_personal_notes/WebService.php
@@ -171,6 +171,16 @@ class WebService
                         NOW(), 0,
                         '".Db::escape_string($new_notes)."'
                     )
+
+                    # Workaround for https://github.com/opencaching/okapi/issues/530.
+                    # May be simplified by changing the whole OCPL implementation to an
+                    # 'insert ... on duplicate update', but this way we need not to rely
+                    # on the existence of indexes:
+
+                    on duplicate key update
+                        `desc` = '".Db::escape_string($new_notes)."',
+                        desc_html = 0,
+                        date = NOW()
                 ");
             } else {
                 Db::query("

--- a/okapi/views/introduction/introduction.tpl.php
+++ b/okapi/views/introduction/introduction.tpl.php
@@ -63,8 +63,8 @@ Here is the list of other OKAPI installations:</p>
     </li>
 </ul>
 
-<p>* - Opencaching.DE includes other sites - Opencaching.IT, OpencachingSpain.ES
-and Opencaching.FR - which are in fact the one site visible on multiple domains.
+<p>* - Opencaching.DE includes other sites - Opencaching.IT and Opencaching.FR
+- which are in fact the one site visible on multiple domains.
 All three share one database, so you can access all their data through
 Opencaching.DE OKAPI installation.</p>
 


### PR DESCRIPTION
This is a manual OKAPI update, because automatic update is broken. It should fix the recent error messages regarding duplicate keys when inserting to `cache_notes` table.

Current OCPL code does not run on my develsite, so I could not test this. Will take care if it does not work.