### PR TITLE
GeoCacheCommons - corrected active status list, added visible status list

### DIFF
--- a/lib/Objects/GeoCache/GeoCacheCommons.php
+++ b/lib/Objects/GeoCache/GeoCacheCommons.php
@@ -385,8 +385,7 @@ class GeoCacheCommons extends BaseObject {
     }
 
     /**
-     * Returns comma separated list of cache status being active in play
-     * (not archived)
+     * Returns comma separated list of cache status being active (not archived)
      *
      * @return string cache status list, ready for use in SQL f.ex.
      */

--- a/lib/Objects/GeoCache/GeoCacheCommons.php
+++ b/lib/Objects/GeoCache/GeoCacheCommons.php
@@ -370,7 +370,23 @@ class GeoCacheCommons extends BaseObject {
     }
 
     /**
-     * Returns comma separated list of cache status being active
+     * Returns comma separated list of cache status being visible for common
+     * users
+     *
+     * @return string cache status list, ready for use in SQL f.ex.
+     */
+    public static function CacheVisibleStatusList()
+    {
+        return implode(', ', [
+            self::STATUS_READY,
+            self::STATUS_UNAVAILABLE,
+            self::STATUS_ARCHIVED
+        ]);
+    }
+
+    /**
+     * Returns comma separated list of cache status being active in play
+     * (not archived)
      *
      * @return string cache status list, ready for use in SQL f.ex.
      */
@@ -378,8 +394,7 @@ class GeoCacheCommons extends BaseObject {
     {
         return implode(', ', [
             self::STATUS_READY,
-            self::STATUS_UNAVAILABLE,
-            self::STATUS_ARCHIVED
+            self::STATUS_UNAVAILABLE
         ]);
     }
 


### PR DESCRIPTION
Poprawka do #1637.
Tym razem sprawdziłem dokładnie na devie działanie z keszem zarchiwizowanym i bez niego. Wrrr....
`CacheVisibleStatusList()` przewidziany do przyszłego wykorzystania, np. przy przewodnikach.