### PR TITLE
add OKAPI font path setting

### DIFF
--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -271,6 +271,7 @@ $config['oc']['limits']['notification_radius'] = 150;
 
 $config['okapi']['data_license_url'] = 'http://wiki.opencaching.pl/index.php/OC_PL_Conditions_of_Use';
 $config['okapi']['admin_emails'] = false;
+$config['okapi']['tilemap_font_path'] = null;
 // $config['okapi']['admin_emails'] = array('rygielski@mimuw.edu.pl', 'following@online.de');
 
 // Number of minutes to edit cache log without increment the "edit_count" field. Usefull eg. to correct spelling errors.

--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -47,6 +47,7 @@ function get_okapi_settings()
         'SITELANG' => $lang,
         'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
         'VAR_DIR' => rtrim($dynbasepath, '/'),
+        'TILEMAP_FONT_PATH' => $config['okapi']['tilemap_font_path'],
         'IMAGES_DIR' => rtrim($picdir, '/'),
         'IMAGES_URL' => rtrim($picurl, '/').'/',
         'IMAGE_MAX_UPLOAD_SIZE' => $config['limits']['image']['filesize'] * 1024 * 1024,


### PR DESCRIPTION
Fix for map display on my OCPL devel site.

Files reside on a CIFS mount, which is incompatible with PHP `imagettfbbox()`. Need to put the font file somewhere else.

This also allows to customize the font for cache names on the map.