### PR TITLE
Date of publication displayed, for now on viewcache page only

### DIFF
--- a/Controllers/ViewCacheController.php
+++ b/Controllers/ViewCacheController.php
@@ -5,6 +5,7 @@ namespace Controllers;
 use Utils\Gis\Gis;
 use Utils\Log\CacheAccessLog;
 use Utils\Text\Rot13;
+use Utils\Text\Formatter;
 use Utils\Uri\Uri;
 use lib\Controllers\MeritBadgeController;
 use lib\Objects\Coordinates\Coordinates;
@@ -123,9 +124,24 @@ class ViewCacheController extends BaseController
 
         tpl_set_var('altitude', $this->geocache->getAltitude());
 
-        $this->view->setVar('cacheHiddenDate', $this->geocache->getDatePlaced()->format($this->ocConfig->getDateFormat()));
-        $this->view->setVar('cacheCreationDate', $this->geocache->getDateCreated()->format($this->ocConfig->getDateFormat()));
-        $this->view->setVar('cacheLastModifiedDate', $this->geocache->getLastModificationDate()->format($this->ocConfig->getDateFormat()));
+        $this->view->setVar(
+            'cacheHiddenDate',
+            Formatter::date($this->geocache->getDatePlaced())
+        );
+        $this->view->setVar(
+            'cacheCreationDate',
+            Formatter::date($this->geocache->getDateCreated())
+        );
+        $this->view->setVar(
+            'cacheLastModifiedDate',
+            Formatter::date($this->geocache->getLastModificationDate())
+        );
+        $this->view->setVar(
+            'cachePublishedDate',
+            empty($this->geocache->getDatePublished())
+            ? ""
+            : Formatter::date($this->geocache->getDatePublished())
+        );
 
         tpl_set_var('total_number_of_logs', $this->geocache->getFounds() + $this->geocache->getNotFounds() + $this->geocache->getNotesCount());
 

--- a/lib/Objects/GeoCache/GeoCache.php
+++ b/lib/Objects/GeoCache/GeoCache.php
@@ -38,6 +38,9 @@ class GeoCache extends GeoCacheCommons
     /* @var $dateActivate \DateTime */
     private $dateActivate;
 
+    /** @var \DateTime {@see GeoCache::setDatePublished()} */
+    private $datePublished;
+
     private $sizeId;
     private $ratingId;              //OKAPI rating calculated from score
     private $status;
@@ -393,6 +396,7 @@ class GeoCache extends GeoCacheCommons
         $this->ratingId = self::ScoreAsRatingNum($this->score); //rating is returned by OKAPI only-
 
         $this->setDateActivate($geocacheDbRow['date_activate']);
+        $this->setDatePublished($geocacheDbRow['date_published']);
         return $this;
     }
 
@@ -1023,6 +1027,28 @@ class GeoCache extends GeoCacheCommons
         }
     }
 
+    /**
+     * Gives the cache date of publication
+     *
+     * @return \DateTime the cache date of publication, null if not set
+     */
+    public function getDatePublished()
+    {
+        return $this->datePublished;
+    }
+
+    /**
+     * Sets the date of cache publication
+     *
+     * @param string the date to set
+     */
+    private function setDatePublished($datePublished)
+    {
+        if ($datePublished != null) {
+            $this->datePublished = new \DateTime($datePublished);
+        }
+    }
+
     public function getStatusTranslationIdentifier()
     {
         $statuses = $this->dictionary->getCacheStatuses();
@@ -1532,4 +1558,3 @@ class GeoCache extends GeoCacheCommons
     }
 
 }
-

--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -207,6 +207,7 @@ $translations = array(
     'date_hidden_label' => 'Versteckt am',
     'date_event_label' => 'Veranstaltungsbeginn',
     'date_created_label' => 'Erstellt am',
+    'date_published_label' => 'Date published', /* EN! */
     'last_modified_label' => 'Zuletzt geändert am',
     'last_modified2_label' => 'Zuletzt geändert am',
     'waypoint' => 'Wegpunkte',

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -207,6 +207,7 @@ $translations = array(
     'date_hidden_label' => 'Date hidden',
     'date_event_label' => 'Event date',
     'date_created_label' => 'Date created',
+    'date_published_label' => 'Date published',
     'last_modified_label' => 'Last modification',
     'last_modified2_label' => 'Last modified',
     'waypoint' => 'Waypoint',

--- a/lib/languages/fr.php
+++ b/lib/languages/fr.php
@@ -214,6 +214,7 @@ $translations = array(
     'date_hidden_label' => 'Cachée le',
     'date_event_label' => 'Date de l\'événement',
     'date_created_label' => 'Date de création',
+    'date_published_label' => 'Date published', /* EN! */
     'last_modified_label' => 'Dernière mise à jour',
     'last_modified2_label' => 'Dernière modification',
     'waypoint' => 'Waypoint',

--- a/lib/languages/nl.php
+++ b/lib/languages/nl.php
@@ -207,6 +207,7 @@ $translations = array(
     'date_hidden_label' => 'Geplaatst op',
     'date_event_label' => 'Datum evenement',
     'date_created_label' => 'Gemaakt op',
+    'date_published_label' => 'Date published', /* EN! */
     'last_modified_label' => 'Laatste verandering',
     'last_modified2_label' => 'Laatste verandering',
     'waypoint' => 'Waypoint',

--- a/lib/languages/pl.php
+++ b/lib/languages/pl.php
@@ -207,6 +207,7 @@ $translations = array(
     'date_hidden_label' => 'Data ukrycia',
     'date_event_label' => 'Data rozpoczęcia wydarzenia',
     'date_created_label' => 'Data utworzenia',
+    'date_published_label' => 'Data opublikowania',
     'last_modified_label' => 'Ostatnio zmodyfikowano',
     'last_modified2_label' => 'Ostatnio zmodyfikowana',
     'waypoint' => 'Waypoint',

--- a/lib/languages/ro.php
+++ b/lib/languages/ro.php
@@ -207,6 +207,7 @@ $translations = array(
     'date_hidden_label' => 'Data ascunderii',
     'date_event_label' => 'Data evenimentului',
     'date_created_label' => 'Data creării',
+    'date_published_label' => 'Date published', /* EN! */
     'last_modified_label' => 'Ultima modificare',
     'last_modified2_label' => 'Ultima modificare ***',
     'waypoint' => 'Punct',

--- a/tpl/stdstyle/viewcache/viewcache.tpl.php
+++ b/tpl/stdstyle/viewcache/viewcache.tpl.php
@@ -314,6 +314,11 @@ use lib\Objects\GeoKret\GeoKretyApi;
             </div>
 
             <div>
+                <img src="tpl/stdstyle/images/free_icons/date.png" class="icon16" alt="published-date">
+                {{date_published_label}}: <?=$view->cachePublishedDate?>
+            </div>
+
+            <div>
                 <img src="tpl/stdstyle/images/free_icons/date.png" class="icon16" alt="last-mod">
                 {{last_modified_label}}: <?=$view->cacheLastModifiedDate?>
             </div>


### PR DESCRIPTION
Added a cache date of publication to the GeoCache object and view cache page. Due to the fact it is not necessary to update OKAPI for viewcache, only this page is updated for now.

Samples:
![date_published](https://user-images.githubusercontent.com/17698165/41029262-8879497c-697b-11e8-9df0-dac4ff04b661.png)
![date_published_en](https://user-images.githubusercontent.com/17698165/41029452-f77f25bc-697b-11e8-845c-dac79db25859.png)

