### PR TITLE
Fixes #1564 - copy coordinates to the clipboard

### DIFF
--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -2794,8 +2794,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'I accept', /* EN */
 
-    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
-    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_prompt' => 'Copy coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'Coordinates', /* EN */
     'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
-    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
+    'copy_coords_failure' => 'Coordinates have not been copied.<br>Your browser does not support the copy-to-clipboard operation.', /* EN */
 );

--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -2794,4 +2794,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'I accept', /* EN */
 
+    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
+    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
 );

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2793,8 +2793,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.',
     'gdpr_acceptBtn' => 'I accept',
 
-    'copy_coords_prompt' => 'Copy the coordinates to the clipboard',
-    'copy_coords_success_prefix' => 'The coordinates',
+    'copy_coords_prompt' => 'Copy coordinates to the clipboard',
+    'copy_coords_success_prefix' => 'Coordinates',
     'copy_coords_success_suffix' => 'have been copied to the clipboard',
-    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.',
+    'copy_coords_failure' => 'Coordinates have not been copied.<br>Your browser does not support the copy-to-clipboard operation.',
 );

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2792,4 +2792,9 @@ $translations = array(
     'gdpr_text' => 'From May 25, 2018, due to the provisions of the GDPR, we changed',
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.',
     'gdpr_acceptBtn' => 'I accept',
+
+    'copy_coords_prompt' => 'Copy the coordinates to the clipboard',
+    'copy_coords_success_prefix' => 'The coordinates',
+    'copy_coords_success_suffix' => 'have been copied to the clipboard',
+    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.',
 );

--- a/lib/languages/fr.php
+++ b/lib/languages/fr.php
@@ -2792,8 +2792,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'I accept', /* EN */
 
-    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
-    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_prompt' => 'Copy coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'Coordinates', /* EN */
     'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
-    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
+    'copy_coords_failure' => 'Coordinates have not been copied.<br>Your browser does not support the copy-to-clipboard operation.', /* EN */
 );

--- a/lib/languages/fr.php
+++ b/lib/languages/fr.php
@@ -2792,4 +2792,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'I accept', /* EN */
 
+    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
+    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
 );

--- a/lib/languages/nl.php
+++ b/lib/languages/nl.php
@@ -2793,4 +2793,8 @@ $translations = array(
     'gdpr_text2' => 'Om de site verder te kunnen gebruiken dient men de veranderingen te lezen en te accepteren. <br> Wanneer je hier niet mee eens bent, <a href="mailto:{OCTeamEmail}"> contacteer ons </a> om je account van de site te verwijderen.',
     'gdpr_acceptBtn' => 'Ik accepteer',
 
+    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
+    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
 );

--- a/lib/languages/nl.php
+++ b/lib/languages/nl.php
@@ -2793,8 +2793,8 @@ $translations = array(
     'gdpr_text2' => 'Om de site verder te kunnen gebruiken dient men de veranderingen te lezen en te accepteren. <br> Wanneer je hier niet mee eens bent, <a href="mailto:{OCTeamEmail}"> contacteer ons </a> om je account van de site te verwijderen.',
     'gdpr_acceptBtn' => 'Ik accepteer',
 
-    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
-    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_prompt' => 'Copy coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'Coordinates', /* EN */
     'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
-    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
+    'copy_coords_failure' => 'Coordinates have not been copied.<br>Your browser does not support the copy-to-clipboard operation.', /* EN */
 );

--- a/lib/languages/pl.php
+++ b/lib/languages/pl.php
@@ -2796,4 +2796,9 @@ $translations = array(
     'gdpr_text' => 'Od dnia 25 maja 2018 ze względu na przepisy RODO zmieniliśmy',
     'gdpr_text2' => 'Aby nadal korzystać z serwisu, zapoznaj się ze zmianami i zaakceptuj je.<br>Jeśli się nie zgadzasz - <a href="mailto:{OCTeamEmail}">skontaktuj się z nami</a> by usunąć Twoje konto w serwisie.',
     'gdpr_acceptBtn' => 'Akceptuję',
+
+    'copy_coords_prompt' => 'Kopiuj współrzędne do schowka',
+    'copy_coords_success_prefix' => 'Współrzędne',
+    'copy_coords_success_suffix' => 'zostały skopiowane do schowka',
+    'copy_coords_failure' => 'Współrzędne nie zostały skopiowane do schowka.<br>Sprawdź czy Twoja przeglądarka wspiera operację kopiowania do schowka.',
 );

--- a/lib/languages/pl.php
+++ b/lib/languages/pl.php
@@ -2800,5 +2800,5 @@ $translations = array(
     'copy_coords_prompt' => 'Kopiuj współrzędne do schowka',
     'copy_coords_success_prefix' => 'Współrzędne',
     'copy_coords_success_suffix' => 'zostały skopiowane do schowka',
-    'copy_coords_failure' => 'Współrzędne nie zostały skopiowane do schowka.<br>Sprawdź czy Twoja przeglądarka wspiera operację kopiowania do schowka.',
+    'copy_coords_failure' => 'Współrzędne nie zostały skopiowane.<br>Twoja przeglądarka nie wspiera operacji kopiowania do schowka.',
 );

--- a/lib/languages/ro.php
+++ b/lib/languages/ro.php
@@ -2793,8 +2793,8 @@ $translations = array(
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'De acord', /* EN */
 
-    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
-    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_prompt' => 'Copy coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'Coordinates', /* EN */
     'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
-    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
+    'copy_coords_failure' => 'Coordinates have not been copied.<br>Your browser does not support the copy-to-clipboard operation.', /* EN */
 );

--- a/lib/languages/ro.php
+++ b/lib/languages/ro.php
@@ -2792,4 +2792,9 @@ $translations = array(
     'gdpr_text' => 'From May 25, 2018, due to the provisions of the GDPR, we changed', /* EN */
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.', /* EN */
     'gdpr_acceptBtn' => 'De acord', /* EN */
+
+    'copy_coords_prompt' => 'Copy the coordinates to the clipboard', /* EN */
+    'copy_coords_success_prefix' => 'The coordinates', /* EN */
+    'copy_coords_success_suffix' => 'have been copied to the clipboard', /* EN */
+    'copy_coords_failure' => 'The coordinates have not been copied to the clipboard.<br>Check if your browser supports the clipbord copying operation.', /* EN */
 );

--- a/tpl/stdstyle/images/misc/copy-coords.svg
+++ b/tpl/stdstyle/images/misc/copy-coords.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 31 31" width="32" height="32" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <g id="p1">
+            <path
+                style="fill:#0000c0;stroke:#5050ff;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+                d="m 15 15 v 7 l 1 -1 z"
+            />
+            <path
+                style="fill:#ffffff;stroke:#707070;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+                d="m 15 15 v 7 l -1 -1 z"
+            />
+        </g>
+        <g id="p2">
+            <path
+                style="fill:none;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+                d="m 14 3 h 14"
+            />
+        </g>
+    </defs>
+    <g>
+        <rect
+            x="12" y="0.5" rx="3" ry="3" width="18" height="18"
+            style="fill:#ffffff;stroke:#707070;stroke-width:0.7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+        />
+        <use xlink:href="#p2"/>
+        <use xlink:href="#p2" transform="translate(0 3)"/>
+        <use xlink:href="#p2" transform="translate(0 6)"/>
+        <use xlink:href="#p2" transform="translate(5.5 9) scale(0.6 1.0)"/>
+    </g>
+    <g transform="translate(-1.5 -1) rotate(-7 16.5 9.25)">
+        <path
+            style="fill:#05e050;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+            d="m 15 8.5 l 11 -2.5 -2.5 11 -2 -4 -5 5 -2.75 -2.75 5 -5 z"
+        />
+    </g>
+    <g transform="translate(-11, -12) scale(1.45 1.45)">
+        <circle cx="15" cy="22" r="5" style="fill:#e0e0ff;stroke:#505050;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"/>
+        <circle cx="15" cy="22" r="3" style="fill:#b0b0ff;stroke:#505050;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"/>
+        <use xlink:href="#p1" transform="scale(0.7 0.7) translate(6.4 9.4) rotate(45 15 22)"/>
+        <use xlink:href="#p1" transform="scale(0.7 0.7) translate(6.4 9.4) rotate(135 15 22)"/>
+        <use xlink:href="#p1" transform="scale(0.7 0.7) translate(6.4 9.4) rotate(225 15 22)"/>
+        <use xlink:href="#p1" transform="scale(0.7 0.7) translate(6.4 9.4) rotate(315 15 22)"/>
+        <use xlink:href="#p1"/>
+        <use xlink:href="#p1" transform="rotate(90 15 22)"/>
+        <use xlink:href="#p1" transform="rotate(180 15 22)"/>
+        <use xlink:href="#p1" transform="rotate(270 15 22)"/>
+    </g>
+    
+</svg>

--- a/tpl/stdstyle/viewcache/viewcache.css
+++ b/tpl/stdstyle/viewcache/viewcache.css
@@ -294,10 +294,47 @@ a.links4:hover {
     text-decoration: underline;
 }
 
-.CoordsDegMinSec, .CoordsDecimal {
-    display: none;  
+#viewcache-coordsinfo {
+    padding-bottom: 0.5em;
 }
 
-#cacheCoordinates {
+.viewcache-coordsinfo-block {
+    display: inline-block;
+    vertical-align: top;
+}
+
+.viewcache-coords-values {
+    position: relative;
+    top: -0.2em;
+}
+
+.CoordsDegMinSec, .CoordsDecimal {
+    display: none;
+}
+
+#cacheCoordinates, #copy-coords {
     cursor: pointer;
+    line-height: 1.0em
+}
+
+.copy-coords-status {
+    background: #fffbc6 !important;
+}
+
+.copy-coords-status .ui-widget-header {
+    border: none;
+    background: transparent;
+}
+
+.copy-coords-status .ui-dialog-titlebar-close:focus {
+    border: none;
+    outline: none;
+}
+
+.copy-coords-status .ui-dialog-titlebar-close::-moz-focus-inner {
+  border: 0;
+}
+
+.copy-coords-status .failure {
+    color: #a00000;
 }

--- a/tpl/stdstyle/viewcache/viewcache.css
+++ b/tpl/stdstyle/viewcache/viewcache.css
@@ -308,13 +308,24 @@ a.links4:hover {
     top: -0.2em;
 }
 
+.coords-hidden {
+    padding-top: 0.2em
+}
+
 .CoordsDegMinSec, .CoordsDecimal {
     display: none;
 }
 
 #cacheCoordinates, #copy-coords {
     cursor: pointer;
+}
+
+.line1, #cacheCoordinates {
     line-height: 1.0em
+}
+
+#copy-coords-status {
+    display: none;
 }
 
 .copy-coords-status {
@@ -335,6 +346,10 @@ a.links4:hover {
   border: 0;
 }
 
-.copy-coords-status .failure {
+.copy-coords-status .copy-coords-failure {
     color: #a00000;
+}
+
+.copy-coords-status .copy-coords-values {
+    font-weight: bold;
 }

--- a/tpl/stdstyle/viewcache/viewcache.js
+++ b/tpl/stdstyle/viewcache/viewcache.js
@@ -170,7 +170,7 @@ var dialogElement;
 
 function copyCoords(e) {
     let statusText = tr['copy_coords_failure'];
-    let statusClass = "failure";
+    let statusClass = "copy-coords-failure";
     let coordsElem = $('.' + currentCordsFormat);
     if (coordsElem != null) {
         let coords = coordsElem.text().trim();
@@ -184,7 +184,7 @@ function copyCoords(e) {
                 statusClass = "";
                 statusText =
                     tr['copy_coords_success_prefix']
-                    + "<br><span style=\"font-weight: bold\">"
+                    + "<br><span class=\"copy-coords-values\">"
                     + coords
                     + "</span><br>"
                     + tr['copy_coords_success_suffix']

--- a/tpl/stdstyle/viewcache/viewcache.js
+++ b/tpl/stdstyle/viewcache/viewcache.js
@@ -165,3 +165,87 @@ function changeCoordsFormat(){
   }
 }
 
+var closeDialog = 0;
+var dialogElement;
+
+function copyCoords(e) {
+    let statusText = tr['copy_coords_failure'];
+    let statusClass = "failure";
+    let coordsElem = $('.' + currentCordsFormat);
+    if (coordsElem != null) {
+        let coords = coordsElem.text().trim();
+        let temp = $("<input>");
+        $("body").append(temp);
+        temp.val(coords).select();
+        if (document.queryCommandEnabled("copy")) {
+            let result = document.execCommand("copy", false, null);
+            temp.remove();
+            if (result) {
+                statusClass = "";
+                statusText =
+                    tr['copy_coords_success_prefix']
+                    + "<br><span style=\"font-weight: bold\">"
+                    + coords
+                    + "</span><br>"
+                    + tr['copy_coords_success_suffix']
+            }
+        }
+    }
+    let copyStatus = $("#copy-coords-status");
+    if (copyStatus.length) {
+        copyStatus.html(statusText);
+        copyStatus.dialog({
+            autoOpen: true,
+            minHeight: 20,
+            minWidth : 50,
+            width: "auto",
+            position: {
+                my: "center",
+                at: "center",
+                of: e.target
+            },
+            classes: {
+                "ui-dialog": "copy-coords-status ui-corner-all",
+                "ui-dialog-content": "copy-coords-status " + statusClass,
+                "ui-dialog-titlebar-close": "copy-coords-status",
+            },
+            open: function() {
+                closeDialog = 1;
+                $(document).bind('click', documentClickCloseDialog);
+            },
+            focus: function() {
+                closeDialog = 0;
+            },
+            close: function() {
+                $(document).unbind('click', documentClickCloseDialog);
+                dialogElement = null;
+            }
+        });
+        dialogElement = copyStatus;
+        closeDialog = 0;
+    }
+}
+
+function documentClickCloseDialog() {
+    if (closeDialog && dialogElement != null) {
+        dialogElement.dialog('close');
+    }
+    closeDialog = 1;
+}
+
+$(document).ready(function() {
+    if (document.queryCommandSupported("copy")) {
+        $("#viewcache-coordsinfo").append(
+            '<div class="viewcache-coordsinfo-block">'
+            + '<span class="content-title-noshade-size0">'
+            + '<img id="copy-coords"'
+            + ' src="tpl/stdstyle/images/misc/copy-coords.svg"'
+            + ' onclick="copyCoords(event)"'
+            + ' class="icon32"'
+            + ' alt="' + tr['copy_coords_prompt'] + '"'
+            + ' title="' + tr['copy_coords_prompt'] + '"/>'
+            + '</span>'
+            + '</div>'
+        );
+    }
+});

--- a/tpl/stdstyle/viewcache/viewcache.js
+++ b/tpl/stdstyle/viewcache/viewcache.js
@@ -234,7 +234,10 @@ function documentClickCloseDialog() {
 }
 
 $(document).ready(function() {
-    if (document.queryCommandSupported("copy")) {
+    if (
+        $("#cacheCoordinates").length
+        && document.queryCommandSupported("copy")
+    ) {
         $("#viewcache-coordsinfo").append(
             '<div class="viewcache-coordsinfo-block">'
             + '<span class="content-title-noshade-size0">'

--- a/tpl/stdstyle/viewcache/viewcache.tpl.php
+++ b/tpl/stdstyle/viewcache/viewcache.tpl.php
@@ -178,58 +178,72 @@ use lib\Objects\GeoKret\GeoKretyApi;
 
 <div class="content2-container">
     <div class="content2-container-2col-left" id="viewcache-baseinfo">
-        <div class="content-title-noshade-size3">
-          <img src="tpl/stdstyle/images/blue/kompas.png" class="icon32" alt="compass">
-
-            <?php if ($view->isUserAuthorized || $view->alwaysShowCoords) { ?>
-                <span id="cacheCoordinates" onclick="changeCoordsFormat()" title="<?=tr('viewCache_switchCoordsFormat')?>">
-                <?php if (!$view->userModifiedCacheCoords) { ?>
-                  <span class="CoordsDegMin">
-                    <?=$view->geoCache->getCoordinates()->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DEG_MIN)?>
-                  </span>
-                  <span class="CoordsDegMinSec">
-                    <?=$view->geoCache->getCoordinates()->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DEG_MIN_SEC)?>
-                  </span>
-                  <span class="CoordsDecimal">
-                    <?=$view->geoCache->getCoordinates()->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DECIMAL)?>
-                  </span>
-                <?php } else { // if-userModifiedCacheCoords ?>
-                  <span class="CoordsDegMin">
-                    <?=$view->userModifiedCacheCoords->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DEG_MIN)?>
-                  </span>
-                  <span class="CoordsDegMinSec">
-                    <?=$view->userModifiedCacheCoords->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DEG_MIN_SEC)?>
-                  </span>
-                  <span class="CoordsDecimal">
-                    <?=$view->userModifiedCacheCoords->getAsText(
-                        Coordinates::COORDINATES_FORMAT_DECIMAL)?>
-                  </span>
-
-                <?php } // if-userModifiedCacheCoords ?>
+        <div class="content-title-noshade-size3" id="viewcache-coordsinfo">
+            <div class="viewcache-coordsinfo-block">
+                <span class="content-title-noshade-size0">
+                    <img src="tpl/stdstyle/images/blue/kompas.png" class="icon32" alt="compass"/>
                 </span>
-
-                <span class="content-title-noshade-size0">(WGS84)</span>
-
-                <?php if ($view->userModifiedCacheCoords) { ?>
-                    <span class="content-title-noshade-size0">
-                      <a href="#coords_mod_section">
-                        <img src="tpl/stdstyle/images/blue/signature1-orange.png" class="icon32"
-                          alt="<?=tr('orig_coord_modified_info')?><?=$view->geoCache->getCoordinates()->getAsText()?>"
-                          title="<?=tr('orig_coord_modified_info')?><?=$view->geoCache->getCoordinates()->getAsText()?>">
-                      </a>
+            </div>
+            <?php if ($view->isUserAuthorized || $view->alwaysShowCoords) { ?>
+                <div class="viewcache-coordsinfo-block viewcache-coords-values">
+                    <span
+                        id="cacheCoordinates"
+                        onclick="changeCoordsFormat()"
+                        title="<?=tr('viewCache_switchCoordsFormat')?>">
+                    <?php if (!$view->userModifiedCacheCoords) { ?>
+                        <span class="CoordsDegMin">
+                            <?=$view->geoCache->getCoordinates()->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DEG_MIN)?>
+                        </span>
+                        <span class="CoordsDegMinSec">
+                            <?=$view->geoCache->getCoordinates()->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DEG_MIN_SEC)?>
+                        </span>
+                        <span class="CoordsDecimal">
+                            <?=$view->geoCache->getCoordinates()->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DECIMAL)?>
+                        </span>
+                    <?php } else { // if-userModifiedCacheCoords ?>
+                        <span class="CoordsDegMin">
+                            <?=$view->userModifiedCacheCoords->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DEG_MIN)?>
+                        </span>
+                        <span class="CoordsDegMinSec">
+                            <?=$view->userModifiedCacheCoords->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DEG_MIN_SEC)?>
+                        </span>
+                        <span class="CoordsDecimal">
+                            <?=$view->userModifiedCacheCoords->getAsText(
+                                Coordinates::COORDINATES_FORMAT_DECIMAL)?>
+                        </span>
+                    <?php } // if-userModifiedCacheCoords ?>
                     </span>
+                    <div class="content-title-noshade-size0" style="line-height: 1.0em;">(WGS84)</div>
+                </div>
+                <?php if ($view->userModifiedCacheCoords) { ?>
+                    <div class="viewcache-coordsinfo-block">
+                        <span class="content-title-noshade-size0">
+                          <a href="#coords_mod_section">
+                            <img src="tpl/stdstyle/images/blue/signature1-orange.png" class="icon32"
+                              alt="<?=tr('orig_coord_modified_info')?><?=$view->geoCache->getCoordinates()->getAsText()?>"
+                              title="<?=tr('orig_coord_modified_info')?><?=$view->geoCache->getCoordinates()->getAsText()?>">
+                          </a>
+                        </span>
+                    </div>
                 <?php } //coords modified ?>
-
             <?php } else { //user-not-authorized ?>
-                <?=tr('hidden_coords')?>
+                <div class="viewcache-coordsinfo-block" style="padding-top: 0.2em">
+                    <?=tr('hidden_coords')?>
+                </div>
             <?php } //else-user-not-authorized ?>
-
-
+                <script language="javascript">
+                    var tr = {
+                        'copy_coords_prompt': '<?php print tr('copy_coords_prompt') ?>',
+                        'copy_coords_success_prefix': '<?php print tr('copy_coords_success_prefix') ?>',
+                        'copy_coords_success_suffix': '<?php print tr('copy_coords_success_suffix') ?>',
+                        'copy_coords_failure': '<?php print tr('copy_coords_failure') ?>',
+                    };
+                </script>
         </div>
 
         <div class="list-of-details">
@@ -1053,3 +1067,5 @@ use lib\Objects\GeoKret\GeoKretyApi;
 </div>
 
 <?php } //if ($view->badgesPopUp ?>
+
+<div id="copy-coords-status" style="display: none"></div>

--- a/tpl/stdstyle/viewcache/viewcache.tpl.php
+++ b/tpl/stdstyle/viewcache/viewcache.tpl.php
@@ -218,7 +218,7 @@ use lib\Objects\GeoKret\GeoKretyApi;
                         </span>
                     <?php } // if-userModifiedCacheCoords ?>
                     </span>
-                    <div class="content-title-noshade-size0" style="line-height: 1.0em;">(WGS84)</div>
+                    <div class="content-title-noshade-size0 line1">(WGS84)</div>
                 </div>
                 <?php if ($view->userModifiedCacheCoords) { ?>
                     <div class="viewcache-coordsinfo-block">
@@ -232,16 +232,16 @@ use lib\Objects\GeoKret\GeoKretyApi;
                     </div>
                 <?php } //coords modified ?>
             <?php } else { //user-not-authorized ?>
-                <div class="viewcache-coordsinfo-block" style="padding-top: 0.2em">
+                <div class="viewcache-coordsinfo-block coords-hidden">
                     <?=tr('hidden_coords')?>
                 </div>
             <?php } //else-user-not-authorized ?>
                 <script language="javascript">
                     var tr = {
-                        'copy_coords_prompt': '<?php print tr('copy_coords_prompt') ?>',
-                        'copy_coords_success_prefix': '<?php print tr('copy_coords_success_prefix') ?>',
-                        'copy_coords_success_suffix': '<?php print tr('copy_coords_success_suffix') ?>',
-                        'copy_coords_failure': '<?php print tr('copy_coords_failure') ?>',
+                        'copy_coords_prompt': '<?=tr('copy_coords_prompt')?>',
+                        'copy_coords_success_prefix': '<?=tr('copy_coords_success_prefix')?>',
+                        'copy_coords_success_suffix': '<?=tr('copy_coords_success_suffix')?>',
+                        'copy_coords_failure': '<?=tr('copy_coords_failure')?>',
                     };
                 </script>
         </div>
@@ -1068,4 +1068,4 @@ use lib\Objects\GeoKret\GeoKretyApi;
 
 <?php } //if ($view->badgesPopUp ?>
 
-<div id="copy-coords-status" style="display: none"></div>
+<div id="copy-coords-status"></div>


### PR DESCRIPTION
A kid of fast fix, to be refactored in reactive layout of course. Clicable icon with javascript associated to copy coordinates in currently chosen format to the clipboard.

Will not work on every browser, but tested successfully on linux: chromium 65 and firefox 60 and android: chrome and firefox latest versions. Most probably will work on windows too, but I need to check it out :wink:.

What was:
![copy_coords_to_clipboard_en_old](https://user-images.githubusercontent.com/17698165/41356694-b32474fe-6f24-11e8-9645-4695fa314029.png)

What will be:
![copy_coords_to_clipboard_en_new](https://user-images.githubusercontent.com/17698165/41356724-bfee4c46-6f24-11e8-81a4-9446d526ec2b.png)

If someone can provide a better icon, it would be great...