### PR TITLE
user role introduction

### DIFF
--- a/lib/Objects/User/User.php
+++ b/lib/Objects/User/User.php
@@ -25,6 +25,7 @@ class User extends UserCommons
     private $hiddenGeocachesCount;
     private $logNotesCount;
     private $email;
+    private $role;
 
     /** @var $homeCoordinates Coordinates */
     private $homeCoordinates;
@@ -292,6 +293,9 @@ class User extends UserCommons
                     break;
                 case 'notify_radius':
                     $this->notifyRadius = $value;
+                    break;
+                case 'role':
+                    $this->role = $value;
                     break;
                 case 'admin':
                     $this->isAdmin = boolval($value);

--- a/sqlAlters/2018-10-28_userRole.sql
+++ b/sqlAlters/2018-10-28_userRole.sql
@@ -1,0 +1,8 @@
+-- kojoty: new field in user table: role
+
+
+ALTER TABLE `user` ADD `role` SET('ocTeam','advUser','sysAdmin') NULL DEFAULT NULL 
+COMMENT 'role of the user: ocTeam|advUser (confidential users with access to tested func.)|sysAdmin (for admins only)' AFTER `email`, ADD INDEX `roleIndex` (`role`);
+
+-- add 'ocTeam' role to all admin users
+UPDATE user SET role = role|1 WHERE user.admin = 1;


### PR DESCRIPTION
@andrixnet @harrieklomp @deg-pl 
This PR contains sql-alter.
Please apply it to your DB.

This is introduction of the "role" for the user.
Every user has set of assigned "roles" - it means that ordinary user doesn't have any role - some user can have many of them.

I see three roles for now:
- **ocTeam member** - same as current 'admin' (replace "admin" column)
- **advanced user** - user with permissions to tested features etc. (for example to /test controller)
- **system admin** - user with permissions to further technical admin panels - I'd like use this role to limit access to for example APC interface etc.

Of course the list of roles can me modified in future, but this is not configurable between nodes now (all nodes have same roles).

In next PRs I delivered necessary code changes + admin column will be removed.
