### PR TITLE
Add OKAPI signalling cronjob

### DIFF
--- a/Controllers/Cron/OkapiController.php
+++ b/Controllers/Cron/OkapiController.php
@@ -1,0 +1,62 @@
+<?php
+namespace Controllers\Cron;
+
+use Controllers\BaseController;
+use lib\Controllers\MeritBadgeController;
+use lib\Objects\GeoCache\GeoCache;
+use okapi\Facade;
+
+class OkapiController extends BaseController
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function isCallableFromRouter($actionName)
+    {
+        // This controller is used by cron only - router shouldn't call it!
+        return false;
+    }
+
+    public function index()
+    {
+        // The OKAPI signal processing is reentrant - we don't need a lock.
+        $this->process_signals();
+    }
+
+    private function process_signals()
+    {
+        # Do 10 signals each. If the external altitude fetcher is slow,
+        # this will speed up things by running multiple cronjob instances
+        # simultaneously.
+
+        while ($signals = Facade::fetch_signals(10)) {
+            foreach ($signals as $signal) {
+                switch ($signal['type']) {
+
+                    case 'log-merit-badges':
+                        $cacheId = $signal['payload']['cache_id'];
+                        $userId = $signal['payload']['user_id'];
+
+                        $ctrlMeritBadge = new MeritBadgeController;
+                        $ctrlMeritBadge->updateTriggerLogCache($cacheId, $userId);
+                        $ctrlMeritBadge->updateTriggerTitledCache($cacheId, $userId);
+                        $ctrlMeritBadge->updateTriggerCacheAuthor($cacheId);
+
+                        Facade::signals_done([$signal]);
+                        break;
+
+                    case 'cache-altitude':
+                        $cacheId = $signal['payload']['cache_id'];
+
+                        $geoCache = GeoCache::fromCacheIdFactory($cacheId);
+                        $geoCache->updateAltitude();
+
+                        Facade::signals_done([$signal]);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/docs/crontabs/cron-job-list
+++ b/docs/crontabs/cron-job-list
@@ -32,6 +32,9 @@
 # in okapi/cronjobs.php for more information.
 */5  *   *   *   *   wget -O - -q -t 1 https://opencaching.pl/okapi/cron5
 
+# OKAPI signalling cronjob, updates merit badges etc.
+*/5  *   *   *   *   /home/ocpl/cron-defs/do-wget-url   util.sec/okapi/okapi_cronjob.php  okapi_cronjob.html
+
 # Database maintanance
 10   6   *   *   *   /home/ocpl/cron-defs/do-mysql-flush
 

--- a/util.sec/okapi/okapi_cronjob.php
+++ b/util.sec/okapi/okapi_cronjob.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Does OKAPI housekeeping, should be run in short intervals from cron.
+ */
+use Controllers\Cron\OkapiController;
+
+require_once (__DIR__.'/../../lib/common.inc.php');
+
+$ctrl = new OkapiController();
+$ctrl->index();
+exit();


### PR DESCRIPTION
This is a proposal to fix https://github.com/opencaching/okapi/issues/552 - update merit badges when users submit OKAPI logs. Also, it prepares editing cache coordinates via OKAPI, by doing the altitude calculation. And allows to add future "OKAPI->OCPL housekeeping" jobs.

Advantages:
* No redundant logic in OKAPI for merit badges etc.
* No code dependencies - if OCPL developers want to change the MeritBadgeController interface, this can be done independently from OKAPI code.
* Allows to change cache coordinates without having to wait for the external altitude provider. (This feature could also be provided via Facade, if needed.)

Disadvantages:
* The changes are not updated immediately, but with a time lag of some minutes by a cronjob.

The OKAPI side is already implemented and active. At OCPL sites, the following cronjob would be added:

`*/5 * * * * php /var/www/html/ocpl/util.sec/okapi/okapi_cronjob.php`
(or wherever the file is located.)

OKAPI stores the update reqests e.g. for merit badges in the `okapi_signals` table, and the new OCPL `OkapiController` cronjob reads and executes them.