### PR TITLE
use configured default languages for GPX

### DIFF
--- a/lib/Objects/GeoCache/GeoCache.php
+++ b/lib/Objects/GeoCache/GeoCache.php
@@ -1127,24 +1127,26 @@ class GeoCache extends GeoCacheCommons
     }
 
     /**
-     * This function is moved from clicompatbase
+     * Sets the language for GPX download of this cache.
+     *
      * @param int $cacheid
      */
     public static function setCacheDefaultDescLang($cacheid)
     {
+        global $config;
 
-        $r['desc_languages'] = XDb::xMultiVariableQueryValue(
+        $descLanguages = XDb::xMultiVariableQueryValue(
             "SELECT `desc_languages` FROM `caches`
-            WHERE `cache_id`= :1 LIMIT 1", null, $cacheid);
+            WHERE `cache_id`= :1 LIMIT 1", null, $cacheid
+        );
+        $desclang = mb_substr($descLanguages, 0, 2);
 
-        if (mb_strpos($r['desc_languages'], 'PL') !== false)
-            $desclang = 'PL';
-        else if (mb_strpos($r['desc_languages'], 'EN') !== false)
-            $desclang = 'EN';
-        else if ($r['desc_languages'] == '')
-            $desclang = '';
-        else
-            $desclang = mb_substr($r['desc_languages'], 0, 2);
+        foreach ($config['defaultLanguageList'] as $lang) {
+            if (mb_strpos($descLanguages, $lang) !== false) {
+                $desclang = $lang;
+                break;
+            }
+        }
 
         XDb::xSql(
             "UPDATE `caches` SET

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -63,7 +63,7 @@ $config = array(
      * mainly for MSIE
      */
     'headerFavicon' => 'oc_icon.png',
-    /** Language list for new caches */
+    /** Language list for new caches and for GPX */
     'defaultLanguageList' => array(
         'PL', 'EN', 'FR', 'DE', 'NL', 'RO'
     ),

--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -45,6 +45,7 @@ function get_okapi_settings()
         'DB_USERNAME' => $dbusername,
         'DB_PASSWORD' => $dbpasswd,
         'SITELANG' => $lang,
+        'SITELANGS' => array_map('strtolower', $config['defaultLanguageList']),
         'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
         'VAR_DIR' => rtrim($dynbasepath, '/'),
         'TILEMAP_FONT_PATH' => $config['okapi']['tilemap_font_path'],


### PR DESCRIPTION
Sets `caches.default_desclang` from `config['defaultLanguageList']` instead of PL, EN. This field controls the language of GPX download.