### PR TITLE
Fixes #1455 (fast fix)

### DIFF
--- a/lib/Objects/GeoCache/GeoCache.php
+++ b/lib/Objects/GeoCache/GeoCache.php
@@ -608,6 +608,7 @@ class GeoCache extends GeoCacheCommons
     public function getCacheIcon(User $forUser=null)
     {
         $logStatus = null;
+        $isOwner = false;
         if(!is_null($forUser)){
             $logsCount = $this->getLogsCountByType($forUser, array(GeoCacheLog::LOGTYPE_FOUNDIT, GeoCacheLog::LOGTYPE_DIDNOTFIND));
             if(isset($logsCount[GeoCacheLog::LOGTYPE_FOUNDIT]) && $logsCount[GeoCacheLog::LOGTYPE_FOUNDIT]>0){
@@ -615,9 +616,16 @@ class GeoCache extends GeoCacheCommons
             }else if(isset($logsCount[GeoCacheLog::LOGTYPE_DIDNOTFIND]) && $logsCount[GeoCacheLog::LOGTYPE_DIDNOTFIND]>0){
                 $logStatus = GeoCacheLog::LOGTYPE_DIDNOTFIND;
             }
+            $isOwner = ($this->getOwnerId() == $forUser->getUserId());
         }
 
-        return self::CacheIconByType($this->cacheType, $this->status, $logStatus);
+        return self::CacheIconByType(
+            $this->cacheType,
+            $this->status,
+            $logStatus,
+            false,
+            $isOwner
+        );
     }
 
     public function getSizeId()

--- a/lib/Objects/GeoCache/GeoCacheCommons.php
+++ b/lib/Objects/GeoCache/GeoCacheCommons.php
@@ -208,12 +208,17 @@ class GeoCacheCommons extends BaseObject {
     /**
      * Retrurn cache icon based on its type and status
      *
-     * @param enum $type
-     * @param enum $status
+     * @param enum $type the cache type
+     * @param enum $status the cache status
+     * @param enum $logStatus (optional) log status information to include in icon
+     * @param bool $fileNameOnly (optional) true if the result should be a filename,
+     *     false (default) if it should be prefixed by full path
+     * @param bool $isOwner (optional) true if the icon should be for the cache owner,
+     *     false (default) otherwise
      * @return string - path + filename of the right icon
      */
     public static function CacheIconByType(
-        $type, $status, $logStatus = null, $fileNameOnly = false)
+        $type, $status, $logStatus = null, $fileNameOnly = false, $isOwner = false)
     {
 
         $statusPart = ""; //part of icon name represents cache status
@@ -242,6 +247,10 @@ class GeoCacheCommons extends BaseObject {
             case GeoCacheLog::LOGTYPE_DIDNOTFIND:
                 $logStatusPart = '-dnf';
                 break;
+            default:
+                if ($isOwner) {
+                    $logStatusPart = '-owner';
+                }
         }
 
         $typePart = ""; //part of icon name represents cache type


### PR DESCRIPTION
Works in `MyNeighbourhood` and cache pages. Does not work f. ex. on mycaches.php page (GeoCache class is not used there).
The solution should not affect any existing direct `GeoCacheCommons::CacheIconByType` calls.