### PR TITLE
Enable Okapi diagnostics for geopath search

### DIFF
--- a/Controllers/MainMapAjaxController.php
+++ b/Controllers/MainMapAjaxController.php
@@ -357,6 +357,7 @@ class MainMapAjaxController extends BaseController
              preg_match(self::GEOPATH_ID_REGEX, $_GET['csId']) ) {
 
                 $this->searchParams['powertrail_ids'] = $_GET['csId'];
+                $this->searchParams['ocpl_call'] = true;
         }
 
 


### PR DESCRIPTION
This enables Okapi developers to evaluate the usage of 'powertrail_ids' search parameter. If noone uses it except OCPL code, we can remove it from the public interface. See https://github.com/opencaching/okapi/issues/560 and https://github.com/opencaching/okapi/commit/e6a78302be86d1867d782d4b0da5e4f76e0dec70 for more information.