### PR TITLE
Proposal: public cronjob schedule

### DIFF
--- a/Controllers/Cron/CronAdminController.php
+++ b/Controllers/Cron/CronAdminController.php
@@ -21,16 +21,16 @@ class CronAdminController extends BaseController
 
     public function index()
     {
-        $this->securityCheck();
-
-        $this->showCronAdmin();
+        if ($this->isUserLogged()) {
+            $this->showCronAdmin();
+        } else {
+            $this->view->redirect('/');
+        }
     }
 
     public function run($job = null)
     {
-        $this->securityCheck();
-
-        if ($job) {
+        if ($job && $this->allowRun()) {
             $this->runJob($job);
         }
         $this->view->redirect(SimpleRouter::getLink('Cron.CronAdmin'));
@@ -40,6 +40,7 @@ class CronAdminController extends BaseController
     {
         $cronJobs = new CronJobsController();
         $this->view->setVar('jobs', $cronJobs->getScheduleStatus());
+        $this->view->setVar('allowRun', $this->allowRun());
         $this->view->setTemplate('sysAdmin/cronAdmin');
         $this->view->buildView();
     }
@@ -50,11 +51,8 @@ class CronAdminController extends BaseController
         $cronJobs->index();
     }
 
-    private function securityCheck()
+    private function allowRun()
     {
-        if (!$this->isUserLogged() || !$this->loggedUser->hasSysAdminRole()) {
-            $this->view->redirect('/');
-            exit();
-        }
+        return $this->isUserLogged() && $this->loggedUser->hasSysAdminRole();
     }
 }

--- a/Controllers/Cron/CronAdminController.php
+++ b/Controllers/Cron/CronAdminController.php
@@ -28,14 +28,18 @@ class CronAdminController extends BaseController
     public function run($job = null)
     {
         if ($job && $this->allowRun()) {
+            ob_start();
             $this->runJob($job);
+            $this->showCronAdmin(ob_get_clean());
+        } else {
+            $this->view->redirect(SimpleRouter::getLink('Cron.CronAdmin'));
         }
-        $this->view->redirect(SimpleRouter::getLink('Cron.CronAdmin'));
     }
 
-    private function showCronAdmin()
+    private function showCronAdmin($message = '')
     {
         $cronJobs = new CronJobsController();
+        $this->view->setVar('message', $message);
         $this->view->setVar('jobs', $cronJobs->getScheduleStatus());
         $this->view->setVar('allowRun', $this->allowRun());
         $this->view->setTemplate('sysAdmin/cronAdmin');

--- a/Controllers/Cron/CronAdminController.php
+++ b/Controllers/Cron/CronAdminController.php
@@ -21,11 +21,8 @@ class CronAdminController extends BaseController
 
     public function index()
     {
-        if ($this->isUserLogged()) {
-            $this->showCronAdmin();
-        } else {
-            $this->view->redirect('/');
-        }
+        $this->redirectNotLoggedUsers();
+        $this->showCronAdmin();
     }
 
     public function run($job = null)

--- a/tpl/stdstyle/sysAdmin/cronAdmin.tpl.php
+++ b/tpl/stdstyle/sysAdmin/cronAdmin.tpl.php
@@ -7,6 +7,9 @@ use Utils\Uri\SimpleRouter;
     <div class="content2-pagetitle">
         {{admin_cron_title}}
     </div>
+    <p>
+        <?= $view->message ?>
+    </p>
     <table class="table table-striped full-width">
         <tr>
             <th>{{admin_cron_lbl_job}}</th>

--- a/tpl/stdstyle/sysAdmin/cronAdmin.tpl.php
+++ b/tpl/stdstyle/sysAdmin/cronAdmin.tpl.php
@@ -12,7 +12,7 @@ use Utils\Uri\SimpleRouter;
             <th>{{admin_cron_lbl_job}}</th>
             <th>{{admin_cron_lbl_schedule}}</th>
             <th>{{admin_cron_lbl_lastrun}}</th>
-            <th>{{action}}</th>
+            <?php if ($view->allowRun) { ?><th>{{action}}</th><?php } ?>
         </tr>
 <?php foreach ($view->jobs as $jobName => $jobData) { ?>
         <tr>
@@ -26,13 +26,15 @@ use Utils\Uri\SimpleRouter;
                     <?= substr($jobData['lastRun'], 11, 8) ?>
                 <?php } ?>
             </td>
-            <td>
-                <?php if ($jobData['mayRunNow']) { ?>
-                    <a href="<?=SimpleRouter::getLink('Cron.CronAdmin', 'run', $jobName) ?>">
-                        {{admin_cron_run_now}}
-                    </a>
-                <?php } ?>
-            </td>
+            <?php if ($view->allowRun) { ?>
+                <td>
+                    <?php if ($jobData['mayRunNow']) { ?>
+                        <a href="<?=SimpleRouter::getLink('Cron.CronAdmin', 'run', $jobName) ?>">
+                            {{admin_cron_run_now}}
+                        </a>
+                    <?php } ?>
+                </td>
+            <?php } ?>
         </tr>
 <?php } ?>
     </table>


### PR DESCRIPTION
The cron schedule does not contain any sensitive information. It can by interesting for any developer and even for users when the jobs will run or did run.

So I suggest to make the cron admin page public at least for logged-in users, and only restrict _running_ jobs to sysAdmins.