### PR TITLE
1831 in context localization

### DIFF
--- a/Config/Menu/customUserMenu.default.php
+++ b/Config/Menu/customUserMenu.default.php
@@ -3,6 +3,7 @@
 use Controllers\MyRecommendationsController;
 use Utils\Uri\SimpleRouter;
 use Controllers\CacheNotesController;
+use Utils\I18n\I18n;
 
 /**
  * This is simple configuration of links presented in sidebar of the page
@@ -34,5 +35,5 @@ $menu = [ // DON'T CHANGE $menu var name!
     'mnu_ignoredCaches' => '/myignores.php',
     'mnu_myRecommends'  => SimpleRouter::getLink(MyRecommendationsController::class, 'recommendations'),
     'mnu_savedQueries'  => '/query.php',
-    'mnu_okapiExtApps'  => '/okapi/apps/?langpref=' . $GLOBALS['lang'],
+    'mnu_okapiExtApps'  => '/okapi/apps/?langpref=' . I18n::getCurrentLang(),
 ];

--- a/Config/i18n.default.php
+++ b/Config/i18n.default.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This is simple configuration of translations and localizatin of the OC code
+ *
+ * This is a DEFAULT configuration for ALL nodes, which contains necessary vars.
+ *
+ * If you to customize it for your node
+ * create config for your node and there override array values as needed.
+ */
+
+$config = [];
+
+/**
+ * List of languages supported by node.
+ * Use two-lower-letters codes.
+ * Please note that for now still we have also translations in DB!
+ */
+$config['supportedLanguages'] = ['pl', 'en', 'nl', 'ro'];
+
+
+/**
+ * If node support crowdinInContext mode
+ */
+$config['crowdinInContextSupported'] = true;
+
+/**
+ * Crowdin in-context translation plugin needs "pseudo" language file to inject its identifiers
+ * See https://crowdin.com/project/oc-polish-code-translations/settings#in-context for details.
+ */
+$config['crowdinInContextPseudoLang'] = 'aa';
+

--- a/Config/i18n.default.php
+++ b/Config/i18n.default.php
@@ -11,11 +11,18 @@
 $config = [];
 
 /**
+ * Default node language
+ */
+$config['defaultLang'] = 'en';
+
+/**
  * List of languages supported by node.
  * Use two-lower-letters codes.
  * Please note that for now still we have also translations in DB!
  */
 $config['supportedLanguages'] = ['pl', 'en', 'nl', 'ro'];
+
+
 
 
 /**

--- a/Config/i18n.nl.php
+++ b/Config/i18n.nl.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is configuration specific for NL node
+ * It contains only overrides to DEFAULT config
+ */
+
+
+/**
+ * List of languages supported
+ * Please note that for now still we have also translations in DB!
+ */
+$config['supportedLanguages'] = ['pl', 'en', 'nl', 'de', 'ro'];

--- a/Config/i18n.pl.php
+++ b/Config/i18n.pl.php
@@ -5,6 +5,12 @@
  */
 
 /**
+ * Default node language
+ */
+$config['defaultLang'] = 'pl';
+
+
+/**
  * List of supported languages
  * Please note that for now still we have also translations in DB!
  */

--- a/Config/i18n.pl.php
+++ b/Config/i18n.pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This is configuration specific for PL node
+ * It contains only overrides to DEFAULT config
+ */
+
+/**
+ * List of supported languages
+ * Please note that for now still we have also translations in DB!
+ */
+$config['supportedLanguages'] = ['pl', 'en', 'nl'];

--- a/Config/i18n.ro.php
+++ b/Config/i18n.ro.php
@@ -1,16 +1,17 @@
 <?php
 /**
- * This is configuration specific for NL node
+ * This is configuration specific for RO node
  * It contains only overrides to DEFAULT config
  */
 
 /**
  * Default node language
  */
-$config['defaultLang'] = 'nl';
+$config['defaultLang'] = 'ro';
+
 
 /**
- * List of languages supported
+ * List of supported languages
  * Please note that for now still we have also translations in DB!
  */
-$config['supportedLanguages'] = ['pl', 'en', 'nl', 'de', 'ro'];
+$config['supportedLanguages'] = ['pl', 'en', 'nl', 'ro'];

--- a/Config/i18n.uk.php
+++ b/Config/i18n.uk.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This is configuration specific for UK node
+ * It contains only overrides to DEFAULT config
+ */
+
+/**
+ * List of supported languages
+ * Please note that for now still we have also translations in DB!
+ */
+$config['supportedLanguages'] = ['pl', 'en', 'nl'];

--- a/Config/site.default.php
+++ b/Config/site.default.php
@@ -3,7 +3,16 @@
 use lib\Objects\GeoCache\GeoCacheCommons;
 
 /**
-  * DEFAULT configuration of general site properties
+ * This is simple configuration of maps in the OC code
+ *
+ * This is a DEFAULT configuration for ALL nodes, which contains necessary vars.
+ *
+ * If you to customize it for your node
+ * create config for your node and there override array values as needed.
+ */
+
+/**
+ * Configuration of general site properties in defaut version
  */
 
 /**

--- a/Config/site.default.php
+++ b/Config/site.default.php
@@ -7,7 +7,18 @@ use lib\Objects\GeoCache\GeoCacheCommons;
  */
 
 /**
- * Theses sizes are not available for
+ * Configuration of general site properties in defaut version
+ */
+$site = [];
+
+
+/**
+ * Primary country (or countries) for this node
+ */
+$site['primaryCountries'] = ['PL'];
+
+/**
+ * Theses sizes are available for
  *    - creating caches
  *    - changing the type of a cache to this size
  *    - searching for caches.
@@ -22,3 +33,4 @@ $site['enabledCacheSizes'] = [
     GeoCacheCommons::SIZE_XLARGE,
     GeoCacheCommons::SIZE_NONE,
 ];
+

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -141,7 +141,7 @@ class MainLayoutController extends BaseController
         $this->view->setVar('_logoSubtitle', $logoSubtitle);
 
         $this->view->setVar('_languageFlags',
-            I18n::getLanguagesFlagsData($this->view->getLang()));
+            I18n::getLanguagesFlagsData(I18n::getCurrentLang()));
 
         $this->view->setVar('_crowdinInContextEnabled', CrowdinInContextMode::enabled());
         // CrowdinInContext mode is enabled by setting var in uri

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -12,6 +12,7 @@ use lib\Objects\GeoCache\PrintList;
 use lib\Objects\OcConfig\OcConfig;
 use lib\Objects\User\UserAuthorization;
 use Utils\Cache\OcMemCache;
+use Utils\I18n\CrowdinInContextMode;
 
 /**
  * This controller prepares common data used by almost every page at oc
@@ -141,6 +142,11 @@ class MainLayoutController extends BaseController
 
         $this->view->setVar('_languageFlags',
             I18n::getLanguagesFlagsData($this->view->getLang()));
+
+        $this->view->setVar('_crowdinInContextEnabled', CrowdinInContextMode::enabled());
+        // CrowdinInContext mode is enabled by setting var in uri
+        $this->view->setVar('_crowdinInContextActionUrl', Uri::setOrReplaceParamValue(CrowdinInContextMode::VAR_NAME, true));
+
 
         $this->view->setVar('_qSearchByOwnerEnabled', $config['quick_search']['byowner']);
         $this->view->setVar('_qSearchByFinderEnabled', $config['quick_search']['byfinder']);

--- a/Controllers/PageLayout/MainLayoutController.php
+++ b/Controllers/PageLayout/MainLayoutController.php
@@ -146,7 +146,8 @@ class MainLayoutController extends BaseController
         $this->view->setVar('_crowdinInContextEnabled', CrowdinInContextMode::enabled());
         // CrowdinInContext mode is enabled by setting var in uri
         $this->view->setVar('_crowdinInContextActionUrl', Uri::setOrReplaceParamValue(CrowdinInContextMode::VAR_NAME, true));
-
+        // CrowdinInContext can be enabled only by advUsers
+        $this->view->setVar('_crowdinInContextAllowed', $this->isUserLogged() && $this->loggedUser->hasAdvUserRole());
 
         $this->view->setVar('_qSearchByOwnerEnabled', $config['quick_search']['byowner']);
         $this->view->setVar('_qSearchByFinderEnabled', $config['quick_search']['byfinder']);

--- a/Controllers/RSSController.php
+++ b/Controllers/RSSController.php
@@ -15,6 +15,7 @@ use lib\Objects\User\User;
 use lib\Objects\Neighbourhood\MyNbhSets;
 use lib\Objects\Neighbourhood\Neighbourhood;
 use Utils\Uri\SimpleRouter;
+use Utils\I18n\I18n;
 
 class RSSController extends BaseController
 {
@@ -132,7 +133,7 @@ class RSSController extends BaseController
             __CLASS__ . '::newCaches',
             1 * 60 * 60,
             function() {
-                return self::newCachesDataPrepare($this->view->getLang());
+                return self::newCachesDataPrepare(I18n::getCurrentLang());
             });
 
         foreach ($caches as $cache) {
@@ -206,7 +207,7 @@ class RSSController extends BaseController
             __CLASS__ . '::newNews',
             1 * 60 * 60,
             function() {
-                return self::newNewsDataPrepare($this->view->getLang());
+                return self::newNewsDataPrepare(I18n::getCurrentLang());
             });
 
         foreach ($allNews as $news) {

--- a/Controllers/ViewCacheController.php
+++ b/Controllers/ViewCacheController.php
@@ -15,6 +15,7 @@ use lib\Objects\GeoCache\GeoCacheDesc;
 use lib\Objects\GeoCache\OpenChecker;
 use lib\Objects\GeoCache\PrintList;
 use lib\Objects\GeoCache\Waypoint;
+use Utils\I18n\I18n;
 
 class ViewCacheController extends BaseController
 {
@@ -393,8 +394,6 @@ class ViewCacheController extends BaseController
 
     private function processDesc()
     {
-        global $lang;
-
         // determine description language
         $availableDescLangs = mb_split(',', $this->geocache->getDescLanguagesList());
 
@@ -402,8 +401,8 @@ class ViewCacheController extends BaseController
         if ( isset($_REQUEST['desclang']) && (array_search($_REQUEST['desclang'], $availableDescLangs) !== false)) {
             $descLang = $_REQUEST['desclang'];
 
-        } elseif ( array_search( mb_strtoupper($lang) , $availableDescLangs) ) { // or try current lang
-            $descLang = mb_strtoupper($lang);
+        } elseif ( array_search( mb_strtoupper(I18n::getCurrentLang()) , $availableDescLangs) ) { // or try current lang
+            $descLang = mb_strtoupper(I18n::getCurrentLang());
 
         } else { // use first available otherwise
             $descLang = $availableDescLangs[0];

--- a/Utils/I18n/CrowdinInContextMode.php
+++ b/Utils/I18n/CrowdinInContextMode.php
@@ -9,23 +9,22 @@ use Utils\Uri\SimpleRouter;
 class CrowdinInContextMode
 {
     const VAR_NAME = 'crowdinInContextMode';
+    const PREVIOUS_LANG_VAR = 'crowdinInContextBackToLang';
 
     /**
      * This function is call at the begining of every script
      * to handle CrowdinInContext if necessary
      */
-    public static function initHandler()
+    public static function checkRequest($langToUse)
     {
-        if (!isset($_REQUEST[self::VAR_NAME])) {
-            // nothing new to do
-            return;
-        }
-
-        // crowdinInContext mode toggle detected
-        if (self::enabled()) {
-            self::disable();
-        } else {
-            self::enable();
+        if (isset($_REQUEST[self::VAR_NAME])){
+            if (CrowdinInContextMode::enabled()) {
+                // CrowdinInContext mode is enabled now => this is request to disable it
+                CrowdinInContextMode::disable();
+            } else {
+                // CrowdinInContext mode is disabled now => this is request to enable it
+                CrowdinInContextMode::enable($langToUse);
+            }
         }
     }
 
@@ -34,20 +33,37 @@ class CrowdinInContextMode
         return OcCookie::getOrDefault(self::VAR_NAME, false);
     }
 
-    public static function enable()
+    public static function enable($previousLang)
     {
-        OcCookie::set(self::VAR_NAME, true, true);
+        OcCookie::set(self::VAR_NAME, true);
+        OcCookie::set(self::PREVIOUS_LANG_VAR, $previousLang, true);
 
         $cleanUri = Uri::removeParam(self::VAR_NAME);
         SimpleRouter::redirect($cleanUri);
+        exit;
     }
 
     public static function disable()
     {
+        $prevLang = self::getPreviousLanguage();
+        OcCookie::delete(self::PREVIOUS_LANG_VAR, true);
         OcCookie::delete(self::VAR_NAME, true);
 
-        $cleanUri = Uri::removeParam(self::VAR_NAME);
-        SimpleRouter::redirect($cleanUri);
+        $uri = Uri::removeParam(self::VAR_NAME);
+        $uri = Uri::setOrReplaceParamValue(I18n::URI_LANG_VAR, $prevLang, $uri);
+
+        SimpleRouter::redirect($uri);
+        exit;
+    }
+
+    public static function getPreviousLanguage()
+    {
+        $prevLang = OcCookie::getOrDefault(self::PREVIOUS_LANG_VAR, null);
+        if (is_null($prevLang)) {
+            // previous language is not found in cookie
+            return I18n::getDefaultLang();
+        }
+        return $prevLang;
     }
 
     public static function isSupportedInConfig()

--- a/Utils/I18n/CrowdinInContextMode.php
+++ b/Utils/I18n/CrowdinInContextMode.php
@@ -1,0 +1,63 @@
+<?php
+namespace Utils\I18n;
+
+use Utils\Uri\OcCookie;
+use lib\Objects\OcConfig\OcConfig;
+use Utils\Uri\Uri;
+use Utils\Uri\SimpleRouter;
+
+class CrowdinInContextMode
+{
+    const VAR_NAME = 'crowdinInContextMode';
+
+    /**
+     * This function is call at the begining of every script
+     * to handle CrowdinInContext if necessary
+     */
+    public static function initHandler()
+    {
+        if (!isset($_REQUEST[self::VAR_NAME])) {
+            // nothing new to do
+            return;
+        }
+
+        // crowdinInContext mode toggle detected
+        if (self::enabled()) {
+            self::disable();
+        } else {
+            self::enable();
+        }
+    }
+
+    public static function enabled()
+    {
+        return OcCookie::getOrDefault(self::VAR_NAME, false);
+    }
+
+    public static function enable()
+    {
+        OcCookie::set(self::VAR_NAME, true, true);
+
+        $cleanUri = Uri::removeParam(self::VAR_NAME);
+        SimpleRouter::redirect($cleanUri);
+    }
+
+    public static function disable()
+    {
+        OcCookie::delete(self::VAR_NAME, true);
+
+        $cleanUri = Uri::removeParam(self::VAR_NAME);
+        SimpleRouter::redirect($cleanUri);
+    }
+
+    public static function isSupportedInConfig()
+    {
+        return OcConfig::instance()->getI18Config()['crowdinInContextSupported'];
+    }
+
+    public static function getPseudoLang()
+    {
+        return OcConfig::instance()->getI18Config()['crowdinInContextPseudoLang'];
+    }
+
+}

--- a/Utils/I18n/I18n.php
+++ b/Utils/I18n/I18n.php
@@ -11,6 +11,7 @@ use Utils\Debug\Debug;
 class I18n
 {
     const FAILOVER_LANGUAGE = 'en';
+    const COOKIE_LANG_VAR = 'lang';
 
     private $currentLanguage;
     private $trArray;
@@ -51,10 +52,12 @@ class I18n
      */
     public static function getCurrentLang()
     {
-        // temporary use external global var
-        global $lang;
-        return $lang;
-        // return $this->currentLanguage;
+        return self::instance()->currentLanguage;
+    }
+
+    public static function getLangForDbTranslations()
+    {
+        return self::getCurrentLang();
     }
 
     /**
@@ -90,8 +93,8 @@ class I18n
      */
     public static function isTranslationAvailable($str)
     {
-        $instance = self::instance();
         $language = self::getCurrentLang();
+        $instance = self::instance();
         return isset($instance->trArray[$language][$str]) && $instance->trArray[$language][$str];
     }
 
@@ -125,7 +128,7 @@ class I18n
         if (isset($_REQUEST['lang'])) {
             return $_REQUEST['lang'];
         } else {
-            return OcCookie::getOrDefault('lang', $this->getDefaultLang());
+            return OcCookie::getOrDefault(self::COOKIE_LANG_VAR, $this->getDefaultLang());
         }
     }
 
@@ -189,10 +192,8 @@ class I18n
 
     private function setCurrentLang($languageCode)
     {
-        // temporary use global var also
-        global $lang;
-        $lang = $languageCode;
         $this->currentLanguage = $languageCode;
+        OcCookie::set(self::COOKIE_LANG_VAR, $languageCode, true);
     }
 
     /**
@@ -208,14 +209,14 @@ class I18n
         return OcConfig::instance()->getI18Config()['defaultLang'];
     }
 
-    private function isLangSupported($lang){
+    private function isLangSupported($langCode){
 
         if (CrowdinInContextMode::isSupportedInConfig()) {
-            if ($lang == CrowdinInContextMode::getPseudoLang() ){
+            if ($langCode == CrowdinInContextMode::getPseudoLang() ){
                 return true;
             }
         }
-        return in_array($lang, $this->getSupportedTranslations());
+        return in_array($langCode, $this->getSupportedTranslations());
     }
 
     private function handleUnsupportedLangAndExit($requestedLang)

--- a/Utils/I18n/I18n.php
+++ b/Utils/I18n/I18n.php
@@ -3,26 +3,26 @@ namespace Utils\I18n;
 
 use Exception;
 use Utils\Uri\Uri;
+use lib\Objects\OcConfig\OcConfig;
 
 class I18n
 {
-
     /**
-     * supported translations list is stored in config['supportedLanguages'] var in settings* files
-     * @return array of supported tranlation in form: 'PL', 'EN', 'NL', 'RO'
+     * supported translations list is stored in i18n::$config['supportedLanguages'] var in config files
+     * @return array of supported languags
      */
     public static function getSupportedTranslations(){
-
-        if(isset($GLOBALS['config']['supportedLanguages']) && is_array($GLOBALS['config']['supportedLanguages'])){
-            return $GLOBALS['config']['supportedLanguages'];
-        } else {
-            error_log(__METHOD__.': There is no $config[supportedLanguages] settings -'.
-                        'please load settingsDefault.inc.php in your setting.inc.php!');
-            return array('en', 'nl', 'pl', 'ro');
-        }
+        return OcConfig::instance()->getI18Config()['supportedLanguages'];
     }
 
     public static function isTranslationSupported($lang){
+
+        if (CrowdinInContextMode::isSupportedInConfig()) {
+            if ($lang == CrowdinInContextMode::getPseudoLang() ){
+                return true;
+            }
+        }
+
         return in_array($lang, self::getSupportedTranslations());
     }
 
@@ -64,6 +64,7 @@ class I18n
         return $result;
     }
 
+
     // Methods for retrieving and maintaining old-style database translations.
     // This should become obsolete some time.
 
@@ -72,7 +73,7 @@ class I18n
     public static function getTranslationTables()
     {
         return [
-            'cache_size', 'cache_status', 'cache_type', 'log_types', 'waypoint_type', 
+            'cache_size', 'cache_status', 'cache_type', 'log_types', 'waypoint_type',
             'countries', 'languages'
         ];
     }

--- a/Utils/I18n/I18n.php
+++ b/Utils/I18n/I18n.php
@@ -7,6 +7,7 @@ use Utils\Uri\OcCookie;
 use Utils\Uri\Uri;
 use lib\Objects\OcConfig\OcConfig;
 use Utils\Debug\Debug;
+use Utils\Database\XDb;
 
 class I18n
 {
@@ -55,9 +56,21 @@ class I18n
         return self::instance()->currentLanguage;
     }
 
-    public static function getLangForDbTranslations()
+    /**
+     * Return language which can be used to look up for translation in given Db table
+     * DON'T USE DB TRANSLATION! This method is only to support legacy code.
+     *
+     * @param string $tableName
+     * @return string - language code
+     */
+    public static function getLangForDbTranslations($tableName)
     {
-        return self::getCurrentLang();
+        $langCode = self::getCurrentLang();
+        if (XDb::xContainsColumn($tableName, $langCode)) {
+            return $langCode;
+        } else {
+            return self::FAILOVER_LANGUAGE;
+        }
     }
 
     /**

--- a/Utils/I18n/Languages.php
+++ b/Utils/I18n/Languages.php
@@ -13,13 +13,13 @@ use Utils\Database\XDb;
 class Languages
 {
 
-    public static function LanguageNameFromCode($countryCode, $lang){
+    public static function LanguageNameFromCode($countryCode, $langCode){
 
         $rs = XDb::xSql(
-            "SELECT `short`, `$lang` FROM `languages` WHERE `short`= ? ", $countryCode);
+            "SELECT `short`, `$langCode` FROM `languages` WHERE `short`= ? ", $countryCode);
 
         if ( $record = XDb::xFetchArray($rs) ) {
-            return $record[$lang];
+            return $record[$langCode];
         } else {
             return false;
         }

--- a/Utils/I18n/Languages.php
+++ b/Utils/I18n/Languages.php
@@ -68,7 +68,9 @@ class Languages
                 setlocale(LC_TIME, 'en_EN');
                 break;
             default:
-                error_log(__METHOD__.": Error: trying to load unsupported locale: $langCode !?");
+                if ($langCode != CrowdinInContextMode::getPseudoLang()) {
+                    error_log(__METHOD__.": Error: trying to load unsupported locale: $langCode !?");
+                }
                 setlocale(LC_CTYPE, 'en_EN');
                 setlocale(LC_TIME, 'en_EN');
                 break;

--- a/Utils/Uri/OcCookie.php
+++ b/Utils/Uri/OcCookie.php
@@ -120,7 +120,14 @@ class OcCookie
     {
         $cookieExpiry = time() + UserAuthorization::PERMANENT_LOGIN_TIMEOUT;
 
-        $result = CookieBase::setCookie(self::getOcCookieName(), base64_encode(json_encode(self::$ocData)), $cookieExpiry, '/', false, true, CookieBase::SAME_SITE_RESTRICTION_LAX);
+        $result = CookieBase::setCookie(
+            self::getOcCookieName(),
+            base64_encode( json_encode(self::$ocData)),
+            $cookieExpiry,
+            '/',
+            false,
+            true,
+            CookieBase::SAME_SITE_RESTRICTION_LAX);
 
         if (! $result) {
             Debug::errorLog(__METHOD__ . ": Can't set OCUserData cookie");

--- a/Utils/Uri/SimpleRouter.php
+++ b/Utils/Uri/SimpleRouter.php
@@ -112,6 +112,26 @@ class SimpleRouter
         exit;
     }
 
+
+    /**
+     * Redirect to new location
+     *
+     * @param string $uri
+     * @param bool $absoluteUri - if set means that uri is absolute (contains protocol and host etc.)
+     */
+    public static function redirect($uri, $absoluteUri=null)
+    {
+        if (is_null($absoluteUri)) {
+            // if the first char of $uri is not a slash add slash
+            if (substr($uri, 0, 1) !== '/') {
+                $uri = '/'.$uri;
+            }
+            $uri = "//" . $_SERVER['HTTP_HOST'] . $uri;
+        }
+
+        header("Location: $uri");
+    }
+
     /**
      * Replace ctrl part from route into php-namespace class name
      *

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -237,7 +237,7 @@ class View {
 
     public function getLang()
     {
-        I18n::getCurrentLang();
+        return I18n::getCurrentLang();
     }
 
     /**

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -7,6 +7,7 @@ use Utils\Debug\Debug;
 use Controllers\PageLayout\MainLayoutController;
 use Utils\I18n\CrowdinInContextMode;
 use Utils\Uri\SimpleRouter;
+use Utils\I18n\I18n;
 
 class View {
 
@@ -236,7 +237,7 @@ class View {
 
     public function getLang()
     {
-        return ApplicationContainer::Instance()->getLang();
+        I18n::getCurrentLang();
     }
 
     /**

--- a/Utils/View/View.php
+++ b/Utils/View/View.php
@@ -5,6 +5,8 @@ use Utils\DateTime\Year;
 use lib\Objects\ApplicationContainer;
 use Utils\Debug\Debug;
 use Controllers\PageLayout\MainLayoutController;
+use Utils\I18n\CrowdinInContextMode;
+use Utils\Uri\SimpleRouter;
 
 class View {
 
@@ -37,6 +39,7 @@ class View {
         $this->_googleAnalyticsKey = isset($GLOBALS['googleAnalytics_key']) ?
                 $GLOBALS['googleAnalytics_key'] : '';
 
+        $this->handleCrowdinInContextMode();
     }
 
     /**
@@ -132,6 +135,16 @@ class View {
         return ob_get_clean();
     }
 
+    public function handleCrowdinInContextMode()
+    {
+        if(!CrowdinInContextMode::enabled()){
+            // crowdin-in-context mode is not enabled
+            return;
+        }
+
+        // crowdin-in-context mode is enabled - load proper chunk
+        $this->addHeaderChunk('crowdinInContext');
+    }
 
     public function loadJQuery()
     {
@@ -205,13 +218,7 @@ class View {
      */
     public function redirect($uri)
     {
-
-        // if the first char of $uri is not a slash add slash
-        if (substr($uri, 0, 1) !== '/') {
-            $uri = '/'.$uri;
-        }
-
-        header("Location: " . "//" . $_SERVER['HTTP_HOST'] . $uri);
+        SimpleRouter::redirect($uri);
     }
 
     public function getSeasonCssName()

--- a/articles.php
+++ b/articles.php
@@ -1,6 +1,7 @@
 <?php
 
 use lib\Objects\Stats\CacheStats;
+use Utils\I18n\I18n;
 
 //prepare the templates and include all neccessary
 require_once(__DIR__.'/lib/common.inc.php');
@@ -46,7 +47,7 @@ if ($article == '') {
     $tplname = 'articles/' . $article;
 }
 
-tpl_set_var('language4js', $lang);
+tpl_set_var('language4js', I18n::getCurrentLang());
 
 // make the template and send it out
 tpl_BuildTemplate();

--- a/editcache.php
+++ b/editcache.php
@@ -8,6 +8,7 @@ use lib\Objects\Coordinates\Coordinates;
 use Utils\EventHandler\EventHandler;
 use lib\Objects\GeoCache\GeoCacheLog;
 use lib\Objects\OcConfig\OcConfig;
+use Utils\I18n\I18n;
 
 require_once(__DIR__.'/lib/common.inc.php');
 
@@ -451,7 +452,7 @@ if ($error == false) {
 
                         $code1 = $cache_country;
                         $adm1 = XDb::xMultiVariableQueryValue(
-                            "SELECT ".XDb::xEscape($lang).
+                            "SELECT ".XDb::xEscape(I18n::getCurrentLang()).
                             " FROM `countries`
                              WHERE `countries`.`short`= :1 ", 0, $code1);
 
@@ -558,7 +559,7 @@ if ($error == false) {
 
                 //check if selected country is in list_default
                 if ($show_all_countries == 0) {
-                    $eLang = XDb::xEscape($lang);
+                    $eLang = XDb::xEscape(I18n::getCurrentLang());
                     $rs = XDb::xSql(
                         "SELECT `short` FROM `countries`
                         WHERE (`list_default_$eLang`=1) AND (lower(`short`) = lower( ? ))",
@@ -569,7 +570,7 @@ if ($error == false) {
                 }
 
                 //get the record
-                $eLang = XDb::xEscape($lang);
+                $eLang = XDb::xEscape(I18n::getCurrentLang());
                 if ($show_all_countries == 0) {
                     $rs = XDb::xSql('SELECT `' . $eLang . '`, `short` FROM `countries`
                                WHERE `list_default_' . $eLang . '`=1
@@ -596,7 +597,7 @@ if ($error == false) {
                 $cache_attribs_string = '';
 
                 $rs = XDb::xSql("SELECT `id`, `text_long`, `icon_undef`, `icon_large` FROM `cache_attrib`
-                                 WHERE `language`= ? ORDER BY `category`, `id`", $default_lang);
+                                 WHERE `language`= ? ORDER BY `category`, `id`", I18n::getCurrentLang());
                 while ($record = XDb::xFetchArray($rs)) {
                     $line = $cache_attrib_pic;
                     $line = mb_ereg_replace('{attrib_id}', $record['id'], $line);
@@ -675,9 +676,9 @@ if ($error == false) {
                     }
 
                     if ($type['id'] == $cache_type) {
-                        $types .= '<option value="' . $type['id'] . '" selected="selected">' . htmlspecialchars($type[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $types .= '<option value="' . $type['id'] . '" selected="selected">' . htmlspecialchars($type[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     } else {
-                        $types .= '<option value="' . $type['id'] . '">' . htmlspecialchars($type[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $types .= '<option value="' . $type['id'] . '">' . htmlspecialchars($type[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     }
                 }
                 tpl_set_var('typeoptions', $types);
@@ -721,7 +722,7 @@ if ($error == false) {
                         '<tr>
                             <td colspan="2">
                                 <img src="images/flags/' . strtolower($descLang) . '.gif" class="icon16" alt="">
-                                    &nbsp;' . htmlspecialchars(Languages::LanguageNameFromCode($descLang, $lang), ENT_COMPAT, 'UTF-8') . '&nbsp;&nbsp;
+                                    &nbsp;' . htmlspecialchars(Languages::LanguageNameFromCode($descLang, I18n::getCurrentLang()), ENT_COMPAT, 'UTF-8') . '&nbsp;&nbsp;
                                 <img src="images/actions/edit-16.png" border="0" align="middle" alt="" title="Edit">
                                 [<a href="' . htmlspecialchars($edit_url, ENT_COMPAT, 'UTF-8') . '" onclick="return check_if_proceed();">' . tr('edit') . '</a>]' .
                                 $removedesc .
@@ -875,17 +876,13 @@ if ($error == false) {
                 }
 
                 //Add Waypoint
-                if (XDb::xContainsColumn('waypoint_type', $lang)){
-                    $lang_db = $lang;
-                } else{
-                    $lang_db = "en";
-                }
+                $lang_db = I18n::getLangForDbTranslations('waypoint_type');
 
                 $cache_type = $cache_record['type'];
                 if ($cache_type != GeoCache::TYPE_MOVING) {
                     tpl_set_var('waypoints_start', '');
                     tpl_set_var('waypoints_end', '');
-                    $eLang = XDb::xEscape($lang);
+                    $eLang = XDb::xEscape($lang_db);
                     $wp_rs = XDb::xSql(
                         "SELECT `wp_id`, `type`, `longitude`, `latitude`,  `desc`, `status`, `stage`,
                                 `waypoint_type`.`$eLang` wp_type, waypoint_type.icon wp_icon

--- a/editdesc.php
+++ b/editdesc.php
@@ -4,6 +4,7 @@ use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCache;
 use Utils\I18n\Languages;
 use Utils\Text\UserInputFilter;
+use Utils\I18n\I18n;
 
 //prepare the templates and include all neccessary
 require_once(__DIR__.'/lib/common.inc.php');
@@ -104,7 +105,7 @@ if ( $desc_record = XDb::xFetchArray($desc_rs) ) {
         $desc = $desc_record['desc'];
     }
 
-    $eLang = XDb::xEscape($lang);
+    $eLang = XDb::xEscape(I18n::getCurrentLang());
 
     //here we only set up the template variables
     tpl_set_var('desc', htmlspecialchars($desc, ENT_COMPAT, 'UTF-8'), true);
@@ -147,12 +148,12 @@ if ( $desc_record = XDb::xFetchArray($desc_rs) ) {
     tpl_set_var('descid', $descid);
     tpl_set_var('cacheid', htmlspecialchars($desc_record['cache_id'], ENT_COMPAT, 'UTF-8'));
     tpl_set_var('desclang', htmlspecialchars($desc_lang, ENT_COMPAT, 'UTF-8'));
-    tpl_set_var('desclang_name', htmlspecialchars(Languages::LanguageNameFromCode($desc_lang, $lang), ENT_COMPAT, 'UTF-8'));
+    tpl_set_var('desclang_name', htmlspecialchars(Languages::LanguageNameFromCode($desc_lang, I18n::getCurrentLang()), ENT_COMPAT, 'UTF-8'));
     tpl_set_var('cachename', htmlspecialchars($desc_record['name'], ENT_COMPAT, 'UTF-8'));
 }
 
 
 //make the template and send it out
-tpl_set_var('language4js', $lang);
+tpl_set_var('language4js', I18n::getCurrentLang());
 tpl_BuildTemplate();
 

--- a/editlog.php
+++ b/editlog.php
@@ -10,6 +10,7 @@ use okapi\Facade;
 use Utils\EventHandler\EventHandler;
 use Utils\Text\InputFilter;
 use lib\Objects\GeoCache\MobileCacheMove;
+use Utils\I18n\I18n;
 
 //prepare the templates and include all neccessary
 require_once(__DIR__.'/lib/common.inc.php');
@@ -469,11 +470,7 @@ if ($error == false) {
                         }
                     }
 
-
-                    if (XDb::xContainsColumn('log_types', $lang))
-                        $lang_db = $lang;
-                    else
-                        $lang_db = "en";
+                    $lang_db = I18n::getLangForDbTranslations('log_types');
 
                     if ($type['id'] == $log_type) {
                         $logtypeoptions .= '<option value="' . $type['id'] . '" selected="selected">' . htmlspecialchars($type[$lang_db], ENT_COMPAT, 'UTF-8') . '</option>' . "\n";
@@ -522,5 +519,5 @@ if ($error == false) {
 }
 
 //make the template and send it out
-tpl_set_var('language4js', $lang);
+tpl_set_var('language4js', I18n::getCurrentLang());
 tpl_BuildTemplate();

--- a/editwp.php
+++ b/editwp.php
@@ -1,6 +1,7 @@
 <?php
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 //prepare the templates and include all neccessary
 require_once(__DIR__.'/lib/common.inc.php');
@@ -75,9 +76,9 @@ if ($error == false) {
                 foreach (get_wp_types_from_database($cache_record['type']) as $type) {
 
                     if ($type['id'] == $wp_type) {
-                        $types .= '<option value="' . $type['id'] . '" selected="selected">' . htmlspecialchars($type[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $types .= '<option value="' . $type['id'] . '" selected="selected">' . htmlspecialchars($type[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     } else {
-                        $types .= '<option value="' . $type['id'] . '">' . htmlspecialchars($type[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $types .= '<option value="' . $type['id'] . '">' . htmlspecialchars($type[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     }
                 }
                 tpl_set_var('typeoptions', $types);

--- a/graphs/BarGraphcstat.php
+++ b/graphs/BarGraphcstat.php
@@ -5,8 +5,6 @@ use Utils\Database\XDb;
 
 require(__DIR__.'/../lib/common.inc.php');
 
-global $lang;
-
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
 

--- a/graphs/BarGraphcstatM.php
+++ b/graphs/BarGraphcstatM.php
@@ -5,8 +5,6 @@ use Utils\Database\XDb;
 
 require(__DIR__.'/../lib/common.inc.php');
 
-global $lang;
-
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
 

--- a/graphs/BarGraphustat.php
+++ b/graphs/BarGraphustat.php
@@ -5,8 +5,6 @@ use Utils\Database\XDb;
 
 require(__DIR__.'/../lib/common.inc.php');
 
-global $lang;
-
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
 

--- a/graphs/COGstat.php
+++ b/graphs/COGstat.php
@@ -5,8 +5,6 @@ use Utils\Database\XDb;
 
 require(__DIR__.'/../lib/common.inc.php');
 
-global $lang;
-
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
 

--- a/graphs/PieGraphcstat.php
+++ b/graphs/PieGraphcstat.php
@@ -2,10 +2,9 @@
 
 use Libs\JpGraph\JpGraphLoader;
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 require(__DIR__.'/../lib/common.inc.php');
-
-global $lang;
 
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
@@ -22,10 +21,7 @@ if (isset($_REQUEST['cacheid'])) {
 $y = array();
 $x = array();
 
-if (XDb::xContainsColumn('log_types', $lang))
-    $lang_db = XDb::xEscape($lang);
-else
-    $lang_db = "en";
+$lang_db = I18n::getLangForDbTranslations('log_types');
 
 // Ustawic sprawdzanie jezyka w cache_type.pl !!!!
 $rsCSF = XDb::xSql(

--- a/graphs/PieGraphustat.php
+++ b/graphs/PieGraphustat.php
@@ -2,10 +2,9 @@
 
 use Libs\JpGraph\JpGraphLoader;
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 require(__DIR__.'/../lib/common.inc.php');
-
-global $lang;
 
 // jpgraph package doesn't contains fonts
 define('TTF_DIR',__DIR__.'/../lib/fonts/');
@@ -24,10 +23,7 @@ if (isset($_REQUEST['userid']) && isset($_REQUEST['t'])) {
 $y = array();
 $x = array();
 
-if (XDb::xContainsColumn('cache_type', $lang))
-    $lang_db = XDb::xEscape($lang);
-else
-    $lang_db = "en";
+$lang_db = I18n::getLangForDbTranslations('cache_type');
 
 if ($tit == "cc") {
     // Ustawic sprawdzanie jezyka  w cache_type.pl !!!!

--- a/lib/Objects/ApplicationContainer.php
+++ b/lib/Objects/ApplicationContainer.php
@@ -5,7 +5,6 @@ namespace lib\Objects;
 use lib\Objects\User\User;
 use lib\Objects\OcConfig\OcConfig;
 use Utils\Database\OcDb;
-use Utils\I18n\I18n;
 
 final class ApplicationContainer
 {

--- a/lib/Objects/ApplicationContainer.php
+++ b/lib/Objects/ApplicationContainer.php
@@ -5,6 +5,7 @@ namespace lib\Objects;
 use lib\Objects\User\User;
 use lib\Objects\OcConfig\OcConfig;
 use Utils\Database\OcDb;
+use Utils\I18n\I18n;
 
 final class ApplicationContainer
 {
@@ -89,10 +90,5 @@ final class ApplicationContainer
         return $this->ocConfig;
     }
 
-
-    public function getLang()
-    {
-        return $GLOBALS['lang'];
-    }
 }
 

--- a/lib/Objects/Coordinates/GeoCode.php
+++ b/lib/Objects/Coordinates/GeoCode.php
@@ -5,6 +5,7 @@ namespace lib\Objects\Coordinates;
 use lib\Objects\OcConfig\OcConfig;
 use Utils\Debug\Debug;
 use Exception;
+use Utils\I18n\I18n;
 
 class GeoCode
 {
@@ -111,7 +112,7 @@ class GeoCode
      */
     public static function fromGoogleApi(Coordinates $coords)
     {
-        global $googlemap_key, $lang; //TODO: refactor configs
+        global $googlemap_key; //TODO: refactor configs
 
         $lat = $coords->getLatitude();
         $lon = $coords->getLongitude();
@@ -120,8 +121,9 @@ class GeoCode
             return null;
         }
 
+        $language = I18n::getCurrentLang();
         $url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lon" .
-        "&key=$googlemap_key&language=$lang&result_type=administrative_area_level_1";
+        "&key=$googlemap_key&language=$language&result_type=administrative_area_level_1";
 
         $data = @file_get_contents($url);
         $resp = json_decode($data);

--- a/lib/Objects/Coordinates/NutsLocation.php
+++ b/lib/Objects/Coordinates/NutsLocation.php
@@ -4,6 +4,7 @@ namespace lib\Objects\Coordinates;
 
 use lib\Objects\BaseObject;
 use Utils\Debug\Debug;
+use Utils\I18n\I18n;
 
 /**
  * Class represents location of the point in NUTS nomenclature.
@@ -98,7 +99,7 @@ class NutsLocation extends BaseObject
         }
 
         // try to translate country name
-        if (tr_available($this->codes[self::LEVEL_COUNTRY])){
+        if (I18n::isTranslationAvailable($this->codes[self::LEVEL_COUNTRY])){
             $country = tr($this->codes[self::LEVEL_COUNTRY]);
         } else {
             $country = $this->names[self::LEVEL_COUNTRY];

--- a/lib/Objects/GeoCache/GeoCache.php
+++ b/lib/Objects/GeoCache/GeoCache.php
@@ -9,6 +9,7 @@ use lib\Objects\PowerTrail\PowerTrail;
 use lib\Objects\User\MultiUserQueries;
 use lib\Objects\User\User;
 use Utils\EventHandler\EventHandler;
+use Utils\I18n\I18n;
 
 /**
  * Description of geoCache
@@ -1289,7 +1290,7 @@ class GeoCache extends GeoCacheCommons
 
     public function getCacheAttributesList()
     {
-        global $lang, $config;
+        global $config;
 
         if (is_array($this->cacheAttributesList)) {
             return $this->cacheAttributesList;
@@ -1302,7 +1303,7 @@ class GeoCache extends GeoCacheCommons
                     AND cache_attrib.language = ?
                     AND caches_attributes.cache_id = ?
                 ORDER BY cache_attrib.category, cache_attrib.id",
-            strtoupper($lang), $this->getCacheId());
+            strtoupper(I18n::getLangForDbTranslations()), $this->getCacheId());
 
         if (XDb::xNumRows($s) == 0) {
             //TODO: there can be a lack of cache attrib translation in current language - then retrive translation in english

--- a/lib/Objects/GeoCache/GeoCache.php
+++ b/lib/Objects/GeoCache/GeoCache.php
@@ -1303,7 +1303,7 @@ class GeoCache extends GeoCacheCommons
                     AND cache_attrib.language = ?
                     AND caches_attributes.cache_id = ?
                 ORDER BY cache_attrib.category, cache_attrib.id",
-            strtoupper(I18n::getLangForDbTranslations()), $this->getCacheId());
+            strtoupper(I18n::getLangForDbTranslations('cache_attrib')), $this->getCacheId());
 
         if (XDb::xNumRows($s) == 0) {
             //TODO: there can be a lack of cache attrib translation in current language - then retrive translation in english

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -66,6 +66,9 @@ final class OcConfig extends ConfigReader
     /** @var array general site properties */
     private $siteConfig;
 
+    /** @var array of i18n settings */
+    private $i18nConfig;
+
     /** @var array the \Utils\Lock objects configuration array */
     private $lockConfig;
     /** @var array the watchlist configuration array */
@@ -405,6 +408,14 @@ final class OcConfig extends ConfigReader
             }
         }
         return $this->siteConfig;
+    }
+
+    public function getI18Config()
+    {
+        if ($this->i18nConfig == null) {
+            $this->i18nConfig = self::getConfig("i18n");
+        }
+        return $this->i18nConfig;
     }
 
     /**

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -40,7 +40,6 @@ final class OcConfig extends ConfigReader
     private $mainPageMapZoom;
     private $siteInService = false;
     private $pagetitle;
-    private $defaultLanguage;
     private $pictureDirectory;
     private $pictureUrl;
     private $contactMail;
@@ -136,7 +135,6 @@ final class OcConfig extends ConfigReader
         $this->mainPageMapZoom = $main_page_map_zoom;
         $this->siteInService = $site_in_service;
         $this->pagetitle = $pagetitle;
-        $this->defaultLanguage = $lang;
         $this->pictureDirectory = $picdir;
         $this->pictureUrl = $picurl;
         $this->contactMail = $contact_mail;

--- a/lib/caches.inc.php
+++ b/lib/caches.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 function get_log_types_from_database()
 {
@@ -41,12 +42,9 @@ function get_wp_types_from_database($cachetype)
 
 
 
-function cache_type_from_id($id, $lang)
+function cache_type_from_id($id)
 {
-    if (Xdb::xContainsColumn('cache_type', $lang))
-        $lang_db = $lang;
-    else
-        $lang_db = "en";
+    $lang_db = I18n::getLangForDbTranslations('cache_type');
 
     foreach (get_cache_types_from_database() AS $cache_type) {
         if ($cache_type['id'] == $id) {

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -19,7 +19,6 @@ require_once(__DIR__.'/settingsGlue.inc.php');
 // TODO: kojoty: it should be removed after config refactoring
 // now if common.inc.php is not loaded in global context settings are not accessible
 $GLOBALS['config'] = $config;
-$GLOBALS['lang'] = $lang;
 $GLOBALS['site_name'] = $site_name;
 $GLOBALS['contact_mail'] = $contact_mail;
 
@@ -46,8 +45,8 @@ if (php_sapi_name() != "cli") { // this is not neccesarry for command-line scrip
 
     UserAuthorization::verify();
 
-    initTemplateSystem();
     I18n::init();
+    initTemplateSystem();
 }
 
 function initTemplateSystem(){
@@ -73,7 +72,7 @@ function initTemplateSystem(){
     }
 
     tpl_set_var('title', htmlspecialchars(OcConfig::instance()->getPageTitle(), ENT_COMPAT, 'UTF-8'));
-    tpl_set_var('lang', $GLOBALS['lang']);
+    tpl_set_var('lang', I18n::getCurrentLang());
     tpl_set_var('bodyMod', '');
     tpl_set_var('cachemap_header', '');
     tpl_set_var('htmlheaders', '');

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -6,6 +6,7 @@ use Utils\Debug\ErrorHandler;
 use Utils\View\View;
 use lib\Objects\User\UserAuthorization;
 use lib\Objects\OcConfig\OcConfig;
+use Utils\I18n\I18n;
 
 ErrorHandler::install();
 
@@ -46,7 +47,7 @@ if (php_sapi_name() != "cli") { // this is not neccesarry for command-line scrip
     UserAuthorization::verify();
 
     initTemplateSystem();
-    initTranslations();
+    I18n::initTranslations();
 }
 
 function initTemplateSystem(){

--- a/lib/common.inc.php
+++ b/lib/common.inc.php
@@ -47,7 +47,7 @@ if (php_sapi_name() != "cli") { // this is not neccesarry for command-line scrip
     UserAuthorization::verify();
 
     initTemplateSystem();
-    I18n::initTranslations();
+    I18n::init();
 }
 
 function initTemplateSystem(){

--- a/lib/common_tpl_funcs.php
+++ b/lib/common_tpl_funcs.php
@@ -43,7 +43,6 @@ function tpl_redirect($page)
     global $absolute_server_URI;
 
     //page has to be the filename without domain i.e. 'viecache.php?cacheid=1'
-    write_cookie_settings();
     http_write_no_cache();
 
     header("Location: " . $absolute_server_URI . $page);
@@ -61,7 +60,6 @@ function tpl_get_current_page()
 function tpl_redirect_absolute($absolute_server_URI)
 {
     //page has to be the filename with domain i.e. 'http://abc.de/viecache.php?cacheid=1'
-    write_cookie_settings();
     http_write_no_cache();
 
     header("Location: " . $absolute_server_URI);
@@ -150,7 +148,7 @@ function set_tpl_subtitle($title)
 function tpl_BuildTemplate($minitpl = false, $noCommonTemplate=false)
 {
     //template handling vars
-    global $tplname, $vars, $lang, $config, $usr;
+    global $tplname, $vars, $config, $usr;
 
     // object
     /** @var View $view */
@@ -183,7 +181,6 @@ function tpl_BuildTemplate($minitpl = false, $noCommonTemplate=false)
     //does template exist?
     if (!file_exists(__DIR__.'/../tpl/stdstyle/' . $tplname . '.tpl.php')) {
         //set up the error template
-        $error = true;
         tpl_set_var('error_msg', "Page not found");
         tpl_set_var('tplname', $tplname);
         $tplname = 'error';
@@ -199,9 +196,6 @@ function tpl_BuildTemplate($minitpl = false, $noCommonTemplate=false)
 
     $sCode = tpl_do_translate($sCode);
 
-    //store the cookie
-    write_cookie_settings();
-
     //send http-no-caching-header
     http_write_no_cache();
 
@@ -210,13 +204,6 @@ function tpl_BuildTemplate($minitpl = false, $noCommonTemplate=false)
 
     //run the template code
     eval('?>'.$sCode);
-}
-
-//store the cookie vars
-function write_cookie_settings()
-{
-    global $lang;
-    OcCookie::set('lang', $lang, true);
 }
 
 function http_write_no_cache()

--- a/lib/ftsearch.inc.php
+++ b/lib/ftsearch.inc.php
@@ -42,8 +42,6 @@ $ftsearch_simplerules[] = array('va', 'wa');
 
 function ftsearch_hash(&$str)
 {
-    global $lang;
-
     $astr = ftsearch_split($str, true);
 
     foreach ($astr AS $k => $s) {

--- a/lib/language.inc.php
+++ b/lib/language.inc.php
@@ -24,10 +24,9 @@ function getAutoloadTranslationWithoutFailover($str, $lang)
  */
 function tr($str, array $args = null)
 {
-    global $lang;
     if (is_null($args)) {
-        return I18n::translatePhrase($str, $lang);
+        return I18n::translatePhrase($str);
     } else {
-        return vsprintf(I18n::translatePhrase($str, $lang), $args);
+        return vsprintf(I18n::translatePhrase($str), $args);
     }
 }

--- a/lib/language.inc.php
+++ b/lib/language.inc.php
@@ -31,15 +31,3 @@ function tr($str, array $args = null)
         return vsprintf(I18n::translatePhrase($str, $lang), $args);
     }
 }
-
-function tr2($str, $lang)
-{
-    global $language;
-
-    if (!isset($language[$lang])) {
-        I18n::loadLangFile($lang);
-    }
-
-    return I18n::translatePhrase($str, $lang);
-}
-

--- a/lib/language.inc.php
+++ b/lib/language.inc.php
@@ -24,7 +24,7 @@ function getAutoloadTranslationWithoutFailover($str, $lang)
  */
 function tr($str, array $args = null)
 {
-    global $language, $lang;
+    global $lang;
     if (is_null($args)) {
         return I18n::translatePhrase($str, $lang);
     } else {

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2687,4 +2687,7 @@ $translations = array(
     'page_error_2' => 'The OC site admins have been notified.',
     'page_error_3' => 'If the problem persists, please <a href="/articles.php?page=contact">contact</a> the OC team and describe step by step how to reproduce this error.',
     'page_error_back' => 'Go to the main page',
+
+    'common_enableCrowdinInContext' => 'Improve translations',
+    'common_disableCrowdinInContext' => 'Disable translations improvement mode',
 );

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2656,6 +2656,7 @@ $translations = array(
     'myNotes_coordsRemovingError' => 'User coordinates removing failed',
     'myNotes_emptyList' => 'No notes found in geocaches',
     'myNotes_showFullNote' => 'more',
+    'myNotes_hideFullNote' => 'less',
 
     'gdpr_text' => 'From May 25, 2018, due to the provisions of the GDPR, we changed',
     'gdpr_text2' => 'To continue using the site, read the changes and accept them. <br> If you do not agree - <a href="mailto:{OCTeamEmail}"> contact us </a> to delete your account on the site.',

--- a/lib/search.ggz.inc.php
+++ b/lib/search.ggz.inc.php
@@ -1,11 +1,11 @@
 <?php
 
-function call_okapi($usr, $waypoints, $lang, $file_base_name, $zip_part)
+function call_okapi($usr, $waypoints, $language, $file_base_name, $zip_part)
 {
 
     $okapi_response = \okapi\Facade::service_call('services/caches/formatters/ggz', $usr['userid'], array(
                 'cache_codes' => $waypoints,
-                'langpref' => $lang,
+                'langpref' => $language,
                 'ns_ground' => 'true',
                 'ns_ox' => 'true',
                 'images' => 'none',

--- a/lib/search.gpx.inc.php
+++ b/lib/search.gpx.inc.php
@@ -9,6 +9,7 @@ use Utils\Database\XDb;
 use Utils\Database\OcDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
 use lib\Objects\GeoCache\CacheNote;
+use Utils\I18n\I18n;
 
 global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 require_once (__DIR__.'/common.inc.php');
@@ -482,11 +483,12 @@ if ($usr || ! $hide_coords) {
 
         // start extra info
         $thisextra = "";
+        $language = I18n::getCurrentLang();
         $rsAttributes = XDb::xSql("SELECT `caches_attributes`.`attrib_id`, `cache_attrib`.`text_long`
                 FROM `caches_attributes`, `cache_attrib`
                 WHERE `caches_attributes`.`cache_id`= ?
                     AND `caches_attributes`.`attrib_id` = `cache_attrib`.`id`
-                    AND `cache_attrib`.`language` = '$lang'
+                    AND `cache_attrib`.`language` = '$language'
                 ORDER BY `caches_attributes`.`attrib_id`", $r['cacheid']);
 
         if (($r['votes'] > 3) || ($r['topratings'] > 0) || (XDb::xNumRows($rsAttributes) > 0)) {
@@ -583,11 +585,10 @@ if ($usr || ! $hide_coords) {
         $thisline = str_replace('{owner}', xmlentities(convert_string($r['username'])), $thisline);
         $thisline = str_replace('{owner_id}', xmlentities($r['owner_id']), $thisline);
 
-        $lang = XDb::xEscape($lang);
         $rsAttributes = XDb::xSql("SELECT `caches_attributes`.`attrib_id`, `cache_attrib`.`text_long`
                 FROM `caches_attributes`, `cache_attrib`
                 WHERE `caches_attributes`.`cache_id`= ? AND `caches_attributes`.`attrib_id` = `cache_attrib`.`id`
-                    AND `cache_attrib`.`language` = '$lang'
+                    AND `cache_attrib`.`language` = '$language'
                 ORDER BY `caches_attributes`.`attrib_id`", $r['cacheid']);
 
         // create log list

--- a/lib/search.gpxgc.inc.php
+++ b/lib/search.gpxgc.inc.php
@@ -7,6 +7,7 @@ use Utils\Database\OcDb;
 use lib\Objects\GeoCache\CacheNote;
 use lib\Objects\GeoCache\GeoCacheCommons;
 use lib\Objects\GeoCache\GeoCacheLog;
+use Utils\I18n\I18n;
 
 global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 
@@ -359,11 +360,11 @@ if ($usr || ! $hide_coords) {
         // start extra info
         $thisextra = "";
 
-        $lang = XDb::xEscape($lang);
+        $language = I18n::getCurrentLang();
         $rsAttributes = XDb::xSql("SELECT `cache_attrib`.`id`, `caches_attributes`.`attrib_id`, `cache_attrib`.`text_long`
                             FROM `caches_attributes`, `cache_attrib`
                             WHERE `caches_attributes`.`cache_id`= ? AND `caches_attributes`.`attrib_id` = `cache_attrib`.`id`
-                                AND `cache_attrib`.`language` = '$lang'
+                                AND `cache_attrib`.`language` = '$language'
                             ORDER BY `caches_attributes`.`attrib_id`", $r['cacheid']);
 
             if (($r['votes'] > 3) || ($r['topratings'] > 0) || (XDb::xNumRows($rsAttributes) > 0)) {
@@ -578,9 +579,8 @@ if ($usr || ! $hide_coords) {
         // Waypoints
         $waypoints = '';
 
-        $lang = XDb::xEscape($lang);
         $rswp = XDb::xSql(
-            "SELECT  `longitude`, `cache_id`, `latitude`,`desc`,`stage`, `type`, `status`,`waypoint_type`." . $lang . " `wp_type_name`
+            "SELECT  `longitude`, `cache_id`, `latitude`,`desc`,`stage`, `type`, `status`,`waypoint_type`." . $language . " `wp_type_name`
             FROM `waypoints`
                 INNER JOIN waypoint_type ON (waypoints.type = waypoint_type.id)
             WHERE  `waypoints`.`cache_id`=?

--- a/lib/search.html.inc.php
+++ b/lib/search.html.inc.php
@@ -6,6 +6,7 @@ use Utils\Text\Formatter;
 use Utils\Uri\Uri;
 use Utils\Uri\OcCookie;
 use lib\Objects\Coordinates\Coordinates;
+use Utils\I18n\I18n;
 
 /**
  * This script is used (can be loaded) by /search.php
@@ -68,7 +69,7 @@ function fHideColumn($nr, $set)
     return $C;
 }
 
-global $dbcSearch, $usr, $lang, $hide_coords, $NrColSortSearch, $OrderSortSearch, $SearchWithSort, $TestStartTime, $queryFilter;
+global $dbcSearch, $usr, $hide_coords, $NrColSortSearch, $OrderSortSearch, $SearchWithSort, $TestStartTime, $queryFilter;
 require_once (__DIR__.'/../tpl/stdstyle/lib/icons.inc.php');
 require_once (__DIR__.'/calculation.inc.php');
 
@@ -319,7 +320,7 @@ if ($usr === false) {
         $query .= ' LEFT JOIN `cache_mod_cords` ON `caches`.`cache_id` = `cache_mod_cords`.`cache_id` AND `cache_mod_cords`.`user_id` = ' . $usr['userid'] . ' ';
     }
 }
-$query .= ' LEFT JOIN cache_desc ON cache_desc.cache_id=caches.cache_id AND cache_desc.language=\'' . $lang . '\',
+$query .= ' LEFT JOIN cache_desc ON cache_desc.cache_id=caches.cache_id AND cache_desc.language=\'' . I18n::getCurrentLang() . '\',
             `user`, cache_type
         WHERE `caches`.`user_id`=`user`.`user_id`
         AND `caches`.`cache_id` IN (' . $queryFilter . ')
@@ -400,7 +401,7 @@ for ($i = 0; $i < $dbcSearch->rowCount($s); $i ++) {
         }
     }
     ;
-    $tmpline = str_replace('{cachetype}', htmlspecialchars(cache_type_from_id($caches_record['cache_type'], $lang), ENT_COMPAT, 'UTF-8'), $tmpline);
+    $tmpline = str_replace('{cachetype}', htmlspecialchars(cache_type_from_id($caches_record['cache_type']), ENT_COMPAT, 'UTF-8'), $tmpline);
 
     // sp2ong short_desc ermitteln TODO: nicht die erste sondern die richtige wĂ¤hlen
     $tmpline = str_replace('{wp_oc}', htmlspecialchars($caches_record['wp_oc'], ENT_COMPAT, 'UTF-8'), $tmpline);

--- a/lib/search.jsoncodes.inc.php
+++ b/lib/search.jsoncodes.inc.php
@@ -10,7 +10,7 @@
  * https://github.com/opencaching/opencaching-pl/issues/1039
  */
 
-global $content, $dbcSearch, $lang;
+global $content, $dbcSearch;
 
 $rs = $dbcSearch->simpleQuery("
     select wp_oc

--- a/lib/search.kml.inc.php
+++ b/lib/search.kml.inc.php
@@ -7,8 +7,9 @@ ob_start();
 
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 
-global $absolute_server_URI, $bUseZip, $usr, $hide_coords, $lang, $dbcSearch, $queryFilter;
+global $absolute_server_URI, $bUseZip, $usr, $hide_coords, $dbcSearch, $queryFilter;
 require_once (__DIR__.'/format.kml.inc.php');
 require_once (__DIR__.'/calculation.inc.php');
 
@@ -147,8 +148,19 @@ if ($usr || ! $hide_coords) {
      * lat
      * icon
      */
+    $language = I18n::getCurrentLang();
+    $s = $dbcSearch->simpleQuery(
+        'SELECT `kmlcontent`.`cache_id` `cacheid`, `kmlcontent`.`status` `status`,
+                `kmlcontent`.`longitude` `longitude`, `kmlcontent`.`latitude` `latitude`, `kmlcontent`.cache_mod_cords_id,
+                `kmlcontent`.`type` `type`, `caches`.`date_hidden` `date_hidden`, `caches`.`name` `name`, `caches`.`wp_oc`
+                `cache_wp`, `cache_type`.`' . $language . '` `typedesc`, `cache_size`.`' . $language . '` `sizedesc`,
+                `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username`
+        FROM `kmlcontent`, `caches`, `cache_type`, `cache_size`, `user`
+        WHERE `kmlcontent`.`cache_id`=`caches`.`cache_id`
+            AND `kmlcontent`.`type`=`cache_type`.`id`
+            AND `kmlcontent`.`size`=`cache_size`.`id`
+            AND `kmlcontent`.`user_id`=`user`.`user_id`');
 
-    $s = $dbcSearch->simpleQuery('SELECT `kmlcontent`.`cache_id` `cacheid`, `kmlcontent`.`status` `status`, `kmlcontent`.`longitude` `longitude`, `kmlcontent`.`latitude` `latitude`, `kmlcontent`.cache_mod_cords_id, `kmlcontent`.`type` `type`, `caches`.`date_hidden` `date_hidden`, `caches`.`name` `name`, `caches`.`wp_oc` `cache_wp`, `cache_type`.`' . $lang . '` `typedesc`, `kmlcontent`.`size`, `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username` FROM `kmlcontent`, `caches`, `cache_type`, `user` WHERE `kmlcontent`.`cache_id`=`caches`.`cache_id` AND `kmlcontent`.`type`=`cache_type`.`id` AND `kmlcontent`.`user_id`=`user`.`user_id`');
     while ($r = $dbcSearch->dbResultFetch($s)) {
         $thisline = $kmlLine;
         $thiskmlTypeIMG = $kmlTypeIMG;

--- a/lib/search.okapi.inc.php
+++ b/lib/search.okapi.inc.php
@@ -2,11 +2,12 @@
 use Utils\Database\XDb;
 use okapi\core\Exception\BadRequest;
 use okapi\Facade;
+use Utils\I18n\I18n;
 /**
  * This script is used (can be loaded) by /search.php
  */
 
-global $content, $usr, $hide_coords, $lang, $dbcSearch;
+global $content, $usr, $hide_coords, $dbcSearch;
 
 set_time_limit(1800);
 
@@ -178,7 +179,7 @@ if ($usr || !$hide_coords) {
         // OKAPI services from within OC code.
 
         try {
-            $okapi_response = call_okapi($usr, $waypoints, $lang, $sFilebasename, $zippart);
+            $okapi_response = call_okapi($usr, $waypoints, I18n::getCurrentLang(), $sFilebasename, $zippart);
 
             // This outputs headers and the file content.
             $okapi_response->display();

--- a/lib/search.txt.inc.php
+++ b/lib/search.txt.inc.php
@@ -12,7 +12,7 @@ use lib\Objects\GeoCache\GeoCacheCommons;
 use lib\Objects\GeoCache\CacheNote;
 use lib\Objects\Coordinates\Coordinates;
 
-global $content, $bUseZip, $hide_coords, $usr, $lang, $dbcSearch;
+global $content, $bUseZip, $hide_coords, $usr, $dbcSearch;
 
 set_time_limit(1800);
 

--- a/lib/search.wpt.inc.php
+++ b/lib/search.wpt.inc.php
@@ -6,8 +6,9 @@
 ob_start();
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
-global $content, $bUseZip, $usr, $hide_coords, $dbcSearch, $lang;
+global $content, $bUseZip, $usr, $hide_coords, $dbcSearch;
 
 set_time_limit(1800);
 
@@ -163,8 +164,8 @@ if( $usr || !$hide_coords ) {
                 (SELECT cache_id FROM cache_logs WHERE deleted=0 AND user_id='.$usr['userid'].' AND (type=1 OR type=8)),1,0)
                 as found, `wptcontent`.`longitude` `longitude`, `wptcontent`.`latitude` `latitude`, `wptcontent`.cache_mod_cords_id,
                 `caches`.`date_hidden` `date_hidden`, `caches`.`name` `name`, `caches`.`wp_oc` `wp_oc`, `cache_type`.`short` `typedesc`,
-                `wptcontent`.`size` `size`, `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username` ,
-                `caches`.`status` `status`, `caches`.`type` `type` FROM `wptcontent`, `caches`, `cache_type`, `user`
+                `cache_size`.`'.I18n::getCurrentLang().'` `sizedesc`, `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username` ,
+                `caches`.`size` `size`, `caches`.`status` `status`, `caches`.`type` `type` FROM `wptcontent`, `caches`, `cache_type`, `cache_size`, `user`
         WHERE `wptcontent`.`cache_id`=`caches`.`cache_id`
             AND `wptcontent`.`type`=`cache_type`.`id`
             AND `wptcontent`.`user_id`=`user`.`user_id`' );

--- a/lib/search.wpt.inc.php
+++ b/lib/search.wpt.inc.php
@@ -164,8 +164,8 @@ if( $usr || !$hide_coords ) {
                 (SELECT cache_id FROM cache_logs WHERE deleted=0 AND user_id='.$usr['userid'].' AND (type=1 OR type=8)),1,0)
                 as found, `wptcontent`.`longitude` `longitude`, `wptcontent`.`latitude` `latitude`, `wptcontent`.cache_mod_cords_id,
                 `caches`.`date_hidden` `date_hidden`, `caches`.`name` `name`, `caches`.`wp_oc` `wp_oc`, `cache_type`.`short` `typedesc`,
-                `cache_size`.`'.I18n::getCurrentLang().'` `sizedesc`, `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username` ,
-                `caches`.`size` `size`, `caches`.`status` `status`, `caches`.`type` `type` FROM `wptcontent`, `caches`, `cache_type`, `cache_size`, `user`
+                `wptcontent`.`size` `size`,`caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`, `user`.`username` `username` ,
+                `caches`.`status` `status`, `caches`.`type` `type` FROM `wptcontent`, `caches`, `cache_type`, `user`
         WHERE `wptcontent`.`cache_id`=`caches`.`cache_id`
             AND `wptcontent`.`type`=`cache_type`.`id`
             AND `wptcontent`.`user_id`=`user`.`user_id`' );

--- a/lib/search.xml.inc.php
+++ b/lib/search.xml.inc.php
@@ -3,12 +3,12 @@ use Utils\Database\XDb;
 use Utils\Database\OcDb;
 use lib\Objects\Coordinates\Coordinates;
 use lib\Objects\GeoCache\GeoCacheCommons;
-
+use Utils\I18n\I18n;
 /**
  * This script is used (can be loaded) by /search.php
  */
 
-global $content, $bUseZip, $dbcSearch, $lang;
+global $content, $bUseZip, $dbcSearch;
 
 require_once (__DIR__.'/../lib/calculation.inc.php');
 
@@ -155,13 +155,13 @@ echo "      <startat>" . $startat . "</startat>\n";
 echo "      <perpage>" . $count . "</perpage>\n";
 echo "  </docinfo>\n";
 
-
+$language = I18n::getCurrentLang();
 $stmt = XDb::xSql(
     'SELECT `xmlcontent`.`cache_id` `cacheid`, `xmlcontent`.`longitude` `longitude`, `xmlcontent`.`latitude` `latitude`,
             `xmlcontent`.cache_mod_cords_id, `caches`.`wp_oc` `waypoint`, `caches`.`date_hidden` `date_hidden`,
             `caches`.`name` `name`, `caches`.`country` `country`, `caches`.`type` `type_id`, `caches`.`terrain` `terrain`,
             `caches`.`difficulty` `difficulty`, `caches`.`desc_languages` `desc_languages`,
-            `caches`.`size`, `cache_type`.`'.$lang.'` `type`, `cache_status`.`'.$lang.'` `status`,
+            `cache_size`.`'.$language.'` `size`, `cache_type`.`'.$language.'` `type`, `cache_status`.`'.$language.'` `status`,
             `user`.`username` `username`, `cache_desc`.`desc` `desc`, `cache_desc`.`short_desc` `short_desc`,
             `cache_desc`.`hint` `hint`, `cache_desc`.`desc_html` `html`, `xmlcontent`.`distance` `distance`
     FROM `xmlcontent`, `caches`, `user`, `cache_desc`, `cache_type`, `cache_status`

--- a/lib/search.xml.inc.php
+++ b/lib/search.xml.inc.php
@@ -161,7 +161,7 @@ $stmt = XDb::xSql(
             `xmlcontent`.cache_mod_cords_id, `caches`.`wp_oc` `waypoint`, `caches`.`date_hidden` `date_hidden`,
             `caches`.`name` `name`, `caches`.`country` `country`, `caches`.`type` `type_id`, `caches`.`terrain` `terrain`,
             `caches`.`difficulty` `difficulty`, `caches`.`desc_languages` `desc_languages`,
-            `cache_size`.`'.$language.'` `size`, `cache_type`.`'.$language.'` `type`, `cache_status`.`'.$language.'` `status`,
+            `caches`.`size`, `cache_type`.`'.$language.'` `type`, `cache_status`.`'.$language.'` `status`,
             `user`.`username` `username`, `cache_desc`.`desc` `desc`, `cache_desc`.`short_desc` `short_desc`,
             `cache_desc`.`hint` `hint`, `cache_desc`.`desc_html` `html`, `xmlcontent`.`distance` `distance`
     FROM `xmlcontent`, `caches`, `user`, `cache_desc`, `cache_type`, `cache_status`

--- a/lib/search.zip.inc.php
+++ b/lib/search.zip.inc.php
@@ -1,10 +1,11 @@
 <?php
 
 use okapi\Facade;
+use Utils\I18n\I18n;
 
-function call_okapi($usr, $waypoints, $lang, $file_base_name, $zip_part)
+function call_okapi($usr, $waypoints, $file_base_name, $zip_part)
 {
-    $okapi_params = array('cache_codes' => $waypoints, 'langpref' => $lang,
+    $okapi_params = array('cache_codes' => $waypoints, 'langpref' => I18n::getCurrentLang(),
         'location_source' => 'alt_wpt:user-coords', 'location_change_prefix' => '(F)');
     // TODO: limit log entries per geocache?
     if (isset($_GET['format']))

--- a/lib/settings-example.inc.php
+++ b/lib/settings-example.inc.php
@@ -10,10 +10,6 @@ date_default_timezone_set('Europe/Warsaw');
 // country-id of the running node: pl|ro|nl...
 $config['ocNode'] = 'pl';
 
-//default used language
-if (!isset($lang))
-    $lang = 'pl';
-
 //pagetitle
 if (!isset($pagetitle))
     $pagetitle = 'Geocaching Opencaching Polska';

--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -67,12 +67,6 @@ $config = array(
     'defaultLanguageList' => array(
         'PL', 'EN', 'FR', 'DE', 'NL', 'RO'
     ),
-    /** Languages supported by OC node -
-     * for those languages translations are supported both in file and db-tables
-     * IMPORTANT: use lower letters only! */
-    'supportedLanguages' => array (
-        'pl', 'en', 'nl', 'ro'
-    ),
     /** default country in user registration form */
     'defaultCountry' => 'PL',
 

--- a/lib/t102.php
+++ b/lib/t102.php
@@ -1,6 +1,9 @@
+<?php
+use Utils\I18n\I18n;
+?>
 
 <div id='idGTC' align = "center"> </div>
-<script>GCTLoad( 'ChartTable', '" . $lang . "' );</script>
+<script>GCTLoad( 'ChartTable', '" . <?=I18n::getCurrentLang()?> . "' );</script>
 
 <script>
     var gct = new GCT('idGTC');

--- a/lib/tbr102.php
+++ b/lib/tbr102.php
@@ -23,8 +23,6 @@ require_once(__DIR__.'/common.inc.php');
         $sDateCondition = "";
         $sTypeCondition = "";
 
-        global $lang;
-
         $sUserIDLine = $_REQUEST["UserID"];
         $sDateFrom = $_REQUEST["DF"];
         $sDateTo = $_REQUEST["DT"];
@@ -43,13 +41,13 @@ require_once(__DIR__.'/common.inc.php');
 
         if ($nDayInterval < 65) {
             $sGranulate = " (week( cl.date) + 1) period ";
-            $sPeriodName = tr2('.week', $lang);
+            $sPeriodName = tr('.week');
         } else if ($nDayInterval < 367) {
             $sGranulate = " month( cl.date) period ";
-            $sPeriodName = tr2('.month', $lang);
+            $sPeriodName = tr('.month');
         } else {
             $sGranulate = " year( cl.date) period ";
-            $sPeriodName = tr2('.year', $lang);
+            $sPeriodName = tr('.year');
         }
 
 
@@ -71,10 +69,10 @@ require_once(__DIR__.'/common.inc.php');
 
 
         if (!strlen($sUserIDLine))
-            $sEND = tr2('SelectUsers', $lang);
+            $sEND = tr('SelectUsers');
 
         if (count($asUserID) > 30)
-            $sEND = tr2('more30', $lang);
+            $sEND = tr('more30');
 
         if ($sEND <> "") {
             echo "<script>";

--- a/lib/th102.php
+++ b/lib/th102.php
@@ -22,8 +22,6 @@ require_once(__DIR__.'/common.inc.php');
         $sDateCondition = "";
         $sTypeCondition = "";
 
-        global $lang;
-
         $sUserIDLine = $_REQUEST["UserID"];
         $sDateFrom = $_REQUEST["DF"];
         $sDateTo = $_REQUEST["DT"];
@@ -49,10 +47,10 @@ require_once(__DIR__.'/common.inc.php');
 
 
         if (!strlen($sUserIDLine))
-            $sEND = tr2('SelectUsers', $lang);
+            $sEND = tr('SelectUsers');
 
         if (count($asUserID) > 10)
-            $sEND = tr2('more10', $lang);
+            $sEND = tr('more10');
 
         echo "<script>";
         if ($sEND <> "") {
@@ -112,7 +110,7 @@ require_once(__DIR__.'/common.inc.php');
 
 //echo "gcl.addChartOption('vAxis', { title: 'Ilość keszy' } );";
         echo " var chartOpt = gcl.getChartOption();";
-        echo " chartOpt.vAxis.title= '" . tr2('NrCaches', $lang) . "';";
+        echo " chartOpt.vAxis.title= '" . tr('NrCaches') . "';";
         echo "</script>";
 
 ////////////////////////////

--- a/log.php
+++ b/log.php
@@ -16,6 +16,7 @@ use lib\Objects\GeoCache\GeoCacheLogCommons;
 use Utils\EventHandler\EventHandler;
 use Utils\Text\InputFilter;
 use lib\Objects\GeoCache\MobileCacheMove;
+use Utils\I18n\I18n;
 
 /*
  * todo: create and set up 4 template selector with wybor_WE wybor_NS.
@@ -791,8 +792,8 @@ if (isset($_POST['submitform']) && ($all_ok == true)) {
             }
         }
 
-        if (isset($type[$lang])){
-            $lang_db = $lang;
+        if (isset($type[I18n::getCurrentLang()])){
+            $lang_db = I18n::getCurrentLang();
         } else {
             $lang_db = "en";
         }
@@ -877,7 +878,7 @@ if (isset($_POST['submitform']) && ($all_ok == true)) {
 
 
 //make the template and send it out
-tpl_set_var('language4js', $lang);
+tpl_set_var('language4js', I18n::getCurrentLang());
 tpl_BuildTemplate();
 
 

--- a/mobile/geo.php
+++ b/mobile/geo.php
@@ -2,6 +2,7 @@
 
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 
 require_once("./lib/common.inc.php");
 
@@ -63,7 +64,7 @@ if (isset($_GET['wp']) && !empty($_GET['wp']) && isset($_GET['output']) && !empt
                 $attr_text = '';
                 while ($rekord = XDb::xFetchArray($wynik)) {
 
-                    $query = "select text_long from cache_attrib where id ='" . $rekord['attrib_id'] . "' and language = '" . $lang . "';";
+                    $query = "select text_long from cache_attrib where id ='" . $rekord['attrib_id'] . "' and language = '" . I18n::getCurrentLang() . "';";
                     $wynik2 = XDb::xSql($query);
                     $attr = XDb::xFetchArray($wynik2);
                     $attr_text .= $attr[0] . " | ";
@@ -158,4 +159,4 @@ if (isset($_GET['wp']) && !empty($_GET['wp']) && isset($_GET['output']) && !empt
         }
     }
 }
-?>
+

--- a/mobile/lib/findalgo.inc.php
+++ b/mobile/lib/findalgo.inc.php
@@ -2,6 +2,7 @@
 
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 
 require_once('../lib/ClassPathDictionary.php');
 
@@ -17,11 +18,12 @@ if (isSet($_GET['nazwa']) && !empty($_GET['nazwa']) ||
     function find_news($start, $end)
     {
 
-        global $lang;
         global $ile;
         global $url;
         global $tpl;
         global $znalezione;
+
+        $language = I18n::getCurrentLang();
 
         if (isSet($_GET['nazwa'])) {
             $nazwa = XDb::xEscape($_GET['nazwa']);
@@ -93,7 +95,7 @@ if (isSet($_GET['nazwa']) && !empty($_GET['nazwa']) ||
                 $wynik2 = XDb::xSql($query);
                 $wiersz = XDb::xFetchArray($wynik2);
 
-                $query = "select " . $lang . " from cache_type where id = " . $rekord['type'] . ";";
+                $query = "select " . $language . " from cache_type where id = " . $rekord['type'] . ";";
                 $wynik2 = XDb::xSql($query);
                 $wiersz2 = XDb::xFetchArray($wynik2);
 

--- a/mobile/lib/lang.inc.php
+++ b/mobile/lib/lang.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use Utils\I18n\I18n;
+
 if (isset($_COOKIE['lang']))
     switch ($_COOKIE['lang']) {
         case 'en':
@@ -18,9 +20,10 @@ if (isset($_COOKIE['lang']))
             $lang2 = 'ro';
             break;
         default:
-            $lang2 = $lang;
-    } else
-    $lang2 = $lang;
+            $lang2 = I18n::getCurrentLang();
+} else {
+    $lang2 = I18n::getCurrentLang();
+}
 
 $fhandle = fopen(dirname(__FILE__) . "/lang/" . $lang2, "r");
 

--- a/mobile/mywatches.php
+++ b/mobile/mywatches.php
@@ -1,5 +1,6 @@
 <?php
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 require_once("./lib/common.inc.php");
 
 if (isset($_SESSION['user_id'])) {
@@ -8,8 +9,6 @@ if (isset($_SESSION['user_id'])) {
 
     function find_news($start, $end)
     {
-
-        global $lang;
         global $ile;
         global $url;
         global $znalezione;
@@ -45,7 +44,7 @@ if (isset($_SESSION['user_id'])) {
                     $wynik2 = XDb::xSql($query);
                     $wiersz = XDb::xFetchArray($wynik2);
 
-                    $query = "select " . $lang . " from cache_type where id = " . $rekord['type'] . ";";
+                    $query = "select " . I18n::getCurrentLang() . " from cache_type where id = " . $rekord['type'] . ";";
                     $wynik2 = XDb::xSql($query);
                     $wiersz2 = XDb::xFetchArray($wynik2);
                     $rekord['if_found'] = $if_found;

--- a/mobile/near.php
+++ b/mobile/near.php
@@ -1,6 +1,7 @@
 <?php
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 require_once("./lib/common.inc.php");
 
 function makeUrl($url)
@@ -165,7 +166,7 @@ if (isset($_GET['ns']) && isset($_GET['ew']) && isset($_GET['radius']) && isset(
             if ($kier >= 292.5 && $kier < 337.5)
                 $kier = 'NW';
 
-            $query = "select " . $lang . " from cache_type where id = '" . $wiersz['type'] . "';";
+            $query = "select " . I18n::getCurrentLang() . " from cache_type where id = '" . $wiersz['type'] . "';";
             $wynik2 = XDb::xSql($query);
             $wiersz2 = XDb::xFetchArray($wynik2);
             $rekord['typetext'] = $wiersz2[0];

--- a/mobile/newest.php
+++ b/mobile/newest.php
@@ -1,5 +1,6 @@
 <?php
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 require_once("./lib/common.inc.php");
 
 
@@ -19,7 +20,7 @@ while ($rekord = XDb::xFetchArray($wynik)) {
     $wynik2 = XDb::xSql($query);
     $wiersz = XDb::xFetchArray($wynik2);
 
-    $query = "select " . $lang . " from cache_type where id = " . $rekord['type'] . ";";
+    $query = "select " . I18n::getCurrentLang() . " from cache_type where id = " . $rekord['type'] . ";";
     $wynik2 = XDb::xSql($query);
     $wiersz2 = XDb::xFetchArray($wynik2);
 

--- a/mobile/viewcache.php
+++ b/mobile/viewcache.php
@@ -2,6 +2,7 @@
 use Utils\Database\XDb;
 use Utils\Database\OcDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 
 require_once("./lib/common.inc.php");
 
@@ -82,13 +83,13 @@ if (isSet($_GET['wp']) && !empty($_GET['wp']) && $_GET['wp'] != "OP") {
         $query = "select attrib_id from caches_attributes where cache_id ='" . $caches['cache_id'] . '\';';
         $cache_attributes = XDb::xSql($query);
 
-        $query = "select " . $lang . " from cache_type where id =" . $caches['type'] . ';';
+        $query = "select " . I18n::getCurrentLang() . " from cache_type where id =" . $caches['type'] . ';';
         $wynik = XDb::xSql($query);
         $cache_type = XDb::xFetchArray($wynik);
 
         $cache_size = tr(GeoCacheCommons::CacheSizeTranslationKey($caches['size']));
 
-        $query = "select " . $lang . " from cache_status where id =" . $caches['status'] . ';';
+        $query = "select " . I18n::getCurrentLang() . " from cache_status where id =" . $caches['status'] . ';';
         $wynik = XDb::xSql($query);
         $cache_status = XDb::xFetchArray($wynik);
 
@@ -171,7 +172,7 @@ if (isSet($_GET['wp']) && !empty($_GET['wp']) && $_GET['wp'] != "OP") {
 
             while ($rekord = XDb::xFetchArray($cache_attributes)) {
 
-                $query = "select text_long from cache_attrib where id ='" . $rekord['attrib_id'] . "' and language = '" . $lang . "';";
+                $query = "select text_long from cache_attrib where id ='" . $rekord['attrib_id'] . "' and language = '" . I18n::getCurrentLang() . "';";
                 $wynik = XDb::xSql($query);
                 $attr = XDb::xFetchArray($wynik);
                 $attr_text .= "\\n" . $attr[0] . "\\n";

--- a/my_logs.php
+++ b/my_logs.php
@@ -4,8 +4,6 @@ use lib\Objects\GeoCache\GeoCacheLog;
 use Utils\Database\XDb;
 use Utils\Text\Formatter;
 
-global $lang;
-
 //include template handling
 require_once(__DIR__.'/lib/common.inc.php');
 

--- a/my_logsFind.php
+++ b/my_logsFind.php
@@ -4,8 +4,6 @@ use lib\Objects\GeoCache\GeoCacheLog;
 use Utils\Database\XDb;
 use Utils\Text\Formatter;
 
-global $lang;
-
 require_once(__DIR__.'/lib/common.inc.php');
 
 //user logged in?

--- a/mycaches.php
+++ b/mycaches.php
@@ -4,8 +4,9 @@ use lib\Objects\GeoCache\GeoCacheLog;
 use Utils\Database\OcDb;
 use Utils\Database\XDb;
 use Utils\Text\Formatter;
+use Utils\I18n\I18n;
 
-global $lang, $usr;
+global $usr;
 
 //include template handling
 require_once(__DIR__.'/lib/common.inc.php');
@@ -28,13 +29,7 @@ if ($usr == false) {
     $tplname = 'mycaches';
     require(__DIR__.'/tpl/stdstyle/newlogs.inc.php');
 
-    if (XDb::xContainsColumn('cache_status', $lang)) {
-        $lang_db = $lang;
-    } else {
-        $lang_db = "en";
-    }
-
-    $eLang = XDb::xEscape($lang_db);
+    $eLang = I18n::getLangForDbTranslations('cache_status');
 
     $rs_stat = XDb::xMultiVariableQueryValue(
         "SELECT cache_status.$eLang FROM cache_status WHERE `cache_status`.`id` = :1 ", 0, $stat_cache);

--- a/mycaches_logs.php
+++ b/mycaches_logs.php
@@ -4,7 +4,7 @@ use lib\Objects\GeoCache\GeoCacheLog;
 use Utils\Database\XDb;
 use Utils\Text\Formatter;
 
-global $lang, $usr;
+global $usr;
 
 //include template handling
 require_once(__DIR__.'/lib/common.inc.php');

--- a/myhome.php
+++ b/myhome.php
@@ -4,6 +4,7 @@ use Utils\Database\XDb;
 use lib\Objects\User\User;
 use Utils\Text\TextConverter;
 use lib\Objects\User\UserStats;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -62,7 +63,7 @@ if ($error == false) {
                     AND `log_types`.`id`=`cache_logs`.`type`
                     AND `log_types_text`.`log_types_id`=`log_types`.`id` AND `log_types_text`.`lang`= ?
                     ORDER BY `cache_logs`.`date` DESC, `cache_logs`.`date_created` DESC
-                    LIMIT 10", $usr['userid'], $lang);
+                    LIMIT 10", $usr['userid'], I18n::getCurrentLang());
 
         if (XDb::xNumRows($rs_logs) == 0) {
 
@@ -85,11 +86,7 @@ if ($error == false) {
         }
 
         //get last hidden caches
-        if (XDb::xContainsColumn('cache_status', $lang))
-            $lang_db = $lang;
-        else
-            $lang_db = "en";
-
+        $lang_db = I18n::getLangForDbTranslations('cache_status');
         $rs_caches = XDb::xSql("  SELECT  `cache_id`, `name`, `date_hidden`, `status`,
                             `cache_status`.`id` AS `cache_status_id`, `cache_status`.`".XDb::xEscape($lang_db)."` AS `cache_status_text`
                         FROM `caches`, `cache_status`
@@ -168,7 +165,7 @@ if ($error == false) {
                     AND `log_types`.`id`=`cache_logs`.`type`
                     AND `log_types_text`.`log_types_id`=`log_types`.`id` AND `log_types_text`.`lang`= ?
                     ORDER BY `cache_logs`.`date` DESC, `cache_logs`.`date_created` DESC
-                    LIMIT 10", $usr['userid'], $lang);
+                    LIMIT 10", $usr['userid'], I18n::getCurrentLang());
 
         if (XDb::xNumRows($rs_logs) == 0) {
             tpl_set_var('last_logs_in_your_caches', $no_logs);

--- a/myroutes_add_map2.php
+++ b/myroutes_add_map2.php
@@ -1,6 +1,7 @@
 <?php
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -16,7 +17,10 @@ if ($error == false) {
         $tplname = 'myroutes_add_map2';
         $view = tpl_getView();
 
-        tpl_set_var('cachemap_header', '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key . '&amp;language=' . $lang . '"></script>');
+        tpl_set_var(
+            'cachemap_header',
+            '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key .
+            '&amp;language=' . I18n::getCurrentLang() . '"></script>');
 
         // set map center
         tpl_set_var('map_lat',$main_page_map_center_lat);

--- a/myroutes_edit.php
+++ b/myroutes_edit.php
@@ -1,6 +1,7 @@
 <?php
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 global $googlemap_key;
 
@@ -50,7 +51,9 @@ if ($error == false) {
         $rdesc = isset($_POST['desc']) ? $_POST['desc'] : '';
         $rradius = isset($_POST['radius']) ? $_POST['radius'] : '';
 
-        tpl_set_var('cachemap_header', '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key . '&amp;language=' . $lang . '"></script>');
+        tpl_set_var('cachemap_header',
+            '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key .
+            '&amp;language=' . I18n::getCurrentLang() . '"></script>');
 
         if ($record['user_id'] == $usr['userid']) {
 

--- a/myroutes_search.php
+++ b/myroutes_search.php
@@ -7,6 +7,7 @@ use lib\Objects\GeoCache\GeoCache;
 use okapi\Facade;
 use okapi\core\Exception\BadRequest;
 use lib\Objects\GeoCache\CacheNote;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 require_once (__DIR__.'/lib/export.inc.php');
@@ -16,8 +17,8 @@ require_once (__DIR__.'/lib/caches.inc.php');
 require_once (__DIR__.'/tpl/stdstyle/lib/icons.inc.php');
 
 global $content, $bUseZip, $usr, $config;
-global $default_lang, $cache_attrib_jsarray_line, $cache_attrib_img_line;
-global $lang, $googlemap_key;
+global $cache_attrib_jsarray_line, $cache_attrib_img_line;
+global $googlemap_key;
 
 $database = OcDb::instance();
 
@@ -46,7 +47,9 @@ if (isset($_POST['distance'])) {
 }
 
 
-tpl_set_var('cachemap_header', '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key . '&amp;language=' . $lang . '"></script>');
+tpl_set_var('cachemap_header',
+    '<script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&amp;key=' . $googlemap_key .
+    '&amp;language=' . I18n::getCurrentLang() . '"></script>');
 
 $s = $database->paramQuery(
         'SELECT `user_id`,`name`, `description`, `radius`, `options` FROM `routes`
@@ -195,11 +198,7 @@ tpl_set_var('min_logs_caches_disabled', ($logs == 0) ? ' disabled="disabled"' : 
 $cache_attrib_jsarray_line = "new Array('{id}', {state}, '{text_long}', '{icon}', '{icon_no}', '{icon_undef}', '{category}')";
 $cache_attrib_img_line = '<img id="attrimg{id}" src="{icon}" title="{text_long}" alt="{text_long}" onmousedown="switchAttribute({id})" style="cursor: pointer;" />&nbsp;';
 
-$lang_attribute = $lang;
-if ($lang != $lang) {
-    $lang_attribute = $lang;
-}
-
+$lang_attribute = I18n::getCurrentLang();
 
 // cache-attributes
 $attributes_jsarray = '';
@@ -939,11 +938,11 @@ if (isset($_POST['submit_gpx'])) {
         // start extra info
         $thisextra = "";
 
-        $lang = XDb::xEscape($lang);
+        $language = XDb::xEscape(I18n::getCurrentLang());
         $rsAttributes = XDb::xSql("SELECT `cache_attrib`.`id`, `caches_attributes`.`attrib_id`, `cache_attrib`.`text_long`
                             FROM `caches_attributes`, `cache_attrib`
                             WHERE `caches_attributes`.`cache_id`= ? AND `caches_attributes`.`attrib_id` = `cache_attrib`.`id`
-                                AND `cache_attrib`.`language` = '$lang'
+                                AND `cache_attrib`.`language` = '$language'
                             ORDER BY `caches_attributes`.`attrib_id`", $r['cacheid']);
 
         if (($r['votes'] > 3) || ($r['topratings'] > 0) || (XDb::xNumRows($rsAttributes) > 0)) {
@@ -1112,9 +1111,9 @@ if (isset($_POST['submit_gpx'])) {
         // Waypoints
         $waypoints = '';
 
-        $lang = XDb::xEscape($lang);
+        $langCode = XDb::xEscape(I18n::getCurrentLang());
         $rswp = XDb::xSql(
-            "SELECT  `longitude`, `cache_id`, `latitude`,`desc`,`stage`, `type`, `status`,`waypoint_type`." . $lang . " `wp_type_name`
+            "SELECT  `longitude`, `cache_id`, `latitude`,`desc`,`stage`, `type`, `status`,`waypoint_type`." . $langCode . " `wp_type_name`
             FROM `waypoints`
                 INNER JOIN waypoint_type ON (waypoints.type = waypoint_type.id)
             WHERE  `waypoints`.`cache_id`=?

--- a/newcache.php
+++ b/newcache.php
@@ -11,6 +11,7 @@ use lib\Objects\OcConfig\OcConfig;
 use lib\Objects\User\User;
 use Utils\Debug\Debug;
 use Utils\EventHandler\EventHandler;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -114,8 +115,8 @@ if (! isset($_POST['size'])) {
         $sel_size = GeoCache::SIZE_NONE;
     }
 }
-$sel_lang = isset($_POST['desc_lang']) ? $_POST['desc_lang'] : $default_lang;
-$sel_country = isset($_POST['country']) ? $_POST['country'] : strtoupper($lang);
+$sel_lang = isset($_POST['desc_lang']) ? $_POST['desc_lang'] : I18n::getCurrentLang();
+$sel_country = isset($_POST['country']) ? $_POST['country'] : strtoupper(I18n::getCurrentLang());
 $sel_region = isset($_POST['region']) ? $_POST['region'] : $default_region;
 $show_all_countries = isset($_POST['show_all_countries']) ? $_POST['show_all_countries'] : 0;
 $show_all_langs = isset($_POST['show_all_langs']) ? $_POST['show_all_langs'] : 0;
@@ -338,7 +339,7 @@ if (isset($_POST['show_all_countries_submit'])) {
 }
 
 // langoptions selector
-buildDescriptionLanguageSelector($show_all_langs, $lang, $config['defaultLanguageList'], $db, $show_all);
+buildDescriptionLanguageSelector($show_all_langs, I18n::getCurrentLang(), $config['defaultLanguageList'], $db, $show_all);
 
 // countryoptions
 $countriesoptions = '';
@@ -380,7 +381,7 @@ $cache_attrib_array = '';
 $cache_attribs_string = '';
 
 $rs = XDb::xSql("SELECT `id`, `text_long`, `icon_undef`, `icon_large` FROM `cache_attrib`
-            WHERE `language`= ? ORDER BY `category`, `id`", $default_lang);
+            WHERE `language`= ? ORDER BY `category`, `id`", I18n::getCurrentLang());
 
 while ($record = XDb::xFetchArray($rs)) {
     $line = $cache_attrib_pic;
@@ -668,7 +669,7 @@ if (isset($_POST['submitform'])) {
 
         // insert cache_location
         $code1 = $sel_country;
-        $eLang = XDb::xEscape($lang);
+        $eLang = XDb::xEscape(I18n::getCurrentLang());
         $adm1 = XDb::xMultiVariableQueryValue("SELECT `countries`.$eLang FROM `countries`
                                     WHERE `countries`.`short`= :1 ", 0, $code1);
         // check if selected country has no districts, then use $default_region
@@ -730,7 +731,7 @@ if (isset($_POST['submitform'])) {
     }
 }
 
-tpl_set_var('language4js', $lang);
+tpl_set_var('language4js', I18n::getCurrentLang());
 if ($no_tpl_build == false) {
     // make the template and send it out
     tpl_BuildTemplate();
@@ -764,7 +765,7 @@ function buildCacheSizeSelector($sel_type, $sel_size)
     return $sizes;
 }
 
-function buildDescriptionLanguageSelector($show_all_langs, $lang, $defaultLangugaeList, $db, $show_all)
+function buildDescriptionLanguageSelector($show_all_langs, $langCode, $defaultLangugaeList, $db, $show_all)
 {
     tpl_set_var('show_all_langs', '0');
     tpl_set_var('show_all_langs_submit', '<input class="btn btn-default btn-sm" type="submit" name="show_all_langs_submit" value="' . $show_all . '"/>');
@@ -782,7 +783,7 @@ function buildDescriptionLanguageSelector($show_all_langs, $lang, $defaultLangug
     }
     $langsoptions = '';
     foreach ($defaultLangugaeList as $defLang) {
-        if (strtoupper($lang) === strtoupper($defLang)) {
+        if (strtoupper($langCode) === strtoupper($defLang)) {
             $selected = 'selected="selected"';
         } else {
             $selected = '';

--- a/newcaches.php
+++ b/newcaches.php
@@ -111,7 +111,7 @@ while ($r = XDb::xFetchArray($rs)) {
         $thisline = mb_ereg_replace('{GPicon}', '<img src="images/rating-star-empty.png" class="icon16" alt="" title="">', $thisline);
     };
 
-    $thisline = mb_ereg_replace('{cachetype}', htmlspecialchars(cache_type_from_id($r['type'], $lang), ENT_COMPAT, 'UTF-8'), $thisline);
+    $thisline = mb_ereg_replace('{cachetype}', htmlspecialchars(cache_type_from_id($r['type']), ENT_COMPAT, 'UTF-8'), $thisline);
     $thisline = mb_ereg_replace('{cachename}', htmlspecialchars($r['cachename'], ENT_COMPAT, 'UTF-8'), $thisline);
     $thisline = mb_ereg_replace('{username}', htmlspecialchars($r['username'], ENT_COMPAT, 'UTF-8'), $thisline);
     $thisline = mb_ereg_replace('{region}', htmlspecialchars($r['region'], ENT_COMPAT, 'UTF-8'), $thisline);

--- a/newcachesrest.php
+++ b/newcachesrest.php
@@ -2,8 +2,7 @@
 
 use Utils\Database\XDb;
 use Utils\Text\Formatter;
-
-global $lang;
+use Utils\I18n\I18n;
 
 //prepare the templates and include all neccessary
 require_once (__DIR__.'/lib/common.inc.php');
@@ -18,10 +17,7 @@ if ($error == false) {
     $content = '';
     $cache_country = '';
 
-    if (XDb::xContainsColumn('countries', 'list_default_' . $lang))
-        $lang_db = XDb::xEscape($lang);
-    else
-        $lang_db = "en";
+    $lang_db = I18n::getLangForDbTranslations('countries');
 
     $rs = XDb::xSql(
         "SELECT `caches`.`cache_id` `cache_id`,

--- a/newdesc.php
+++ b/newdesc.php
@@ -4,6 +4,7 @@ use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCache;
 use Utils\Generators\Uuid;
 use Utils\Text\UserInputFilter;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -31,8 +32,6 @@ if ($error == false) {
                 tpl_set_var('desc_err', '');
                 $show_all_langs = false;
 
-                $default_lang = 'PL';
-
                 $lang_message = '<br/><span class="errormsg">' . tr('lngExist') . '</span>';
                 $show_all_langs_submit = '<input type="submit" class="btn btn-default btn-sm" name="show_all_langs_submit" value="' . tr('edDescShowAll') . '"/>';
 
@@ -42,7 +41,7 @@ if ($error == false) {
                 $short_desc = isset($_POST['short_desc']) ? $_POST['short_desc'] : '';
 
                 $hints = isset($_POST['hints']) ? $_POST['hints'] : '';
-                $sel_lang = isset($_POST['desc_lang']) ? $_POST['desc_lang'] : $default_lang;
+                $sel_lang = isset($_POST['desc_lang']) ? $_POST['desc_lang'] : I18n::getCurrentLang();
                 $desc = isset($_POST['desc']) ? $_POST['desc'] : '';
 
                 $desc = UserInputFilter::purifyHtmlString($desc);
@@ -85,7 +84,7 @@ if ($error == false) {
                 $langoptions = '';
                 $q_nosellangs = 'SELECT `language` FROM `cache_desc` WHERE `cache_id`=\'' . XDb::xEscape($cache_id) . '\'';
 
-                $eLang = XDb::xEscape($lang);
+                $eLang = XDb::xEscape(I18n::getCurrentLang());
                 if ($show_all_langs == 0) {
                     $langs_rs = XDb::xSql("SELECT `$eLang`, `short` FROM `languages`
                                            WHERE `short` NOT IN (" . $q_nosellangs . ")
@@ -105,9 +104,9 @@ if ($error == false) {
 
                     if (($langs_record['short'] == $sel_lang) || ($bSelectFirst == true)) {
                         $bSelectFirst = false;
-                        $langoptions .= '<option value="' . htmlspecialchars($langs_record['short'], ENT_COMPAT, 'UTF-8') . '" selected="selected">' . htmlspecialchars($langs_record[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $langoptions .= '<option value="' . htmlspecialchars($langs_record['short'], ENT_COMPAT, 'UTF-8') . '" selected="selected">' . htmlspecialchars($langs_record[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     } else {
-                        $langoptions .= '<option value="' . htmlspecialchars($langs_record['short'], ENT_COMPAT, 'UTF-8') . '">' . htmlspecialchars($langs_record[$lang], ENT_COMPAT, 'UTF-8') . '</option>';
+                        $langoptions .= '<option value="' . htmlspecialchars($langs_record['short'], ENT_COMPAT, 'UTF-8') . '">' . htmlspecialchars($langs_record[I18n::getCurrentLang()], ENT_COMPAT, 'UTF-8') . '</option>';
                     }
 
                     $langoptions .= "\n";
@@ -127,7 +126,7 @@ if ($error == false) {
                 tpl_set_var('desc', htmlspecialchars($desc, ENT_COMPAT, 'UTF-8'), true);
                 tpl_set_var('hints', $hints);
 
-                tpl_set_var('language4js', $lang);
+                tpl_set_var('language4js', I18n::getCurrentLang());
             } else {
                 tpl_redirect('');
             }

--- a/newwp.php
+++ b/newwp.php
@@ -1,6 +1,7 @@
 <?php
 
 use Utils\Database\XDb;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -80,10 +81,8 @@ if ($error == false) {
 
                 //build typeoptions
                 $sel_type = isset($_POST['type']) ? $_POST['type'] : -1;
-                if (XDb::xContainsColumn('waypoint_type', $lang))
-                    $lang_db = $lang;
-                else
-                    $lang_db = "en";
+                $lang_db = I18n::getLangForDbTranslations('waypoint_type');
+
                 $types = '<option disabled selected="selected">' . tr('choose_waypoint_type') . '</options>';
 //                  if ($cache_record['type'] == '2' || $cache_record['type'] == '6' || $cache_record['type'] == '8' || $cache_record['type'] == '9')
                 // check if final waypoint alreday exist for this cache

--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -44,7 +44,7 @@ function get_okapi_settings()
         'DB_NAME' => $dbname,
         'DB_USERNAME' => $dbusername,
         'DB_PASSWORD' => $dbpasswd,
-        'SITELANG' => $lang,
+        'SITELANG' => 'en', //TODO: how to read it from I18n class?
         'SITELANGS' => array_map('strtolower', $config['defaultLanguageList']),
         'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
         'VAR_DIR' => rtrim($dynbasepath, '/'),

--- a/openchecker.php
+++ b/openchecker.php
@@ -28,7 +28,7 @@ use lib\Objects\GeoCache\Waypoint;
 use Utils\View\View;
 
 // variables required by opencaching.pl
-global $lang, $usr;
+global $usr;
 
 //prepare the templates and include all neccessary
 require_once (__DIR__.'/lib/common.inc.php');

--- a/powerTrail.php
+++ b/powerTrail.php
@@ -16,13 +16,14 @@ use lib\Objects\User\User;
 use Utils\Uri\SimpleRouter;
 use Controllers\MainMapController;
 use Utils\Text\Formatter;
+use Utils\I18n\I18n;
 
 /**
  *  Power Trails in opencaching
  *  this is display file. for API check dir powerTrail
  */
 
-global $lang, $usr, $absolute_server_URI;
+global $usr, $absolute_server_URI;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -100,7 +101,7 @@ if ($error == false) {
     tpl_set_var('displayPowerTrails', 'none');
     tpl_set_var('displaySelectedPowerTrail', 'none');
     tpl_set_var('PowerTrailCaches', 'none');
-    tpl_set_var('language4js', $lang);
+    tpl_set_var('language4js', I18n::getCurrentLang());
     tpl_set_var('powerTrailName', '');
     tpl_set_var('powerTrailLogo', '');
     tpl_set_var('mainPtInfo', '');

--- a/powerTrail/ajaxGetPowerTrailCaches.php
+++ b/powerTrail/ajaxGetPowerTrailCaches.php
@@ -3,25 +3,20 @@
 use lib\Objects\GeoCache\GeoCacheCommons;
 use lib\Objects\PowerTrail\PowerTrail;
 
-
-require_once __DIR__ . '/../lib/ClassPathDictionary.php';
-require_once __DIR__ . '/../lib/language.inc.php';
-
+require_once __DIR__ . '/../lib/common.inc.php';
 
 $powerTrail = new PowerTrail(array('id' => (int) $_REQUEST['ptrail']));
+
 if (isset($_REQUEST['choseFinalCaches'])) {
     $choseFinalCaches = true;
 } else {
     $choseFinalCaches = false;
 }
-session_start();
 
 print displayAllCachesOfPowerTrail($powerTrail, $choseFinalCaches);
 
 function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
 {
-    $language = isset($_POST['lang']) ? $_POST['lang'] : 'en';
-
     $userId = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : -9999;
     $powerTrailCachesUserLogsByCache = $powerTrail->getFoundCachsByUser($userId);
     $geocacheFoundArr = array();
@@ -31,7 +26,7 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
 
 
     if ($powerTrail->getCacheCount() == 0) {
-        return '<br /><br />' . tr2('pt082', $language);
+        return '<br /><br />' . tr('pt082');
     }
 
     $statusIcons = array(
@@ -43,24 +38,24 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
     );
 
     $statusDesc = array(
-        1 => tr2('pt141', $language),
-        2 => tr2('pt142', $language),
-        3 => tr2('pt143', $language),
-        5 => tr2('pt144', $language),
-        6 => tr2('pt244', $language)
+        1 => tr('pt141'),
+        2 => tr('pt142'),
+        3 => tr('pt143'),
+        5 => tr('pt144'),
+        6 => tr('pt244')
     );
 
     $cacheTypesIcons = cache::getCacheIconsSet();
     $cacheRows = '<table class="ptCacheTable" align="center" width="90%"><tr>
-        <th>' . tr2('pt075',$language) . '</th>
-        <th>' . tr2('pt076',$language) . '</th>';
+        <th>' . tr('pt075') . '</th>
+        <th>' . tr('pt076') . '</th>';
     if ($choseFinalCaches) {
         $cacheRows .= '<th></th>';
     }
     $cacheRows .=
-            '   <th>' . tr2('pt077',$language) . '</th>
+            '   <th>' . tr('pt077') . '</th>
         <th><img src="tpl/stdstyle/images/log/16x16-found.png" /></th>
-        <th>' . tr2('pt078',$language) . '</th>
+        <th>' . tr('pt078') . '</th>
         <th><img src="images/rating-star.png" /></th>
     </tr>';
     $totalFounds = 0;
@@ -101,7 +96,7 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
         //cachename, username
         $cacheRows .= '<td><b><a href="' . $geocache->getWaypointId() . '">' . $fontColor . $geocache->getCacheName() . '</b></a> (' . $geocache->getOwner()->getUserName() . ') ';
         if ($geocache->isIsPowerTrailFinalGeocache()) {
-            $cacheRows .= '<span class="finalCache">' . tr2('pt148', $language) . '</span>';
+            $cacheRows .= '<span class="finalCache">' . tr('pt148') . '</span>';
         }
 
         $cacheRows .= '</td>';
@@ -127,7 +122,7 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
     $cacheRows .= '
     <tr bgcolor="#efefff">
         <td></td>
-        <td style="font-size: 9px;">' . tr2('pt085', $language) . '</td>
+        <td style="font-size: 9px;">' . tr('pt085') . '</td>
         <td></td>
         <td align="center" style="font-size: 9px;">' . $totalFounds . '</td>
         <td></td>
@@ -146,8 +141,8 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
         foreach ($cacheSize as $key => $value) {
             $cacheSizePercent[$key] = round(($value * 100) / $countCaches);
         }
-        $img = '<table align="center"><tr><td align=center width="50%">' . tr2('pt107', $language) . '<br /><img src="https://chart.googleapis.com/chart?chs=350x100&chd=t:' . $cachetypes[2] . ',' . $cachetypes[3] . ',' . $cachetypes[7] . ',' . $cachetypes[1] . ',' . $restCaches . '&cht=p3&chl=' . $cachetypes[2] . '|' . $cachetypes[3] . '|' . $cachetypes[7] . '|' . $cachetypes[1] . '|' . $restCaches . '&chco=00aa00|FFEB0D|0000cc|cccccc|eeeeee&&chdl=%20' . tr2('pt108', $language) . '%20(' . $cachePercent[2] . '%)|' . tr2('pt109', $language) . '%20(' . $cachePercent[3] . '%)|' . tr2('pt110', $language) . '%20(' . $cachePercent[7] . '%)|' . urlencode(tr2('pt111', $language)) . '%20(' . $cachePercent[1] . '%)|' . urlencode(tr2('pt112', $language)) . '%20(' . $restCachesPercent . '%)" /></td>';
-        $img .= '<td align=center width="50%">' . tr2('pt106', $language) . '<br /><img src="https://chart.googleapis.com/chart?chs=350x100&chd=t:' . $cacheSize[2] . ',' . $cacheSize[3] . ',' . $cacheSize[4] . ',' . $cacheSize[5] . ',' . $cacheSize[6] . '&cht=p3&chl=%20' . $cacheSize[2] . '|' . $cacheSize[3] . '|' . $cacheSize[4] . '|' . $cacheSize[5] . '|' . $cacheSize[6] . '&chco=0000aa|00aa00|aa0000|aaaa00|00aaaa&&chdl=' . urlencode(tr2('pt113', $language)) . '%20(' . $cacheSizePercent[2] . '%)|' . urlencode(tr2('pt114', $language)) . '%20(' . $cacheSizePercent[3] . '%)|' . urlencode(tr2('pt115', $language)) . '%20(' . $cacheSizePercent[4] . '%)|' . urlencode(tr2('pt116', $language)) . '%20(' . $cacheSizePercent[5] . '%)|' . urlencode(tr2('pt117', $language)) . '%20(' . $cacheSizePercent[6] . '%)" /></td></tr></table><br /><br />';
+        $img = '<table align="center"><tr><td align=center width="50%">' . tr('pt107') . '<br /><img src="https://chart.googleapis.com/chart?chs=350x100&chd=t:' . $cachetypes[2] . ',' . $cachetypes[3] . ',' . $cachetypes[7] . ',' . $cachetypes[1] . ',' . $restCaches . '&cht=p3&chl=' . $cachetypes[2] . '|' . $cachetypes[3] . '|' . $cachetypes[7] . '|' . $cachetypes[1] . '|' . $restCaches . '&chco=00aa00|FFEB0D|0000cc|cccccc|eeeeee&&chdl=%20' . tr('pt108') . '%20(' . $cachePercent[2] . '%)|' . tr('pt109') . '%20(' . $cachePercent[3] . '%)|' . tr('pt110') . '%20(' . $cachePercent[7] . '%)|' . urlencode(tr('pt111')) . '%20(' . $cachePercent[1] . '%)|' . urlencode(tr('pt112')) . '%20(' . $restCachesPercent . '%)" /></td>';
+        $img .= '<td align=center width="50%">' . tr('pt106') . '<br /><img src="https://chart.googleapis.com/chart?chs=350x100&chd=t:' . $cacheSize[2] . ',' . $cacheSize[3] . ',' . $cacheSize[4] . ',' . $cacheSize[5] . ',' . $cacheSize[6] . '&cht=p3&chl=%20' . $cacheSize[2] . '|' . $cacheSize[3] . '|' . $cacheSize[4] . '|' . $cacheSize[5] . '|' . $cacheSize[6] . '&chco=0000aa|00aa00|aa0000|aaaa00|00aaaa&&chdl=' . urlencode(tr('pt113')) . '%20(' . $cacheSizePercent[2] . '%)|' . urlencode(tr('pt114')) . '%20(' . $cacheSizePercent[3] . '%)|' . urlencode(tr('pt115')) . '%20(' . $cacheSizePercent[4] . '%)|' . urlencode(tr('pt116')) . '%20(' . $cacheSizePercent[5] . '%)|' . urlencode(tr('pt117')) . '%20(' . $cacheSizePercent[6] . '%)" /></td></tr></table><br /><br />';
     } else {
         $img = '';
     }
@@ -156,19 +151,17 @@ function displayAllCachesOfPowerTrail(PowerTrail $powerTrail, $choseFinalCaches)
 
 function ratings($score, $votes)
 {
-    $language = isset($_POST['lang']) ? $_POST['lang'] : 'en';
-
     if ($votes < 3) {
-        return '<span style="color: gray">' . tr2('pt083', $language) . '</span>';
+        return '<span style="color: gray">' . tr('pt083') . '</span>';
     }
     $scoreNum = GeoCacheCommons::ScoreAsRatingNum($score);
 
 
     switch ($scoreNum) {
-        case 1: return '<span style="color: #790000">' . tr2('pt074', $language) . '</span>';
-        case 2: return '<span style="color: #BF3C3C">' . tr2('pt073', $language) . '</span>';
-        case 3: return '<span style="color: #505050">' . tr2('pt072', $language) . '</span>';
-        case 4: return '<span style="color: #518C00">' . tr2('pt071', $language) . '</span>';
-        case 5: return '<span style="color: #009D00">' . tr2('pt070', $language) . '</span>';
+        case 1: return '<span style="color: #790000">' . tr('pt074') . '</span>';
+        case 2: return '<span style="color: #BF3C3C">' . tr('pt073') . '</span>';
+        case 3: return '<span style="color: #505050">' . tr('pt072') . '</span>';
+        case 4: return '<span style="color: #518C00">' . tr('pt071') . '</span>';
+        case 5: return '<span style="color: #009D00">' . tr('pt070') . '</span>';
     }
 }

--- a/powerTrailCOG.php
+++ b/powerTrailCOG.php
@@ -3,6 +3,7 @@
 use lib\Objects\PowerTrail\PowerTrail;
 use lib\Objects\GeoCache\GeoCache;
 use Utils\Uri\Uri;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -21,7 +22,7 @@ if ($error == false) {
     }
     tpl_set_var("selPtDiv", 'none');
     tpl_set_var("PtDetailsDiv", 'none');
-    tpl_set_var('language4js', $lang);
+    tpl_set_var('language4js', I18n::getCurrentLang());
 
     $view->loadJQuery();
     $view->addLocalCss(Uri::getLinkWithModificationTime('tpl/stdstyle/css/powerTrail.css'));

--- a/printcache.php
+++ b/printcache.php
@@ -5,6 +5,7 @@ use lib\Objects\OcConfig\OcConfig;
 use Utils\Database\XDb;
 use Utils\Uri\Uri;
 use Utils\View\View;
+use Utils\I18n\I18n;
 
 require_once(__DIR__.'/lib/common.inc.php');
 
@@ -131,7 +132,7 @@ if ($_POST['spoiler_only'] == "&spoiler_only=1") {
 ?>
 
 <!DOCTYPE html>
-<html lang="<?= $lang ?>">
+<html lang="<?=I18n::getCurrentLang()?>">
 <head>
     <meta charset="utf-8">
     <title><?php echo OcConfig::instance()->getPageTitle();

--- a/removedesc.php
+++ b/removedesc.php
@@ -3,6 +3,7 @@
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCache;
 use Utils\I18n\Languages;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 
@@ -60,8 +61,7 @@ if ($error == false) {
                         //commit the removement
                         $tplname = 'removedesc';
 
-                        global $lang;
-                        tpl_set_var('desclang_name', Languages::LanguageNameFromCode($desclang, $lang));
+                        tpl_set_var('desclang_name', Languages::LanguageNameFromCode($desclang, I18n::getCurrentLang()));
                         tpl_set_var('cachename', htmlspecialchars($cache_record['name'], ENT_COMPAT, 'UTF-8'));
                         tpl_set_var('cacheid', htmlspecialchars($cache_id, ENT_COMPAT, 'UTF-8'));
                         tpl_set_var('cacheid_urlencode', htmlspecialchars(urlencode($cache_id), ENT_COMPAT, 'UTF-8'));

--- a/search.php
+++ b/search.php
@@ -7,6 +7,7 @@ use Utils\Uri\OcCookie;
 use lib\Objects\GeoCache\GeoCache;
 use lib\Objects\GeoCache\PrintList;
 use lib\Objects\Coordinates\Coordinates;
+use Utils\I18n\I18n;
 
 require_once (__DIR__.'/lib/common.inc.php');
 require_once (__DIR__.'/lib/search.inc.php');
@@ -14,7 +15,7 @@ require_once (__DIR__.'/lib/search-signatures.inc.php');
 require_once (__DIR__.'/lib/export.inc.php');
 require_once (__DIR__.'/lib/calculation.inc.php');
 
-global $dbcSearch, $lang, $TestStartTime, $usr;
+global $dbcSearch, $TestStartTime, $usr;
 
 
 /**
@@ -1172,8 +1173,8 @@ if ($usr == false) {
 function outputSearchForm($options)
 {
     global $usr, $error_plz, $error_locidnocoords, $error_ort, $error_noort, $error_nofulltext;
-    global $default_lang, $search_all_countries, $cache_attrib_jsarray_line, $cache_attrib_img_line;
-    global $lang, $config;
+    global $search_all_countries, $cache_attrib_jsarray_line, $cache_attrib_img_line;
+    global $config;
 
     //simple mode (only one easy filter)
     $filters = file_get_contents('./tpl/stdstyle/search.simple.tpl.php');
@@ -1463,15 +1464,16 @@ function outputSearchForm($options)
 
     // Typ skrzynki
     $cachetype_options = '';
-                if(Xdb::xContainsColumn('cache_type',$lang) )
-                    $lang_db = XDb::xEscape($lang);
-                else
-                    $lang_db = "en";
+
+    $lang_db = I18n::getLangForDbTranslations('cache_type');
 
     $rs = XDb::xSql("SELECT `id`, `$lang_db`, `icon_large` FROM `cache_type` ORDER BY `sort`");
     for ($i = 0; $i < XDb::xNumRows($rs); $i++)
     {
         $record = XDb::xFetchArray($rs);
+
+        //$default_lang = I18n::getCurrentLang();
+
 
         /*
         if ($record['id'] == $options['cachetype'])
@@ -1589,7 +1591,7 @@ function attr_image($tpl, $options, $id, $textlong, $iconlarge, $iconno, $iconun
     // select attributes depend on specified language.
     $database = OcDb::instance();
     $query = "SELECT `id`, `text_long`, `icon_large`, `icon_no`, `icon_undef`, `category` FROM `cache_attrib` WHERE `language` LIKE :1 ORDER BY `id`";
-    $s = $database->multiVariableQuery($query, strtoupper($lang));
+    $s = $database->multiVariableQuery($query, strtoupper(I18n::getCurrentLang()));
     // if specified language is in database
     if($database->rowCount($s) <= 0) {
          // if we have not specified language in db, just use english.

--- a/tpl/stdstyle/articles/contact.inc.php
+++ b/tpl/stdstyle/articles/contact.inc.php
@@ -1,15 +1,11 @@
 <?php
 
+use Utils\I18n\I18n;
+
 class contactDataProcessor
 {
 
-    public static function processContactData($contactData)
-    {
-        $result = self::processContacts($contactData, 1);
-        return $result;
-    }
-
-    private static function processContacts($contactData, $headerLevel)
+    public static function processContacts($contactData, $headerLevel)
     {
         $result = '';
         foreach ($contactData as $contact) {
@@ -23,7 +19,7 @@ class contactDataProcessor
         $result = '';
 
         if (isset($contact['groupName'])) {
-            $result .= "<h$headerLevel>" . self::tr($contact['groupName'], $contact) . "</h$headerLevel>\n";
+            $result .= "<h$headerLevel>" . self::translate($contact['groupName'], $contact) . "</h$headerLevel>\n";
         }
         if (isset($contact['emailAddress'])) {
             $result .= "<p><b>E-mail: " . $contact['emailAddress'] . "</b></p>\n";
@@ -32,10 +28,10 @@ class contactDataProcessor
             $groupDescription = $contact['groupDescription'];
             if (is_array($groupDescription)) {
                 foreach ($groupDescription as $groupItem) {
-                    $result .= "<p>" . self::tr($groupItem, $contact) . "</p>\n";
+                    $result .= "<p>" . self::translate($groupItem, $contact) . "</p>\n";
                 }
             } else {
-                $result .= "<p>" . self::tr($groupDescription, $contact) . "</p>\n";
+                $result .= "<p>" . self::translate($groupDescription, $contact) . "</p>\n";
             }
         }
         if (isset($contact['subgroup'])) {
@@ -45,11 +41,10 @@ class contactDataProcessor
         return $result;
     }
 
-    private static function tr($str, $context = null)
+    private static function translate($str, $context = null)
     {
-        global $language, $lang;
-        if (isset($language[$lang][$str]) && $language[$lang][$str]) {
-            $str = $language[$lang][$str];
+        if(I18n::isTranslationAvailable($str)){
+            $str = I18n::translatePhrase($str, null, true);
         }
         $str = self::resolve($str, $context);
         return $str;
@@ -69,9 +64,4 @@ class contactDataProcessor
 
 }
 
-;
-
-
-$contact_text = contactDataProcessor::processContactData($contactData);
-tpl_set_var('contact_text', $contact_text);
-?>
+tpl_set_var('contact_text', contactDataProcessor::processContacts($contactData, 1));

--- a/tpl/stdstyle/articles/s102.tpl.php
+++ b/tpl/stdstyle/articles/s102.tpl.php
@@ -1,5 +1,6 @@
 <?php
 use Utils\Uri\OcCookie;
+use Utils\I18n\I18n;
 ?>
 <link rel="stylesheet" type="text/css" media="screen,projection" href="/tpl/stdstyle/css/GCT.css" />
 <link rel="stylesheet" type="text/css" media="screen,projection" href="/tpl/stdstyle/css/GCTStats.css" />
@@ -11,7 +12,7 @@ use Utils\Uri\OcCookie;
 
 <script>
   $( function() {
-    $.datepicker.setDefaults($.datepicker.regional["<?=$GLOBALS['lang']?>"]);
+    $.datepicker.setDefaults($.datepicker.regional["<?=I18n::getCurrentLang()?>"]);
   } );
 </script>
 

--- a/tpl/stdstyle/articles/s2.tpl.php
+++ b/tpl/stdstyle/articles/s2.tpl.php
@@ -11,7 +11,6 @@
 <?php
 use Utils\Database\XDb;
 use Utils\Cache\OcMemCache;
-global $lang;
 
 $userscount = XDb::xSimpleQueryValue(
     'SELECT COUNT( DISTINCT user_id) FROM cache_logs WHERE type=1 AND `deleted`=0', 0);

--- a/tpl/stdstyle/articles/s7.tpl.php
+++ b/tpl/stdstyle/articles/s7.tpl.php
@@ -13,13 +13,12 @@
 use Utils\Database\XDb;
 use Utils\Cache\OcMemCache;
 use lib\Objects\OcConfig\OcConfig;
-
-global $lang;
+use Utils\I18n\I18n;
 
 # This page took >60 seconds to render! Added daily caching.
 
 $result = OcMemCache::getOrCreate(
-    "articles_s7-" . $lang,
+    "articles_s7-" . I18n::getCurrentLang(),
     86400,
 function ()
 {

--- a/tpl/stdstyle/articles/s8.tpl.php
+++ b/tpl/stdstyle/articles/s8.tpl.php
@@ -11,13 +11,12 @@
 use Utils\Database\XDb;
 use Utils\Cache\OcMemCache;
 use lib\Objects\OcConfig\OcConfig;
-
-global $lang;
+use Utils\I18n\I18n;
 
 # This page took >60 seconds to render! Added daily caching.
 
 $result = OcMemCache::getOrCreate(
-    "articles_s8-" . $lang,
+    "articles_s8-" . I18n::getCurrentLang(),
     86400,
 function ()
 {

--- a/tpl/stdstyle/badge.tpl.php
+++ b/tpl/stdstyle/badge.tpl.php
@@ -1,3 +1,6 @@
+<?php
+use Utils\I18n\I18n;
+?>
   <script>
     function gctUShowUsers( level ){
         gctU.removeAllRows();
@@ -52,7 +55,7 @@
 
 
 <script>
-<?php echo "GCTLoad( 'ChartTable', '" . $lang . "' );"?>
+<?php echo "GCTLoad( 'ChartTable', '" . I18n::getCurrentLang() . "' );"?>
 </script>
 
 <script>

--- a/tpl/stdstyle/badge_positions_list.tpl.php
+++ b/tpl/stdstyle/badge_positions_list.tpl.php
@@ -1,3 +1,6 @@
+<?php
+use Utils\I18n\I18n;
+?>
 
 <br>
 {head}
@@ -17,7 +20,7 @@
 <br>
 
 <script>
-<?php echo "GCTLoad( 'ChartTable', '" . $lang . "' );"?>
+<?php echo "GCTLoad( 'ChartTable', '" . I18n::getCurrentLang() . "' );"?>
 </script>
 
 <script>

--- a/tpl/stdstyle/cache_titled.tpl.php
+++ b/tpl/stdstyle/cache_titled.tpl.php
@@ -1,3 +1,6 @@
+<?php
+use Utils\I18n\I18n;
+?>
 
 <link rel="stylesheet" type="text/css" media="screen,projection" href="tpl/stdstyle/css/GCT.css" />
 <link rel="stylesheet" type="text/css" media="screen,projection" href="tpl/stdstyle/css/GCTStats.css" />
@@ -17,7 +20,7 @@
 
 
 <script>;
-<?php echo "GCTLoad( 'ChartTable', '" . $lang . "' );";?>
+<?php echo "GCTLoad( 'ChartTable', '" . I18n::getCurrentLang() . "' );";?>
 </script>
 
 

--- a/tpl/stdstyle/chunks/crowdinInContext.tpl.php
+++ b/tpl/stdstyle/chunks/crowdinInContext.tpl.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This chunk is used to load Crowdin-in-context to main template (main.tpl/mini.tpl etc.),
+ * so there is no need to call it in ordinary content templates.
+ *
+ * This chunk is autoloaded in View class
+ */
+return function (){
+    //start of chunk
+?>
+<!-- Crowdin-in-context chunk -->
+<script type="text/javascript">
+  var _jipt = [];
+  _jipt.push(['project', 'oc-polish-code-translations']);
+</script>
+<script src="//cdn.crowdin.com/jipt/jipt.js"></script>
+<!-- End of Crowdin-in-context chunk -->
+<?php
+}; //end of chunk
+
+

--- a/tpl/stdstyle/chunks/tinyMCE.tpl.php
+++ b/tpl/stdstyle/chunks/tinyMCE.tpl.php
@@ -1,5 +1,6 @@
 <?php
 use Utils\Uri\Uri;
+use Utils\I18n\I18n;
 
 /**
  * This chunk is used to load TinyMCE
@@ -39,7 +40,7 @@ return function ($media = true, $selector = '.tinymce') {
     entity_encoding: "raw",
     fontsize_formats: "8px 10px 11px 12px 13px 14px 18px 24px 36px",
     content_style: "* { margin: 0px 0px 0.5em 0px;} p, ul {font-size: 12px; font-family: arial, sans serif;} ol {padding: 0px 0px 0px 25px; font-family: arial, sans serif;} sub {font-size: 0.7em;} sup {font-size: 0.7em;} br { margin: 0;} body {margin: 3px;}",
-    language: "<?=$GLOBALS['lang']?>",
+    language: "<?=I18n::getCurrentLang()?>",
     toolbar1: "newdocument | styleselect formatselect fontselect fontsizeselect",
     toolbar2: "cut copy paste searchreplace | bullist numlist | outdent indent | undo redo | nonbreaking link unlink image<?=$mediatxt?> | code fullscreen",
     toolbar3: "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | hr | subscript superscript | charmap | forecolor backcolor",

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -342,8 +342,20 @@ global $tpl_subtitle;
           <?=$view->licenseHtml?>
           <span class="bottom-flags">
             <?php foreach($view->_languageFlags as $langFlag){ ?>
-              <a rel="nofollow" href="<?=$langFlag['link']?>"><img class="img-navflag" src="<?=$langFlag['img']?>" alt="<?=$langFlag['name']?> version" title="<?=$langFlag['name']?> version"></a>
+              <a rel="nofollow" href="<?=$langFlag['link']?>">
+                <img class="img-navflag" src="<?=$langFlag['img']?>"
+                     alt="<?=$langFlag['name']?> version" title="<?=$langFlag['name']?> version">
+              </a>
             <?php } //forach-lang-flags ?>
+          </span>
+          <span>
+            <a href="<?=$view->_crowdinInContextActionUrl?>">
+                <?php if ($view->_crowdinInContextEnabled) { ?>
+                  <?=tr('common_disableCrowdinInContext')?>
+                <?php } else { // if-_crowdinInContextEnabled ?>
+                  <?=tr('common_enableCrowdinInContext')?>
+                <?php } //if-_crowdinInContextEnabled ?>
+            </a>
           </span>
         </div>
 
@@ -381,6 +393,6 @@ global $tpl_subtitle;
             <script src="<?=$js['url']?>"<?=$js['async'] ? ' async' : ''?> defer></script>
   <?php   } //if
       } //foreach-js ?>
-  <!-- (C) The Opencaching Project 2018 -->
+  <!-- (C) The Opencaching Project 2019 -->
 </body>
 </html>

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -340,14 +340,18 @@ global $tpl_subtitle;
 
         <div class="bottom-page-container">
           <?=$view->licenseHtml?>
-          <span class="bottom-flags">
-            <?php foreach($view->_languageFlags as $langFlag){ ?>
-              <a rel="nofollow" href="<?=$langFlag['link']?>">
-                <img class="img-navflag" src="<?=$langFlag['img']?>"
-                     alt="<?=$langFlag['name']?> version" title="<?=$langFlag['name']?> version">
-              </a>
-            <?php } //forach-lang-flags ?>
-          </span>
+
+          <?php if (!$view->_crowdinInContextEnabled) { ?>
+              <span class="bottom-flags">
+                <?php foreach($view->_languageFlags as $langFlag){ ?>
+                  <a rel="nofollow" href="<?=$langFlag['link']?>">
+                    <img class="img-navflag" src="<?=$langFlag['img']?>"
+                         alt="<?=$langFlag['name']?> version" title="<?=$langFlag['name']?> version">
+                  </a>
+                <?php } //forach-lang-flags ?>
+              </span>
+          <?php } //$view->_crowdinInContextEnabled ?>
+
           <span>
             <a href="<?=$view->_crowdinInContextActionUrl?>">
                 <?php if ($view->_crowdinInContextEnabled) { ?>

--- a/tpl/stdstyle/common/main.tpl.php
+++ b/tpl/stdstyle/common/main.tpl.php
@@ -352,6 +352,7 @@ global $tpl_subtitle;
               </span>
           <?php } //$view->_crowdinInContextEnabled ?>
 
+          <?php if ($view->_crowdinInContextAllowed) { ?>
           <span>
             <a href="<?=$view->_crowdinInContextActionUrl?>">
                 <?php if ($view->_crowdinInContextEnabled) { ?>
@@ -361,6 +362,7 @@ global $tpl_subtitle;
                 <?php } //if-_crowdinInContextEnabled ?>
             </a>
           </span>
+          <?php } //if-$view->_crowdinInContextAllowed ?>
         </div>
 
       </div>

--- a/tpl/stdstyle/common/popup.tpl.php
+++ b/tpl/stdstyle/common/popup.tpl.php
@@ -1,5 +1,8 @@
+<?php
+use Utils\I18n\I18n;
+?>
 <!DOCTYPE html>
-<html lang="<?=$GLOBALS['lang']?>">
+<html lang="<?=I18n::getCurrentLang()?>">
 <head>
   <title><?php echo isset($tpl_subtitle) ? $tpl_subtitle : ''; ?>{title}</title>
   <meta charset="utf-8">

--- a/tpl/stdstyle/editcache.inc.php
+++ b/tpl/stdstyle/editcache.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use Utils\I18n\I18n;
+
 $submit = 'Zapisz';
 $remove = tr('delete');
 $edit = tr('edit');
@@ -32,8 +34,6 @@ $wpline = '<tr>{stagehide_start}<td align="center" valign="middle"><center>{numb
 
 $cache_attrib_js = "new Array({id}, {selected}, '{img_undef}', '{img_large}')";
 $cache_attrib_pic = '<img id="attr{attrib_id}" src="{attrib_pic}" border="0" alt="{attrib_text}" title="{attrib_text}" onmousedown="toggleAttr({attrib_id}); yes_change();" /> ';
-
-$default_lang = $lang;
 
 $activation_form = '
         <tr><td colspan="2">

--- a/tpl/stdstyle/js/search.js
+++ b/tpl/stdstyle/js/search.js
@@ -63,6 +63,6 @@ function CacheExport( type )
     }
     else
     {
-        alert(textNoCachesSelected);
+        alert("No caches to export");
     }
 }

--- a/tpl/stdstyle/log_cache_multi.tpl.php
+++ b/tpl/stdstyle/log_cache_multi.tpl.php
@@ -72,7 +72,6 @@ function get_icon_for_cache_type($type)
             </table>
             <?php
             global $dane;
-            global $lang;
             global $datetimeFormat;
             foreach ($dane as $k => $v) {
                 ?>

--- a/tpl/stdstyle/newcache.inc.php
+++ b/tpl/stdstyle/newcache.inc.php
@@ -31,4 +31,3 @@ $sel_message = tr('choose');
 $cache_attrib_js = "new Array({id}, {selected}, '{img_undef}', '{img_large}')";
 $cache_attrib_pic = '<img id="attr{attrib_id}" src="{attrib_pic}" alt="{attrib_text}" title="{attrib_text}" onmousedown="toggleAttr({attrib_id})"> ';
 
-$default_lang = $lang;

--- a/tpl/stdstyle/powerTrail.tpl.php
+++ b/tpl/stdstyle/powerTrail.tpl.php
@@ -1143,8 +1143,8 @@
         {
             ele.style.display = "none";
             // os_tytul.style.display = "block";
-            text.innerHTML = "{{os_zobo}}";
-            text2.innerHTML = "{{os_zobo}}";
+            //text.innerHTML = "/{/{os_zobo}}";
+            //text2.innerHTML = "/{/{os_zobo}}";
             help_link1.style.display = "block";
             help_link2.style.display = "none";
             cialo.style.display = "block";
@@ -1153,8 +1153,8 @@
         {
             ele.style.display = "block";
             // os_tytul.style.display = "none";
-            text.innerHTML = "{{os_powrot}}";
-            text2.innerHTML = "{{os_powrot}}";
+            //text.innerHTML = "/{/{os_powrot}}";
+            //text2.innerHTML = "/{/{os_powrot}}";
             help_link1.style.display = "none";
             help_link2.style.display = "block";
             cialo.style.display = "none";

--- a/tpl/stdstyle/rating.inc.php
+++ b/tpl/stdstyle/rating.inc.php
@@ -11,9 +11,9 @@ $rating_tpl = '<tr class="form-group-sm">
                 </td>
             </tr>';
 
-$rating_allowed = '<input type="checkbox" name="rating" id="l_rating" value="1" class="checkbox" {chk_sel}/><label for="l_rating">' . $language[$lang]['want_to_recommend'] . '.</label>';
+$rating_allowed = '<input type="checkbox" name="rating" id="l_rating" value="1" class="checkbox" {chk_sel}/><label for="l_rating">' . tr('want_to_recommend'). '.</label>';
 $recommendationsUrl = SimpleRouter::getLink(MyRecommendationsController::class, 'recommendations');
 $rating_maxreached = '<b>' . tr('alternative_recommend') . '<a href="'.$recommendationsUrl.'">' . tr('here') . '</a>.</b>';
-$rating_too_few_founds = '' . $language[$lang]['possible_recommend'] . ': {recommendationsNr}';
-$rating_stat = '' . $language[$lang]['number_my_recommend'] . ': {curr} ' . $language[$lang]['number_possible_recommend'] . ' {max}.';
+$rating_too_few_founds = tr('possible_recommend') . ': {recommendationsNr}';
+$rating_stat = tr('number_my_recommend') . ': {curr} ' . tr('number_possible_recommend') . ' {max}.';
 $rating_own = '<input type="checkbox" name="rating" id="l_rating" value="1" class="checkbox" {chk_dis}/><label for="l_rating"><b>' . tr('not_recommend_own') . '.</b></label>';

--- a/tpl/stdstyle/search.inc.php
+++ b/tpl/stdstyle/search.inc.php
@@ -48,7 +48,6 @@
     $gns_countries['LH'] = 'Litwa';
     $gns_countries['UP'] = 'Ukraina';
 
-    $default_lang = $lang;
     $search_all_countries = '<option value="">'.tr('search00').'</option>';
     $search_all_regions = '<option value="">Wszystkie województwa</option>';
     //$search_all_cachetypes = '<option value="" selected="selected">Wszystkie typy skrzynek</option>';

--- a/tpl/stdstyle/search.result.caches.tpl.php
+++ b/tpl/stdstyle/search.result.caches.tpl.php
@@ -1,4 +1,6 @@
 <?php
+use Utils\I18n\I18n;
+
 ?>
 
 <script src="https://www.google.com/jsapi"></script>
@@ -35,7 +37,7 @@
 </script>
 
 <?php
-global $hide_coords, $colNameSearch, $NrColSortSearch, $OrderSortSearch, $SearchWithSort, $usr, $lang, $selectList, $NrColVisable;
+global $hide_coords, $colNameSearch, $NrColSortSearch, $OrderSortSearch, $SearchWithSort, $usr, $selectList, $NrColVisable;
 
 if ( !$SearchWithSort )
 {
@@ -48,7 +50,7 @@ if ( !$SearchWithSort )
 }
 
 echo "<script>";
-echo " GCTLoad( 'ChartTable', '". $lang ."' );";
+echo " GCTLoad( 'ChartTable', '". I18n::getCurrentLang() ."' );";
 echo "</script>";
 
 $NrColSortToSet = $NrColSortSearch-1;

--- a/tpl/stdstyle/search.result.caches.tpl.php
+++ b/tpl/stdstyle/search.result.caches.tpl.php
@@ -178,8 +178,6 @@ $C18 = fHideColumn( 18, true );
     gct.drawChart();
     gct.addSelectEvent( EventSelectPosFunction );
     gct.addPageEvent( EventPageFunction );
-
-    var textNoCachesSelected = '{{export_no_caches}}';
 </script>
 
 <?php

--- a/tpl/stdstyle/viewcache.inc.php
+++ b/tpl/stdstyle/viewcache.inc.php
@@ -40,7 +40,6 @@ $gallery_link = '<a href="gallery_cache.php?cacheid={cacheid}">' . tr('gallery_s
 
 $viewtext_on = tr('enter_text');
 $viewtext_off = tr('enter_text_error');
-$default_lang = 'PL';
 $event_attended_text = " " . tr('attendends');
 $event_will_attend_text = " " . tr('will_attend');
 

--- a/util.sec/cache_locations/cache_location.class.php
+++ b/util.sec/cache_locations/cache_location.class.php
@@ -5,6 +5,7 @@
 
 use Utils\Database\XDb;
 use Utils\Gis\Gis;
+use Utils\I18n\I18n;
 
 /*
  *
@@ -28,9 +29,6 @@ use Utils\Gis\Gis;
  *
  */
 require_once (__DIR__.'/../../lib/common.inc.php');
-
-global $lang;
-
 
 // select caches which don't have cache_location record
 // OR modification time is later cache location mod.time
@@ -102,14 +100,10 @@ while ($rCache = XDb::xFetchArray($rsCache)) {
         if (mb_strlen($sCode) == 2) {
             $code1 = $sCode;
 
-            if (XDb::xContainsColumn('countries', 'list_default_' . $lang))
-                $lang_db = $lang;
-            else
-                $lang_db = "en";
-
+            $language = I18n::getLangForDbTranslations('countries');
             // try to get localised name first
             $adm1 = XDb::xSimpleQueryValue(
-                "SELECT `countries`.`$lang`
+                "SELECT `countries`.`$language`
                 FROM `countries`
                 WHERE `countries`.`short`='$sCode'", 0);
 
@@ -127,10 +121,6 @@ while ($rCache = XDb::xFetchArray($rsCache)) {
             $adm1, $adm2, $adm3, $adm4, $code1, $code2, $code3, $code4);
 
     } else {
-        if (XDb::xContainsColumn('countries', 'list_default_' . $lang))
-            $lang_db = $lang;
-        else
-            $lang_db = "en";
         $sCountry = XDb::xSimpleQueryValue(
             "SELECT `countries`.`pl` FROM `caches`
             INNER JOIN `countries` ON `caches`.`country`=`countries`.`short`

--- a/util.sec/write_caches_on_map.php
+++ b/util.sec/write_caches_on_map.php
@@ -1,8 +1,6 @@
 <?php
 
 use Utils\Database\XDb;
-global $lang;
-$lang = 'en';
 
 //include template handling
 require_once(__DIR__.'/../lib/common.inc.php');

--- a/util/google-earth/caches.php
+++ b/util/google-earth/caches.php
@@ -4,6 +4,7 @@ ob_start();
 
 use Utils\Database\XDb;
 use lib\Objects\GeoCache\GeoCacheCommons;
+use Utils\I18n\I18n;
 
 /* Bounding Box:
   BBOX=2.38443,48.9322,27.7053,55.0289
@@ -40,11 +41,13 @@ if ((abs($lon_from - $lon_to) > 2) || (abs($lat_from - $lat_to) > 2)) {
     $lat_from = $lat_to;
 }
 
+$language = I18n::getCurrentLang();
+
 $rs = XDb::xSql(
     "SELECT `caches`.`cache_id` `cacheid`, `caches`.`longitude` `longitude`, `caches`.`latitude` `latitude`,
             `caches`.`status` `status`, `caches`.`type` `type`, `caches`.`date_hidden` `date_hidden`,
             `caches`.`name` `name`, `caches`.`wp_oc` `cache_wp`,
-            `cache_type`.`" . $lang . "` `typedesc`, `caches`.`size`, 
+            `cache_type`.`" . $language . "` `typedesc`, `cache_size`.`" . $language . "` `sizedesc`,
             `caches`.`terrain` `terrain`, `caches`.`difficulty` `difficulty`,
             `user`.`username` `username`
     FROM `caches`, `cache_type`, `user`


### PR DESCRIPTION
Hi, this is the next "too big refactor" but I got the flow when I tried to introduce "Crowdin-in-context mode".

What was done:
- **Crowdin-in-context mode can be activated and deactivated by link near the flags in the footer**
- **new configs: `/Config/I18n.*.php`**
- complete refactoring of language.inc.php => I18n class
- reporting of missing translations (requested phrases missing even in en.php)
- global var $lang is now removed across the whole code
- many cleanups in context of language is done


What still needs to be done:
I would like to review all the places when we use "translation-in-db" and refactor to use new method: 
`I18n::getLangForDbTranslations()` - the idea is to use "default" lang if there is no requested lang - it allow to use all languages without "complicated" sync the DB - of course finally we should get rid of translations in DB.