### PR TITLE
Update OKAPI-GPX options to resemble native OC GPX

### DIFF
--- a/tpl/stdstyle/js/okapiGpxFormatterWidget.js
+++ b/tpl/stdstyle/js/okapiGpxFormatterWidget.js
@@ -118,7 +118,7 @@
             params['ns_ox'] = "true";
         }
         if (formResponses['attrs_gcattrs']) {
-            tmp.push("gc:attrs");
+            tmp.push("gc_ocde:attrs");
         }
         if (tmp.length == 0) {
             params['attrs'] = "none";

--- a/tpl/stdstyle/js/okapiGpxFormatterWidget.template.html
+++ b/tpl/stdstyle/js/okapiGpxFormatterWidget.template.html
@@ -58,7 +58,7 @@
                     Should we include information about trackables (e.g. Geokrets) in geocache description?
                 </p>
                 <div><label>
-                    <input type='radio' name='trackables' value='none' checked="checked">
+                    <input type='radio' name='trackables' value='none'>
                     <span data-string-id="paramTrackables_none">
                         Don't include information on trackables.
                     </span>
@@ -73,6 +73,12 @@
                     <input type='radio' name='trackables' value='desc:list'>
                     <span data-string-id="paramTrackables_all">
                         Include a list of all trackables currently present inside the geocache.
+                    </span>
+                </label></div>
+                <div><label>
+                    <input type='radio' name='trackables' value='gc:travelbugs' checked="checked">
+                    <span data-string-id="paramTrackables_gc">
+                        Include all trackables like Groundspeak travelbugs.
                     </span>
                 </label></div>
             </section>
@@ -95,8 +101,7 @@
                 <div><label>
                     <input type='checkbox' name='attrs_gcattrs' checked="checked">
                     <span data-string-id="paramAttrs_gcattrs_HTML">
-                        Generate respective Groundspeak's <i>geocaching.com</i> attributes, if they apply
-                        (only a small subset of Opencaching attributes can be converted to Geocaching ones).
+                        Generate Groundspeak-like attributes.
                     </span>
                 </label></div>
             </section>


### PR DESCRIPTION
* Add an option to include trackables as `<groundspeak:travelbug>` elements, as the in the native OC GPX files.
* Add _all_ Opencaching attributes as `<groundspeak:attribute>` elements, instead of only those which also exist at GC.com.

The OKAPI parameter for the latter one is called "gc_ocde:attrs" for historical reasons. Originally it was only available for OCDE, but for a while now all OC sites include their attributes that way in native GPX.

Needs translation in okapiGpxFormatterWidget.pl.js.