### PR TITLE
migrate APC to APCu

### DIFF
--- a/Utils/Text/UserInputFilter.php
+++ b/Utils/Text/UserInputFilter.php
@@ -87,7 +87,7 @@ class UserInputFilter
 
         // we observed some rare apcu bugs(?) where there is null returned here
         if ( is_null($result) ) {
-//            error_log (__METHOD__.': APCU BUG?! apc_fetch returns null');
+//            error_log (__METHOD__.': APCU BUG?! apcu_fetch returns null');
             $result = false;
         }
 

--- a/lib/search-signatures.inc.php
+++ b/lib/search-signatures.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use Utils\Cache\OcMemCache;
+
 global $usr;
 
 /**
@@ -44,7 +46,11 @@ class requestSigner
                 $signature = sprintf('%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(16384, 20479), mt_rand(32768, 49151), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535));
                 $_SESSION['signature'] = $signature;
             }
-            apcu_store($signature, $usr, 3600);  # cache it for 1 hour
+            OcMemCache::store(
+                $signature,
+                3600,  # cache it for 1 hour
+                $usr
+            );
             return '&signature=' . $signature;
         } else {
             return '';
@@ -69,14 +75,12 @@ class requestSigner
         }
         if (isset($_GET['signature'])) {
             $signature = $_GET['signature'];
-            $user = apcu_fetch($signature);
+            $user = OcMemCache::get($signature);
             if ($user) {
-                $usr = $user;
+                return $user;
             }
         }
-        return $usr;
+        return false;
     }
 
 }
-
-

--- a/lib/search-signatures.inc.php
+++ b/lib/search-signatures.inc.php
@@ -69,7 +69,7 @@ class requestSigner
         }
         if (isset($_GET['signature'])) {
             $signature = $_GET['signature'];
-            $user = apc_fetch($signature);
+            $user = apcu_fetch($signature);
             if ($user) {
                 $usr = $user;
             }

--- a/tpl/stdstyle/articles/s2.tpl.php
+++ b/tpl/stdstyle/articles/s2.tpl.php
@@ -10,6 +10,7 @@
         <td>
 <?php
 use Utils\Database\XDb;
+use Utils\Cache\OcMemCache;
 global $lang;
 
 $userscount = XDb::xSimpleQueryValue(
@@ -81,7 +82,7 @@ $cachelogscount = XDb::xSimpleQueryValue(
     }
 
     $cache_key = 'articles_s2'.md5($a);
-    $lines = apcu_fetch($cache_key);
+    $lines = OcMemCache::get($cache_key);
 
     if ($lines === false) {
         $r = XDb::xSql( $a );
@@ -92,7 +93,7 @@ $cachelogscount = XDb::xSimpleQueryValue(
         }
 
         unset($r);
-        apcu_store($cache_key, $lines, 3600);
+        OcMemCache::store($cache_key, 3600, $lines);
     }
 
     echo "<br />";

--- a/tpl/stdstyle/articles/s2.tpl.php
+++ b/tpl/stdstyle/articles/s2.tpl.php
@@ -81,7 +81,7 @@ $cachelogscount = XDb::xSimpleQueryValue(
     }
 
     $cache_key = 'articles_s2'.md5($a);
-    $lines = apc_fetch($cache_key);
+    $lines = apcu_fetch($cache_key);
 
     if ($lines === false) {
         $r = XDb::xSql( $a );
@@ -92,7 +92,7 @@ $cachelogscount = XDb::xSimpleQueryValue(
         }
 
         unset($r);
-        apc_store($cache_key, $lines, 3600);
+        apcu_store($cache_key, $lines, 3600);
     }
 
     echo "<br />";

--- a/tpl/stdstyle/articles/s7.tpl.php
+++ b/tpl/stdstyle/articles/s7.tpl.php
@@ -11,13 +11,16 @@
         <?php
 
 use Utils\Database\XDb;
+use Utils\Cache\OcMemCache;
 global $lang;
 
 # This page took >60 seconds to render! Added daily caching.
 
-$cache_key = "articles_s7-" . $lang;
-$result = apcu_fetch($cache_key);
-if ($result === false) {
+$result = OcMemCache::getOrCreate(
+    "articles_s7-" . $lang,
+    86400,
+function ()
+{
     ob_start();
 
     $rsUs["count"] = XDb::xSimpleQueryValue(
@@ -69,12 +72,10 @@ if ($result === false) {
 
     XDb::xFreeResults($rsfCR);
 
-    $result = ob_get_clean();
-    apcu_store($cache_key, $result, 86400);
-}
+    return ob_get_clean();
+});
+
 print $result;
-
-
 
         ?>
         </td></tr>

--- a/tpl/stdstyle/articles/s7.tpl.php
+++ b/tpl/stdstyle/articles/s7.tpl.php
@@ -16,7 +16,7 @@ global $lang;
 # This page took >60 seconds to render! Added daily caching.
 
 $cache_key = "articles_s7-" . $lang;
-$result = apc_fetch($cache_key);
+$result = apcu_fetch($cache_key);
 if ($result === false) {
     ob_start();
 
@@ -70,7 +70,7 @@ if ($result === false) {
     XDb::xFreeResults($rsfCR);
 
     $result = ob_get_clean();
-    apc_store($cache_key, $result, 86400);
+    apcu_store($cache_key, $result, 86400);
 }
 print $result;
 

--- a/tpl/stdstyle/articles/s8.tpl.php
+++ b/tpl/stdstyle/articles/s8.tpl.php
@@ -14,7 +14,7 @@ global $lang;
 # This page took >60 seconds to render! Added daily caching.
 
 $cache_key = "articles_s8-" . $lang;
-$result = apc_fetch($cache_key);
+$result = apcu_fetch($cache_key);
 
 if ($result === false) {
     ob_start();
@@ -73,7 +73,7 @@ if ($result === false) {
     XDb::xFreeResults($rsfCR);
 
     $result = ob_get_clean();
-    apc_store($cache_key, $result, 86400);
+    apcu_store($cache_key, $result, 86400);
 }
 print $result;
         ?>

--- a/tpl/stdstyle/articles/s8.tpl.php
+++ b/tpl/stdstyle/articles/s8.tpl.php
@@ -9,14 +9,16 @@
         <td>
         <?php
 use Utils\Database\XDb;
+use Utils\Cache\OcMemCache;
 global $lang;
 
 # This page took >60 seconds to render! Added daily caching.
 
-$cache_key = "articles_s8-" . $lang;
-$result = apcu_fetch($cache_key);
-
-if ($result === false) {
+$result = OcMemCache::getOrCreate(
+    "articles_s8-" . $lang,
+    86400,
+function ()
+{
     ob_start();
 
     $fCt["count"] = XDb::xSimpleQueryValue(
@@ -72,10 +74,11 @@ if ($result === false) {
 
     XDb::xFreeResults($rsfCR);
 
-    $result = ob_get_clean();
-    apcu_store($cache_key, $result, 86400);
-}
+    return ob_get_clean();
+});
+
 print $result;
+
         ?>
         </td></tr>
 </table>


### PR DESCRIPTION
On the current devel VM there is no ACP installed - "Call to undefined function apc_fetch()". After changing to `acpu_fetch()` - which is already used in some other functions - everything works fine.

(In search-signatures.inc.php there is `acpu_store()` combined with `acp_fetch()` ... probably was forgotten to change [here](https://github.com/opencaching/opencaching-pl/commit/3a76c2f102d90bf0a3447c9f70ac3757117a323a#diff-2ad6aaa1ab10811bf9379fdee25978fc)?)