### PR TITLE
ESRI and Bing maps in map.pl.php config

### DIFF
--- a/Config/map.pl.php
+++ b/Config/map.pl.php
@@ -6,77 +6,88 @@
  */
 $map['jsConfig'] = "
 {
-  OSM: new ol.layer.Tile ({
-    source: new ol.source.OSM(),
-  }),
+    OSM: new ol.layer.Tile ({
+        source: new ol.source.OSM(),
+    }),
 
-  Osmapa: new ol.layer.Tile ({
-    source: new ol.source.TileImage ({
-      url: 'http://tile.openstreetmap.pl/osmapa.pl/{z}/{x}/{y}.png',
-      attributions: \"&copy; <a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap</a>\",
-    })
-  }),
+    Osmapa: new ol.layer.Tile ({
+        source: new ol.source.TileImage ({
+            url: 'http://tile.openstreetmap.pl/osmapa.pl/{z}/{x}/{y}.png',
+            attributions: \"&copy; <a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap</a>\",
+        })
+    }),
 
-  UMP: new ol.layer.Tile ({
-    source: new ol.source.TileImage ({
-      url: 'http://tiles.ump.waw.pl/ump_tiles/{z}/{x}/{y}.png',
-      attributions: \"&copy; Mapa z <a href='http://ump.waw.pl/' target='_blank'>UMP-pcPL</a>\",
-    })
-  }),
+    UMP: new ol.layer.Tile ({
+        source: new ol.source.TileImage ({
+            url: 'http://tiles.ump.waw.pl/ump_tiles/{z}/{x}/{y}.png',
+            attributions: \"&copy; Mapa z <a href='http://ump.waw.pl/' target='_blank'>UMP-pcPL</a>\",
+        })
+    }),
 
-  BingMap: new ol.layer.Tile ({
-    source: new ol.source.BingMaps({
-      key: '{Key-BingMap}',
-      imagerySet: 'Road'
-    })
-  }),
+    BingMap: new ol.layer.Tile ({
+        source: new ol.source.BingMaps({
+            key: '{Key-BingMap}',
+            imagerySet: 'Road',
+            maxZoom: 19
+        })
+    }),
 
-  BingSatelite: new ol.layer.Tile ({
-    source: new ol.source.BingMaps({
-      key: '{Key-BingMap}',
-      imagerySet: 'Aerial'
-    })
-  }),
+    BingSatelite: new ol.layer.Tile ({
+        source: new ol.source.BingMaps({
+            key: '{Key-BingMap}',
+            imagerySet: 'Aerial',
+            maxZoom: 19
+        })
+    }),
 
-  Topo: new ol.layer.Tile ({
-    source: new ol.source.TileWMS({
-        url: 'http://mapy.geoportal.gov.pl:80/wss/service/img/guest/TOPO/MapServer/WmsServer',
-        attributions: \"&copy; <a href='http://geoportal.gov.pl/' target='_blank'>geoportal.gov.pl</a>\",
-        params: {
-            VERSION: '1.1.1',
-            LAYERS: 'Raster',
-            TILED: true,
-            FORMAT: 'image/jpeg',
-            BGCOLOR: '0xFFFFFF',
-            TRANSPARENT: false
-        },
-        projection: 'EPSG:4326',
-        tileGrid: ol.tilegrid.createXYZ({
-            extent: ol.proj.get('EPSG:4326').getExtent(),
-            tileSize: [768, 768]
+    Topo: new ol.layer.Tile ({
+        source: new ol.source.TileWMS({
+            url: 'http://mapy.geoportal.gov.pl:80/wss/service/img/guest/TOPO/MapServer/WmsServer',
+            attributions: \"&copy; <a href='http://geoportal.gov.pl/' target='_blank'>geoportal.gov.pl</a>\",
+            params: {
+                VERSION: '1.1.1',
+                LAYERS: 'Raster',
+                TILED: true,
+                FORMAT: 'image/jpeg',
+                BGCOLOR: '0xFFFFFF',
+                TRANSPARENT: false
+            },
+            projection: 'EPSG:4326',
+            tileGrid: ol.tilegrid.createXYZ({
+                extent: ol.proj.get('EPSG:4326').getExtent(),
+                tileSize: [768, 768]
+            }),
         }),
     }),
-  }),
 
-  Orto: new ol.layer.Tile({
-      source: new ol.source.TileWMS({
-          url: 'http://mapy.geoportal.gov.pl:80/wss/service/img/guest/ORTO/MapServer/WmsServer',
-          attributions: \"&copy; <a href='http://geoportal.gov.pl/' target='_blank'>geoportal.gov.pl</a>\",
-          params: {
-              VERSION: '1.1.1',
-              LAYERS: 'Raster',
-              TILED: true,
-              FORMAT: 'image/jpeg',
-              BGCOLOR: '0xFFFFFF',
-              TRANSPARENT: false
-          },
-          projection: 'EPSG:4326',
-          tileGrid: ol.tilegrid.createXYZ({
-              extent: ol.proj.get('EPSG:4326').getExtent(),
-              tileSize: [768, 768]
-          }),
-      }),
-  }),
+    Orto: new ol.layer.Tile({
+        source: new ol.source.TileWMS({
+            url: 'http://mapy.geoportal.gov.pl:80/wss/service/img/guest/ORTO/MapServer/WmsServer',
+            attributions: \"&copy; <a href='http://geoportal.gov.pl/' target='_blank'>geoportal.gov.pl</a>\",
+            params: {
+                VERSION: '1.1.1',
+                LAYERS: 'Raster',
+                TILED: true,
+                FORMAT: 'image/jpeg',
+                BGCOLOR: '0xFFFFFF',
+                TRANSPARENT: false
+            },
+            projection: 'EPSG:4326',
+            tileGrid: ol.tilegrid.createXYZ({
+                extent: ol.proj.get('EPSG:4326').getExtent(),
+                tileSize: [768, 768]
+            }),
+        }),
+    }),
+
+    ESRI: new ol.layer.Tile({
+        source: new ol.source.XYZ({
+            attributions: 'Tiles © <a href=\"https://services.arcgisonline.com/ArcGIS/' +
+                'rest/services/World_Topo_Map/MapServer\">ArcGIS</a>',
+            url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
+                'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
+        })
+    }),
 }
 ";
 
@@ -106,5 +117,3 @@ $map['keyInjectionCallback'] = function(array &$mapConfig){
 
     return true;
 };
-
-

--- a/Config/map.pl.php
+++ b/Config/map.pl.php
@@ -80,12 +80,21 @@ $map['jsConfig'] = "
         }),
     }),
 
-    ESRI: new ol.layer.Tile({
+    ESRITopo: new ol.layer.Tile({
         source: new ol.source.XYZ({
             attributions: 'Tiles © <a href=\"https://services.arcgisonline.com/ArcGIS/' +
                 'rest/services/World_Topo_Map/MapServer\">ArcGIS</a>',
             url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
                 'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
+        })
+    }),
+
+    ESRIStreet: new ol.layer.Tile({
+        source: new ol.source.XYZ({
+            attributions: 'Tiles © <a href=\"https://services.arcgisonline.com/ArcGIS/' +
+                'rest/services/World_Street_Map/MapServer\">ArcGIS</a>',
+            url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
+                'World_Street_Map/MapServer/tile/{z}/{y}/{x}'
         })
     }),
 }


### PR DESCRIPTION
From OCPL forum:

> Czy dałoby się dodać mapki esri?
> Całkiem ciekawe i dokładne mapy.
> Tu przykład World Imaginery (to samo co bing) oraz Topo (w mojej okolicy widzę parę dróg, których nie ma nawet na OSM)
> https://www.arcgis.com/home/webmap/viewer.html
>
> W mapie foto bing wkurza wczytywanie pustych kafelków, kiedy zoom jest zbyt duży. Dlaczego po prostu nie blokują ostatniego możliwego powiększenia? Nie wiem czy z poziomu OC można tym zarządzać? W esri nie ma tego problemu.

- added ESRI Topo map and ESRI Street map to `Config/map.pl.php`. I could not find any licence for the ESRI web services, so I assume the tiles usage is permitted without any significant restrictions,
- added `maxZoom: 19` to Bing Maps sources in `Config/map.pl.php`,
- indented `Config/map/pl/php` map sources definitions.