### PR TITLE
Fix for 'runwatch14'

### DIFF
--- a/powerTrail/candidateEmail.html
+++ b/powerTrail/candidateEmail.html
@@ -32,7 +32,7 @@
         <p>{pt189} <a href="{absolute_server_URI}viewprofile.php?userid={userId}">{userName}</a>. </p>
         <hr />
         <p style="font-size: 10px; font-family: Verdana;">
-            {runwatch14}!
+            {mail_auto_generated}!
         </p>
 
     </body>

--- a/powerTrail/commentEmail.html
+++ b/powerTrail/commentEmail.html
@@ -33,7 +33,7 @@
         </p>
         <hr />
         <p style="font-size: 10px; font-family: Verdana;">
-            {runwatch14}!
+            {mail_auto_generated}!
         </p>
 
     </body>

--- a/powerTrail/sendEmail.php
+++ b/powerTrail/sendEmail.php
@@ -49,7 +49,7 @@ class sendEmail
             $usr['userid'] = -1;
         if (!isset($usr['username']))
             $usr['username'] = 'SYSTEM';
-        $mailbody = mb_ereg_replace('{runwatch14}', tr('runwatch14'), $mailbody);
+        $mailbody = mb_ereg_replace('{mail_auto_generated}', tr('mail_auto_generated'), $mailbody);
         $mailbody = mb_ereg_replace('{commentDateTime}', date($siteDateTimeFormat, strtotime($commentDateTime)), $mailbody);
         $mailbody = mb_ereg_replace('{userId}', $usr['userid'], $mailbody);
         $mailbody = mb_ereg_replace('{userName}', $usr['username'], $mailbody);

--- a/powerTrail/sendEmailCacheCandidate.php
+++ b/powerTrail/sendEmailCacheCandidate.php
@@ -34,7 +34,7 @@ function emailCacheOwner($ptId, $cacheId, $linkCode){
     $mailbody = mb_ereg_replace('{userName}', $usr['username'], $mailbody);
     $mailbody = mb_ereg_replace('{absolute_server_URI}', $absolute_server_URI, $mailbody);
     $mailbody = mb_ereg_replace('{linkCode}', $linkCode, $mailbody);
-    $mailbody = mb_ereg_replace('{runwatch14}', tr('runwatch14'), $mailbody);
+    $mailbody = mb_ereg_replace('{mail_auto_generated}', tr('mail_auto_generated'), $mailbody);
     $mailbody = mb_ereg_replace('{cacheWaypoint}', $cacheData['wp_oc'], $mailbody);
     $mailbody = mb_ereg_replace('{pt183}', tr('pt183'), $mailbody);
     $mailbody = mb_ereg_replace('{pt184}', tr('pt184'), $mailbody);


### PR DESCRIPTION
Replaced 'runwatch14 'with 'mail_auto_generated'.
Both had same text: This message is auto-generated - please do not reply.