### PR TITLE
Admin panel: Do not print encoded json when status of PT is changed

### DIFF
--- a/powerTrail/ajaxUpdateStatus.php
+++ b/powerTrail/ajaxUpdateStatus.php
@@ -76,4 +76,8 @@ if($ptAPI::checkIfUserIsPowerTrailOwner($usr['userid'], $powerTrailId) == 1 || (
 $updateStatusResult['currentStatus'] = $powerTrail->getStatus();
 $updateStatusResult['currentStatusTranslation'] = $powerTrail->getStatusTranslation();
 
-print json_encode($updateStatusResult);
+if ($updateStatusResult['updateStatusResult']) {
+    print $updateStatusResult['currentStatusTranslation'];
+} else {
+    print $updateStatusResult['message'];
+}


### PR DESCRIPTION
On success print new status of power trail. If there was any error
during change print translated message.

Signed-off-by: Michał Żyłowski <czarodziej@mzylowski.pl>

Fixes #1563