### PR TITLE
Fixed poor rating on cache map balloon when zero (too few) votes

### DIFF
--- a/Controllers/CacheMapBalloonController.php
+++ b/Controllers/CacheMapBalloonController.php
@@ -50,7 +50,10 @@ class CacheMapBalloonController extends BaseController
             $resp->coords->lat = $cache->getCoordinates()->getLatitude();
             $resp->coords->lon = $cache->getCoordinates()->getLongitude();
 
-            $resp->ratingDesc = $cache->getRatingDesc();
+            $resp->ratingDesc =
+                $cache->getRatingVotes() < 3
+                ? tr('not_available')
+                : $cache->getRatingDesc();
 
             if($cache->isEvent()){
                 $resp->isEvent = true;


### PR DESCRIPTION
Before:
![cache_map_baloon_old1](https://user-images.githubusercontent.com/17698165/43469874-71debd2c-94e7-11e8-8289-aff71f3339b2.png)

After:
![cache_map_baloon_new1](https://user-images.githubusercontent.com/17698165/43469888-7e27e13a-94e7-11e8-87ff-1c81fdb7a1a7.png)

It is not perfect (the '3' value should be configurable) but not it is compliant with current cache view page logic.