### PR TITLE
Add global error handler; rebase PDO error handling on that

### DIFF
--- a/Utils/Database/OcDb.php
+++ b/Utils/Database/OcDb.php
@@ -44,7 +44,7 @@ class OcDb extends OcPdo
             }
         }
 
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
     /**
@@ -61,7 +61,7 @@ class OcDb extends OcPdo
 
             return $result;
         }
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
     /**
@@ -109,7 +109,7 @@ class OcDb extends OcPdo
             return $result;
         }
 
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
     /**
@@ -149,7 +149,7 @@ class OcDb extends OcPdo
             return $result;
         }
 
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
     /**
@@ -170,7 +170,7 @@ class OcDb extends OcPdo
             return $result;
         }
 
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
 
@@ -212,7 +212,7 @@ class OcDb extends OcPdo
             return $stmt->rowCount();
         }
 
-        $this->error('', new PDOException(__METHOD__.': call PDOstatement issue!'));
+        $this->error('Call PDOstatement issue!');
     }
 
     /**
@@ -233,8 +233,6 @@ class OcDb extends OcPdo
         } catch (PDOException $e) {
 
             $this->error('Query: '.$query, $e);
-
-            return null;
         }
 
         if ($this->debug) {
@@ -329,8 +327,6 @@ class OcDb extends OcPdo
         } catch (PDOException $e) {
 
             $this->error("Query:\n$query\n\nParams:\n".implode(' | ', $params), $e);
-
-            return null;
         }
         if ($this->debug) {
             self::debugOut(__METHOD__.":\n\nQuery:\n$query\n\nParams:\n".implode(' | ', $params));
@@ -397,8 +393,6 @@ class OcDb extends OcPdo
         } catch (PDOException $e) {
             $message = 'Query|Params: '.$query.' | '.implode(' | ', $argList);
             $this->error($message, $e);
-
-            return null;
         }
 
         if ($this->debug) {
@@ -428,10 +422,8 @@ class OcDb extends OcPdo
         if ($numArgs <= 2) {
 
             //only query + default value=> use simpleQuery
-            $e = new PDOException('Improper using of '.__METHOD__.' . Too less arguments. Use simpleQueryValue() instead');
-            $this->error('Improper using of '.__METHOD__, $e, false, false); //skip sending email
+            $this->error('Improper use of '.__METHOD__.': Too few arguments. Use simpleQueryValue() instead.');
 
-            return $this->simpleQueryValue($query, $default);
         } else {
             // check if params are passed as array
             if ($numArgs == 3 && is_array($argList[2])) {

--- a/Utils/Database/OcPdo.php
+++ b/Utils/Database/OcPdo.php
@@ -56,13 +56,13 @@ class OcPdo extends PDO
         }
 
         $dsn = 'mysql:' . implode(';', $dsnpairs);
-        try{
+        try {
             parent::__construct(
                 $dsn, $conf->getDbUser(), $conf->getDbPass(), $options
             );
-        }catch (PDOException $e){
+        } catch (PDOException $e) {
             $message = "OcPdo object creation failed!";
-            $this->error($message, $e, true); //fatal error!
+            $this->error($message, $e);
             return null;
         }
     }
@@ -72,49 +72,15 @@ class OcPdo extends PDO
      *
      * @param string $message - description of the error
      * @param PDOException $e - exception object
-     * @param bool $fatal     - should this error shutdown the script?
-     * @param bool $sendEmail - should Email about error should be send?
      */
-    protected function error(/*PHP7:string*/ $message, PDOException $e=null,
-                             /*PHP7:bool*/ $fatal=false, /*PHP7:bool*/ $sendEmail=true){
-
-        $email_text  = "+++ PDO Error +++ ";
-        $email_text .= "\n+++ Debug: ".$message;
-        if( !is_null($e) ){
-            $email_text .= "\n+++ Ex_Code: ".$e->getCode();
-            $email_text .= "\n+++ Ex_Msg: ".$e->getMessage();
-        }else{
-            //there is no Exception - generate one to get the trace
-            $e = new PDOException();
-        }
-        $email_text .= "\n+++ Ex_Trace:\n".$e->getTraceAsString();
-
-        //get short version of the trace
-        $traceStr = '';
-        foreach($e->getTrace() as $trace){
-            if(isset($trace['file']) && isset($trace['line'])){
-                $traceStr.= ' | '.$trace['file'].'::'.$trace['line'];
-            }
-        }
-
-        //send email to RT
-        if($sendEmail)
-            EmailSender::adminOnErrorMessage($email_text, OcSpamDomain::DB_ERRORS);
-
-        if($this->debug){
-            d($email_text);
-        }
-
-        if($fatal){
-            // TODO: How to better handle error - print some nice error page
-            // this is fatal error - stop the script
-            trigger_error("OcPdo Error:\n $message. Trace: ".$traceStr, E_USER_ERROR);
-            error_log("Db message:".$e->getMessage());
-            exit;
-        }else{
-            // non-fatal error: only print warning
-            trigger_error("OcPdo Error: $message. Trace: ".$traceStr, E_USER_WARNING);
-            error_log("Db message:".$e->getMessage());
+    protected function error(/*PHP7:string*/ $message, PDOException $e = null)
+    {
+        if ($e === null) {
+            throw new PDOException($message);
+        } elseif ($message != '') {
+            throw new PDOException($message . "\n" . $e->getMessage());
+        } else {
+            throw $e;
         }
     }
 

--- a/Utils/Database/OcPdo.php
+++ b/Utils/Database/OcPdo.php
@@ -61,27 +61,25 @@ class OcPdo extends PDO
                 $dsn, $conf->getDbUser(), $conf->getDbPass(), $options
             );
         } catch (PDOException $e) {
-            $message = "OcPdo object creation failed!";
-            $this->error($message, $e);
-            return null;
+            $this->error("OcPdo object creation failed!", $e);
         }
     }
 
     /**
-     * Handle error/exception occurence around DB operations
+     * Process error/exception occurence around DB operations
      *
      * @param string $message - description of the error
-     * @param PDOException $e - exception object
+     * @param PDOException|null $e - exception object
      */
     protected function error(/*PHP7:string*/ $message, PDOException $e = null)
     {
         if ($e === null) {
             throw new PDOException($message);
-        } elseif ($message != '') {
-            throw new PDOException($message . "\n" . $e->getMessage());
-        } else {
-            throw $e;
         }
+        if ($message != '') {
+            throw new PDOException($message . "\n" . $e->getMessage());
+        }
+        throw $e;
     }
 
     /**

--- a/Utils/Debug/ErrorHandler.php
+++ b/Utils/Debug/ErrorHandler.php
@@ -29,8 +29,8 @@ class ErrorHandler
     {
         if ($severity != E_STRICT && $severity != E_DEPRECATED) {
 
-            // Map error / warning / notice to exception, which will be handled
-            // by self::handleException().
+            // Map error / warning / notice to exception, which will either
+            // get caught or be handled by self::handleException().
 
             throw new \ErrorException($message, 0, $severity, $filename, $lineno);
         }
@@ -119,8 +119,17 @@ class ErrorHandler
                     : 'The OC site admins have been notified.';
                 $mainPageLinkTitle = 'Go to the main page'; 
             }
-            $showMainPageLink = basename(@$_SERVER["SCRIPT_FILENAME"]) != 'index.php';
+
+            if (isset($_SERVER["SCRIPT_FILENAME"])) {
+                $showMainPageLink = basename($_SERVER["SCRIPT_FILENAME"]) != 'index.php';
+            } else {
+                $showMainPageLink = false;
+            }
+
             $errorMsg = ($debug_page ? $msg : '');
+
+            // No calls to tpl_ or View:: here, to avoid generating an error
+            // within the error handler (code may be unstable).
 
             include __DIR__ . '/../../tpl/stdstyle/page_error.tpl.php';
         }

--- a/Utils/Debug/ErrorHandler.php
+++ b/Utils/Debug/ErrorHandler.php
@@ -27,7 +27,9 @@ class ErrorHandler
      */
     public static function handleError($severity, $message, $filename, $lineno)
     {
-        if ($severity != E_STRICT && $severity != E_DEPRECATED) {
+        if ($severity != E_STRICT && $severity != E_DEPRECATED &&
+            error_reporting() > 0  // is 0 if suppressed by @ operator
+        ) {
 
             // Map error / warning / notice to exception, which will either
             // get caught or be handled by self::handleException().

--- a/Utils/Debug/ErrorHandler.php
+++ b/Utils/Debug/ErrorHandler.php
@@ -1,0 +1,128 @@
+<?php
+namespace Utils\Debug;
+
+use lib\Objects\OcConfig;
+use Utils\Email\EmailSender;
+
+class ErrorHandler
+{
+    /** Failsafe flag to avoid duplicate error handling **/
+    private static $errorHandled = false;
+
+    /**
+     * Install error and exception handlers; must be called once upon startup,
+     * as early as possible.
+     */
+    public static function install()
+    {
+        register_shutdown_function([__CLASS__, 'handleFatalError']);
+        set_exception_handler([__CLASS__, 'handleException']);
+        set_error_handler([__CLASS__, 'handleError']);
+    }
+
+    /**
+     * Error handler callback; called for all non-fatal PHP errors, warnings
+     * and notices that are no exceptions, e.g. division by zero or reference
+     * of undefined variable.
+     */
+    public static function handleError($severity, $message, $filename, $lineno)
+    {
+        if ($severity != E_STRICT && $severity != E_DEPRECATED) {
+
+            // Map error / warning / notice to exception, which will be handled
+            // by self::handleException().
+
+            throw new \ErrorException($message, 0, $severity, $filename, $lineno);
+        }
+    }
+
+    /**
+     * Exception handler callback; called for all exceptions that are not
+     * handled by a catch {}.
+     */
+    public static function handleException($e)
+    {
+        self::$errorHandled = true;
+        self::processError(
+            get_class($e).": " . $e->getMessage() . "\n\n" . $e->getTraceAsString()
+        );
+    }
+
+    /**
+     * Shutdown callback; called on script termination; handles all fatal
+     * PHP errors except E_PARSE (which cannot be caught in PHP code).
+     */
+    public static function handleFatalError()
+    {
+        if (!self::$errorHandled &&
+            ($error = error_get_last()) &&
+            in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR])
+        ) {
+            self::$errorHandled = true;
+            self::processError(
+                'Fatal error ' . $error['message'] .
+                ' at line ' . $error['line'] . ' of ' . $error['file']
+            );
+        }
+    }
+
+    private static function processError($msg)
+    {
+        global $debug_page;
+
+        // Try to send an admin email
+
+        $mailFail = false;
+        try {
+            EmailSender::adminOnErrorMessage($msg);
+
+        } catch (\Exception $e) {
+            try {
+                mail(
+                    OcConfig::getTechAdminsEmailAddr(),
+                    "OC site error",
+                    $msg
+                );
+            } catch (\Exception $e) {
+                try {
+                    mail("root@localhost", "OC site error", $msg);
+                } catch (\Exception $e) {
+                    $mailFail = true;
+                }
+            }
+        }
+
+        // Try to log error
+
+        try {
+            Debug::errorLog($msg);
+        } catch (\Exception $e) {
+            // logging failed
+        }
+
+        // Output error message
+
+        if (PHP_SAPI == "cli") {
+            echo $msg . "\n";
+        } else {
+            try {
+                $pageError = tr('page_error_1') . ' ';
+                $pageError .= tr($mailFail ? 'page_error_3' : 'page_error_2');
+                $mainPageLinkTitle = tr('page_error_back');
+
+            } catch (\Exception $e) {
+                $pageError = 'An error occured while processing your request. ';
+                $pageError .=
+                    $mailFail
+                    ? 'If the problem persists, please <a href="/articles.php?page=contact">contact</a> ' .
+                      'the OC team and describe step by step how to reproduce this error.'
+                    : 'The OC site admins have been notified.';
+                $mainPageLinkTitle = 'Go to the main page'; 
+            }
+            $showMainPageLink = basename(@$_SERVER["SCRIPT_FILENAME"]) != 'index.php';
+            $errorMsg = ($debug_page ? $msg : '');
+
+            include __DIR__ . '/../../tpl/stdstyle/page_error.tpl.php';
+        }
+    }
+}

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -2,9 +2,12 @@
 
 require_once __DIR__ . '/ClassPathDictionary.php'; // class autoloader
 
+use Utils\Debug\ErrorHandler;
 use Utils\View\View;
 use lib\Objects\User\UserAuthorization;
 use lib\Objects\OcConfig\OcConfig;
+
+ErrorHandler::install();
 
 session_start();
 

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2672,4 +2672,8 @@ $translations = array(
 
     'pictures_intro' => 'Permitted image formats: {picallowedformats}. JPG works best for photos.<br />Maximum allowed size is {maxpicsizeMB} MB. Recommended resolution: {maxpicresolution} pixels.',
 
+    'page_error_1' => 'An error occured while processing your request.',
+    'page_error_2' => 'The OC site admins have been notified.',
+    'page_error_3' => 'If the problem persists, please <a href="/articles.php?page=contact">contact</a> the OC team and describe step by step how to reproduce this error.',
+    'page_error_back' => 'Go to the main page',
 );

--- a/tpl/stdstyle/page_error.tpl.php
+++ b/tpl/stdstyle/page_error.tpl.php
@@ -1,0 +1,30 @@
+<?php
+
+// Do not reference any other PHP items here except the variables set in
+// ErrorHandler::processErrorMsg(), to minimize the risk of error recursion.
+
+?><!DOCTYPE html>
+<html>
+<head>
+    <title>Opencaching - Error</title>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/images/oc_icon.png" />
+    <link rel="apple-touch-icon-precomposed" href="/images/oc_logo_144.png" />
+    <link rel="stylesheet" type="text/css" media="screen" href="/tpl/stdstyle/css/style_screen.css" />
+</head>
+<body style="margin:20px 40px 0 40px; background:white">
+    <a href="/"><img src="/images/oc_logo.png" /></a>
+    <br />
+    <p style="font-size:1.4em; max-width:720px">
+        <br /><?= $pageError ?>
+    </p>
+    <?php if ($showMainPageLink) { ?>
+        <p><a href="/"><?= $mainPageLinkTitle ?></a></p>
+    <?php } ?>
+    <?php if ($errorMsg) { ?>
+        <br />
+        <p><b>--- Additional Information for developers, only displayed if $debug_page is true ---</b></p>
+        <p><?= nl2br($errorMsg) ?></p>
+    <?php } ?>
+</body>
+</html>


### PR DESCRIPTION
This implements error handling as proposed in https://github.com/opencaching/opencaching-pl/issues/1792#issuecomment-450436586. It will handle anything except PHP syntax errors (E_PARSE), which cannot be caught.