### PR TITLE
Toggle of encrypted/decrypted hint changed from jquery to pure javascript

### DIFF
--- a/tpl/stdstyle/viewcache/viewcache.js
+++ b/tpl/stdstyle/viewcache/viewcache.js
@@ -96,11 +96,23 @@ function loadLogEntries(offset, limit){
 function showHint(event)
 {
     event.preventDefault();
-        $("#hintEncrypted").toggle();
-        $("#hintDecrypted").toggle();
-        $("#encryptLinkStr").toggle();
-        $("#decryptLinkStr").toggle();
+    togglePair("hintEncrypted", "hintDecrypted");
+    togglePair("encryptLinkStr", "decryptLinkStr");
     return false;
+}
+
+function togglePair(id1, id2) {
+    var e1 = document.getElementById(id1);
+    var e2 = document.getElementById(id2);
+    if (e1 != null && e2 != null) {
+        if (e1.style.display == "none") {
+            e1.style.display = "";
+            e2.style.display = "none";
+        } else {
+            e2.style.display = "";
+            e1.style.display = "none";
+        }
+    }
 }
 
 function openCgeoWindow(event, ocWaypoint)


### PR DESCRIPTION
There's a problem raised by RoDaJJ on OCPL noticing that on Android browser (the built-in one, I suspect) the Encrypt/Decrypt button for cache hint does not work as expected. @kojoty managed to reproduce it and suggested it is caused by an incomplete support of jquery in the browser. I didn't manage to reproduce it (jquery solution works on every browser found in my phone) but nevertheless I suggest a tiny change bypassing using jquery in the case.

Someone has to check if the change solves the problem, I can't do it myself.