### PR TITLE
Next changes related to GDPR (#1464)

### DIFF
--- a/Controllers/UserRegistrationController.php
+++ b/Controllers/UserRegistrationController.php
@@ -104,6 +104,7 @@ class UserRegistrationController extends BaseController
         $this->view->setVar('username', $username);
         $this->view->setVar('email', $email);
         $this->view->setVar('errorMsg', $errorMsg);
+        $this->view->setVar('minAge', $this->ocConfig->getMinumumAge());
         $this->view->setTemplate('userRegistration/register');
         $this->view->addLocalCss(Uri::getLinkWithModificationTime('/tpl/stdstyle/userAuth/userAuth.css'));
         $this->view->addLocalJs(Uri::getLinkWithModificationTime('/tpl/stdstyle/userAuth/newPassword.js'), true, true);

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -54,6 +54,7 @@ final class OcConfig extends ConfigReader
     private $mailSubjectPrefixForSite;
     private $mailSubjectPrefixForReviewers;
     private $enableCacheAccessLogs;
+    private $minumumAge;
 
     private $dbUser;
     private $dbPass;
@@ -119,14 +120,15 @@ final class OcConfig extends ConfigReader
         $this->mailSubjectPrefixForSite = $subject_prefix_for_site_mails;
         $this->mailSubjectPrefixForReviewers = $subject_prefix_for_reviewers_mails;
         $this->enableCacheAccessLogs = $enable_cache_access_logs;
+        $this->minumumAge = $config['limits']['minimum_age'];
 
-        if( isset($config['mapsConfig']) && is_array( $config['mapsConfig'] ) ){
+        if (isset($config['mapsConfig']) && is_array($config['mapsConfig'])) {
             $this->mapsConfig = $config['mapsConfig'];
-        }else{
+        } else {
             $this->mapsConfig = array();
         }
 
-        $this->isGoogleTranslationEnabled = !( isset( $disable_google_translation ) && $disable_google_translation );
+        $this->isGoogleTranslationEnabled = ! (isset($disable_google_translation) && $disable_google_translation);
 
         $this->dbHost = $opt['db']['server'];
         $this->dbName = $opt['db']['name'];
@@ -240,6 +242,14 @@ final class OcConfig extends ConfigReader
     public function isCacheAccesLogEnabled()
     {
         return $this->enableCacheAccessLogs;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getMinumumAge()
+    {
+        return $this->minumumAge;
     }
 
     protected function getMapsConfig()

--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -427,7 +427,7 @@ $translations = array(
     'register_intro' => 'Please enter your valid e-mail address below - we will send you an activation link. During registration you will also choose a unique username (nickname) that you will use on the site.', /* EN edited register_msg1*/
     'register_info' => 'The user may opt out of using the website. At the same time, all data entered during registration and in the user description will be irretrievably deleted. If you want to deactivate your account, please contact us using your e-mail account. In uncertain cases, please contact us ({contact_mail}). Thank you.', /* EN */
     'register_rulesLbl' => 'Yes, I have read the <strong><a href="{wiki_link_rules}" target="_blank" rel="noopener">Terms of Service</a></strong> {site_name} and I agree to abide by it.', /* EN */
-    'register_ageLbl' => 'Yes, I have reached the age of majority.', /* EN */
+    'register_ageLbl' => 'Yes, I\'m {minAge} or older.', /* EN */
     'register_confirm' => 'Die Aktivierungskode wan an deine Email geschickt.<div class="buffer"></div>Bitte den Anweisungen folgen, die sind über E-Mail geschickt.',
 
     'activation_title' => 'Account-Aktivierung',

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -425,7 +425,7 @@ $translations = array(
     'register_intro' => 'Please enter your valid e-mail address below - we will send you an activation link. During registration you will also choose a unique username (nickname) that you will use on the site.',
     'register_info' => 'The user may opt out of using the website. At the same time, all data entered during registration and in the user description will be irretrievably deleted. If you want to deactivate your account, please contact us using your e-mail account. In uncertain cases, please contact us ({contact_mail}). Thank you.',
     'register_rulesLbl' => 'Yes, I have read the <strong><a href="{wiki_link_rules}" target="_blank" rel="noopener">Terms of Service</a></strong> {site_name} and I agree to abide by it.',
-    'register_ageLbl' => 'Yes, I have reached the age of majority.',
+    'register_ageLbl' => 'Yes, I\'m {minAge} or older.', /* EN */
     'register_confirm' => 'The activation link was sent to you via e-mail.<div class="buffer"></div>If you don\'t see the activation message in your inbox, please check your SPAM folder.',
 
     'activation_title' => 'Account activation',

--- a/lib/languages/nl.php
+++ b/lib/languages/nl.php
@@ -425,7 +425,7 @@ $translations = array(
     'register_intro' => 'Vul hieronder een geldig e-mailadres in - we zullen een activatie link versturen. Vul voor registratie ook een unieke gebruikersnaam (nickname) in die op deze site gebruikt zal worden.',
     'register_info' => 'Als gebruiker laten verwijderen van de website. Hiermee zullen alle opgegeven gegevens tijdens de registratie en de gebruikersomschrijving verwijderd worden. Neem contact met ons op om je account te deactiveren via een e-mail. In onduidelijke gevallen neem contact op via ({contact_mail}). Bedankt.',
     'register_rulesLbl' => 'Ja, Ik heb de <strong><a href="{wiki_link_rules}" target="_blank" rel="noopener">gebruikersvoorwaarden</a></strong> van {site_name} gelezen en accepteer deze.',
-    'register_ageLbl' => 'Ja, ik ben wettelijke meerderjarig.',
+    'register_ageLbl' => 'Yes, I\'m {minAge} or older.', /* EN */
     'register_confirm' => 'De activatie link is verzonden per e-mail.<div class="buffer"></div>Kijk eventueel in de spam folder wanneer geen bericht ontvangen is.',
 
     'activation_title' => 'Account activatie',

--- a/lib/languages/pl.php
+++ b/lib/languages/pl.php
@@ -427,7 +427,7 @@ $translations = array(
     'register_intro' => 'Podaj proszę poniżej swój rzeczywisty adres e-mail - wyślemy na niego link aktywacyjny. Podczas rejestracji wybierasz także unikalną nazwę użytkownika (nick), którą będziesz posługiwać się w serwisie.',
     'register_info' => 'Użytkownik, może zrezygnować z korzystania z serwisu. Będą przy tym usunięte bezpowrotnie wszelkie dane, które wprowadził przy rejestracji oraz w opisie użytkownika Jeśli chcesz dezaktywować swoje konto skontaktuj się z nami za pomocą swojego konta e-mail. W przypadkach niejasnych prosimy o kontakt ({contact_mail}). Dziękujemy.',
     'register_rulesLbl' => 'Tak, zapoznałem się z <strong><a href="{wiki_link_rules}" target="_blank" rel="noopener">Regulaminem</a></strong> serwisu {site_name} i zobowiązuję się go przestrzegać.',
-    'register_ageLbl' => 'Tak, jestem osobą pełnoletnią.',
+    'register_ageLbl' => 'Tak, mam ukończone {minAge} lat.',
     'register_confirm' => 'Link aktywacyjny został wysłany na twój adres e-mail.<div class="buffer"></div><strong>Uwaga! Niektóre serwery pocztowe odrzucają list z linkiem aktywacyjnym z serwera {site_name}.</strong> Jeśli nie potrafisz odnaleźć wiadomości aktywacyjnej, sprawdź w folderze SPAM. Jeśli nie otrzymasz jej w ciągu kilku godzin - prosimy o kontakt na adres {contact_mail}. W korespondencji podaj nazwę użytkownika jakiej użyłeś podczas rejestracji.',
 
     'activation_title' => 'Aktywacja konta',

--- a/lib/languages/ro.php
+++ b/lib/languages/ro.php
@@ -425,7 +425,7 @@ $translations = array(
     'register_intro' => 'Please enter your valid e-mail address below - we will send you an activation link. During registration you will also choose a unique username (nickname) that you will use on the site.', /* EN edited register_msg1*/
     'register_info' => 'The user may opt out of using the website. At the same time, all data entered during registration and in the user description will be irretrievably deleted. If you want to deactivate your account, please contact us using your e-mail account. In uncertain cases, please contact us ({contact_mail}). Thank you.', /* EN */
     'register_rulesLbl' => 'Yes, I have read the <strong><a href="{wiki_link_rules}" target="_blank" rel="noopener">Terms of Service</a></strong> {site_name} and I agree to abide by it.', /* EN */
-    'register_ageLbl' => 'Yes, I have reached the age of majority.', /* EN */
+    'register_ageLbl' => 'Yes, I\'m {minAge} or older.', /* EN */
     'register_confirm' => 'Codul de activare ţi-a fost trimis prin E-Mail<div class="buffer"></div>Verifică şi dosarul cu poştă nedorită (SPAM) dacă nu vezi mesajul de activare în căsuţa poştală.',
 
     'activation_title' => 'Activarea contului',

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -235,6 +235,9 @@ $config['quick_search']['byowner'] = false;
 $config['quick_search']['byfinder'] = false;
 $config['quick_search']['byuser'] = true;
 
+// Minimum age to register (see GDPR policy)
+$config['limits']['minimum_age'] = 16;
+
   /** Limit for uplading pictures per node. */
 
 // Image file size limit in MB

--- a/sqlAlters/2018-05-20_clear_rules_confirmed_flag.sql
+++ b/sqlAlters/2018-05-20_clear_rules_confirmed_flag.sql
@@ -1,0 +1,6 @@
+-- 2018-05-20
+-- @author: deg-pl
+
+-- Clear rules_confirmed flag.
+-- It is GDPR related - from 2018-05-25 every user will have to confirm read new rules
+UPDATE `user` SET `rules_confirmed` = 0 WHERE 1;

--- a/tpl/stdstyle/userRegistration/register.tpl.php
+++ b/tpl/stdstyle/userRegistration/register.tpl.php
@@ -44,7 +44,7 @@ use Utils\Uri\SimpleRouter;
     <div class="buffer"></div>
 
     <input type="checkbox" name="age" id="age-checkbox" required>
-    <label for="age-checkbox"><?=tr('register_ageLbl')?></label>
+    <label for="age-checkbox"><?=str_replace('{minAge}', $view->minAge, tr('register_ageLbl'))?></label>
 
     <div class="buffer"></div>
 


### PR DESCRIPTION
@andrixnet @harrieklomp Please - review and translate strings beginning "register_". There is also an SQLAlter to reset previeous confirmation of rules. Please do this SQLAlter BEFORE 25 of May.

@andrixnet @harrieklomp @Amberel - have you new GDPR rules (terms) ready? From 25 of May all users will have to reconfirm read new rules (terms), or they can't use OC, and may disable their accounts via OC Team.