### PR TITLE
Failover language added for tr and tr2 functions (fixes #1594)

### DIFF
--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -3,15 +3,10 @@
 require_once __DIR__ . '/ClassPathDictionary.php'; // class autoloader
 
 use Utils\View\View;
-use Utils\Uri\Uri;
-use Utils\I18n\I18n;
-use Utils\I18n\Languages;
 use lib\Objects\ApplicationContainer;
 use lib\Objects\User\User;
 use lib\Objects\User\UserAuthorization;
 use lib\Objects\OcConfig\OcConfig;
-use Utils\Text\UserInputFilter;
-use Utils\Uri\OcCookie;
 
 session_start();
 
@@ -68,7 +63,7 @@ if (php_sapi_name() != "cli") { // this is not neccesarry for command-line scrip
     UserAuthorization::verify();
 
     initTemplateSystem();
-    loadTranslation();
+    initTranslations();
 
 }
 
@@ -113,59 +108,6 @@ function initTemplateSystem(){
 
     $GLOBALS['tpl_subtitle'] = '';
 }
-
-function loadTranslation(){
-
-        global $lang, $language, $config;
-
-        //language changed?
-        if(isset($_REQUEST['lang'])){
-            $lang = $_REQUEST['lang'];
-        }else{
-            $lang = OcCookie::getOrDefault('lang', $lang);
-        }
-
-        // load failover language settings
-        if (
-            !empty($config['failoverLanguage'])
-            && !isset($language[$config['failoverLanguage']])
-            && I18n::isTranslationSupported($config['failoverLanguage'])
-        ) {
-            load_language_file($config['failoverLanguage']);
-        }
-
-        //check if $lang is supported by site
-        if(!I18n::isTranslationSupported($lang)){
-
-            // requested language is not supported - display error...
-
-            tpl_set_tplname('error/langNotSupported');
-            header("HTTP/1.0 404 Not Found");
-            $view = tpl_getView();
-
-            $view->loadJQuery();
-            $view->setVar("localCss",
-                Uri::getLinkWithModificationTime('/tpl/stdstyle/error/error.css'));
-            $view->setVar('requestedLang', UserInputFilter::purifyHtmlString($lang));
-            $lang = 'en'; //English must be always supported
-
-            $view->setVar('allLanguageFlags', I18n::getLanguagesFlagsData());
-            load_language_file($lang);
-
-            tpl_BuildTemplate();
-            exit;
-        }
-
-        // load language settings (only if different from failover)
-        if (
-            empty($config['failoverLanguage'])
-            || $lang != $config['failoverLanguage']
-        ) {
-            load_language_file($lang);
-        }
-        Languages::setLocale($lang);
-}
-
 
 //TODO: Remove all functions below from here!
 

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -116,13 +116,22 @@ function initTemplateSystem(){
 
 function loadTranslation(){
 
-        global $lang;
+        global $lang, $config;
 
         //language changed?
         if(isset($_REQUEST['lang'])){
             $lang = $_REQUEST['lang'];
         }else{
             $lang = OcCookie::getOrDefault('lang', $lang);
+        }
+
+        // load failover language settings
+        if (
+            !empty($config['failoverLanguage'])
+            && !isset($language[$config['failoverLanguage']])
+            && I18n::isTranslationSupported($config['failoverLanguage'])
+        ) {
+            load_language_file($config['failoverLanguage']);
         }
 
         //check if $lang is supported by site
@@ -147,8 +156,13 @@ function loadTranslation(){
             exit;
         }
 
-        // load language settings
-        load_language_file($lang);
+        // load language settings (only if different from failover)
+        if (
+            empty($config['failoverLanguage'])
+            || $lang != $config['failoverLanguage']
+        ) {
+            load_language_file($lang);
+        }
         Languages::setLocale($lang);
 }
 
@@ -213,6 +227,3 @@ function help_latToDegreeStr($lat, $type = 1)
 
     return $retval;
 }
-
-
-

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -116,7 +116,7 @@ function initTemplateSystem(){
 
 function loadTranslation(){
 
-        global $lang, $config;
+        global $lang, $language, $config;
 
         //language changed?
         if(isset($_REQUEST['lang'])){

--- a/lib/language.inc.php
+++ b/lib/language.inc.php
@@ -14,31 +14,47 @@ function load_language_file($lang)
     return true;
 }
 
+function postProcessTr(&$ref)
+{
+    if (strpos($ref, "{") !== false)
+        return tpl_do_replace($ref, true);
+    else
+        return $ref;
+}
+
 function tr($str)
 {
-    global $language, $lang;
+    global $language, $lang, $config;
 
     if (isset($language[$lang][$str]) && $language[$lang][$str]) {
-        $ref = &$language[$lang][$str];
-        if (strpos($ref, "{") !== false)
-            return tpl_do_replace($ref, true);
-        else
-            return $ref;
-    } else
+        return postProcessTr($language[$lang][$str]);
+    } else if (
+        isset($config['failoverLanguage'])
+        && isset($language[$config['failoverLanguage']][$str])
+        && $language[$config['failoverLanguage']][$str]
+    ) {
+        return postProcessTr($language[$config['failoverLanguage']][$str]);
+    } else {
         return "No translation available (identifier: $str)-todo";
+    }
 }
 
 function tr2($str, $lang)
 {
-    global $language;
-    load_language_file($lang);
+    global $language, $config;
+
+    if (!isset($language[$lang])) {
+        load_language_file($lang);
+    }
 
     if (@$language[$lang][$str]) {
-        $ref = &$language[$lang][$str];
-        if (strpos($ref, "{") !== false)
-            return tpl_do_replace($ref, true);
-        else
-            return $ref;
+        return postProcessTr($language[$lang][$str]);
+    } else if (
+        isset($config['failoverLanguage'])
+        && isset($language[$config['failoverLanguage']][$str])
+        && $language[$config['failoverLanguage']][$str]
+    ) {
+        return postProcessTr($language[$config['failoverLanguage']][$str]);
     } else {
         return $str . "No translation available (identifier: $str)-todo";
     }
@@ -51,4 +67,3 @@ function tr_available($str){
 
     return isset($language[$lang][$str]) && $language[$lang][$str];
 }
-

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -73,6 +73,7 @@ $config = array(
     'supportedLanguages' => array (
         'pl', 'en', 'nl', 'ro'
     ),
+    'failoverLanguage' => 'en',
     /** default country in user registration form */
     'defaultCountry' => 'PL',
 

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -73,7 +73,6 @@ $config = array(
     'supportedLanguages' => array (
         'pl', 'en', 'nl', 'ro'
     ),
-    'failoverLanguage' => 'en',
     /** default country in user registration form */
     'defaultCountry' => 'PL',
 


### PR DESCRIPTION
Adds the solution of failover english language to translations, that means if translation key is missing in currently selected language, the 'en' translations array is loaded if needed, checked for the key and if the key is not found there too, "No translation available(...)" is returned. Therefore adding new keys to every living translation file is no more necessary, providing the new keys are added to 'en' translation file. The missing keys can be added some time later.

The translations initialization has been moved from `common.inc.php` to `language.inc.php`, too.