### PR TITLE
phpinfo for sysAdmin panel

### DIFF
--- a/Controllers/SysController.php
+++ b/Controllers/SysController.php
@@ -53,5 +53,9 @@ class SysController extends BaseController
 
     }
 
+    public function phpinfo(){
+        phpinfo();
+    }
+
 }
 

--- a/tpl/stdstyle/sysAdmin/index.tpl.php
+++ b/tpl/stdstyle/sysAdmin/index.tpl.php
@@ -1,6 +1,10 @@
+<?php
+use Utils\Uri\SimpleRouter;
+?>
 <h1>Sysadmin panels</h1>
 <div>
   <ul>
-    <li><h3><a href="/sys/apc">APC</a></h3></li>
+    <li><h3><a href="<?=SimpleRouter::getLink('sys','apc')?>">APC</a></h3></li>
+    <li><h3><a href="<?=SimpleRouter::getLink('sys','phpinfo')?>">PHP-INFO</a></h3></li>
   </ul>
 </div>


### PR DESCRIPTION
@andrixnet , @harrieklomp, @deg-pl 

It would be great if you add me sysAdmin role (access to this sysAdmin panel) at your nodes
My account is kojotyPL for both: OCNL and OCRO

It can be possible that after merge it is needed to reset APC cache or I would like to check details of server configuration from php_info..

