### PR TITLE
1653 fix guides map without home coords

### DIFF
--- a/Controllers/GuideController.php
+++ b/Controllers/GuideController.php
@@ -40,8 +40,9 @@ class GuideController extends BaseController
         $this->view->loadJQuery();
 
         $mapModel = new DynamicMapModel();
-        if ($this->loggedUser->getHomeCoordinates()) {
-            $mapModel->setCoords($this->loggedUser->getHomeCoordinates());
+        $coords = $this->loggedUser->getHomeCoordinates();
+        if ($coords && $coords->getLatitude() && $coords->getLongitude()) {
+            $mapModel->setCoords($coords);
             $mapModel->setZoom(11);
         } else {
             $mapModel->setZoom($this->ocConfig->getMainPageMapZoom());

--- a/Controllers/GuideController.php
+++ b/Controllers/GuideController.php
@@ -41,7 +41,11 @@ class GuideController extends BaseController
 
         $mapModel = new DynamicMapModel();
         $coords = $this->loggedUser->getHomeCoordinates();
-        if ($coords && $coords->getLatitude() && $coords->getLongitude()) {
+        if (
+            $coords
+            && $coords->getLatitude() != null
+            && $coords->getLongitude() != null
+        ) {
             $mapModel->setCoords($coords);
             $mapModel->setZoom(11);
         } else {


### PR DESCRIPTION
Fast workaround on User::getHomeCoordinates() returning Coordinates object with null lat and lon if home is not set.
Fixes #1653