### PR TITLE
Email overhaul

### DIFF
--- a/Controllers/Cron/Jobs/AutoArchiveCachesJob.php
+++ b/Controllers/Cron/Jobs/AutoArchiveCachesJob.php
@@ -137,8 +137,6 @@ class AutoArchiveCachesJob extends Job
     {
         $email = new Email();
         if (!$email->addToAddr($cache->getOwner()->getEmail())) {
-            unlink($email);
-
             return;
         }
 
@@ -175,7 +173,7 @@ class AutoArchiveCachesJob extends Job
         $email->setFromAddr($this->ocConfig->getOcteamEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix($this->ocConfig->getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 

--- a/Controllers/Cron/WatchlistController.php
+++ b/Controllers/Cron/WatchlistController.php
@@ -5,6 +5,7 @@
 namespace Controllers\Cron;
 
 use Controllers\BaseController;
+use Utils\Email\Email;
 use Utils\Lock\Lock;
 use lib\Objects\User\UserNotify;
 use lib\Objects\Watchlist\Watchlist;
@@ -153,7 +154,12 @@ class WatchlistController extends BaseController
                 || sizeof($watcher->getWatchLogs()) > 0)
                 && UserNotify::getUserLogsNotify($watcher->getUserId())
             ) {
-                $sendStatus = $this->watchlistReport->prepareAndSend($watcher);
+                if (!Email::isValidEmailAddr($watcher->getEmail())) {
+                    // Only users with valid addresses will receive notifications.
+                    $sendStatus = true;
+                } else {
+                    $sendStatus = $this->watchlistReport->prepareAndSend($watcher);
+                }
                 $watcher->setSendStatus($sendStatus);
             }
             $watcher->setWatchmailNext(

--- a/Utils/Email/Email.php
+++ b/Utils/Email/Email.php
@@ -9,47 +9,28 @@
  */
 namespace Utils\Email;
 
-use Utils\Text\Validator;
 use Exception;
+use Utils\Text\Validator;
 use lib\Objects\OcConfig\OcConfig;
 
 class Email
 {
-
-    private $toAddr = array();
-
-    private $ccAddr = array();
-
-    private $bccAddr = array();
+    private $toAddr = [];
+    private $ccAddr = [];
+    private $bccAddr = [];
 
     private $fromAddr;
-
     private $senderName;
-
-    private $replyToAddr;
-
-    private $xMailer;
+    private $replyToAddr = '';
 
     private $subjectPrefix = '';
-    // subject prefix set in all emails
     private $subject = '';
 
-    private $body = '';
+    private $htmlBody = '';
 
-    private $isHtmlEmail;
-
-    private $isHtmlBody;
-    // does body of the message needs html formatting
     public function __construct()
     {
-        $this->xMailer = phpversion();
-        $this->isHtmlEmail = true; // only HTML emails
-
-        // TODO : should be set based on config
-        $this->subjectPrefix = '';
-        $this->body_header = '';
-        $this->body_footer = '';
-
+        // Set default sender name
         $this->senderName = OcConfig::getSiteName();
     }
 
@@ -59,190 +40,155 @@ class Email
      */
     public function send()
     {
-        if (! $this->isEmailValid()) {
+        // Check mandantory addresses
+        if (empty($this->toAddr)) {
+            throw new Exception("Email recipient missing");
+        }
+        if (empty($this->fromAddr)) {
+            throw new Exception("Email sender missing");
+        }
+        if (!self::isValidEmailAddr($this->toAddr) ||
+            !self::isValidEmailAddr($this->fromAddr)
+        ) {
+            // We cannot decide here how to handle that. Caller must evaluate
+            // the return values of setFromAddr() and addToAddr() if handling
+            // is needed.
+
             return false;
         }
-        // Each line of message should be separated with a CRLF (\r\n).
-        // Lines should not be larger than 70 characters.
-        // TODO:...
-        // wordwrap($message, 70, "\r\n");
-        $headers[] = 'From: ' . $this->senderName . ' <' . $this->fromAddr . '>';
-        $headers[] = 'Reply-To: ' . $this->replyToAddr;
-        $headers[] = 'X-Mailer: PHP/' . $this->xMailer;
 
-        if ($this->isHtmlEmail) {
-            // To send HTML mail, the Content-type header must be set
-            $headers[] = 'MIME-Version: 1.0';
-            $headers[] = 'Content-type: text/html; charset=utf-8';
-
-            if (! $this->isHtmlBody) {
-                // format body
-                $this->body = $this->formatToHtml($this->body);
-            }
+        // Check subject. It is technically allowed to send a email without
+        // subject, but we don't want to do that.
+        if ($this->subject == '') {
+            throw new Exception("Email subject missing");
         }
 
-        // Additional headers
-        if (! empty($this->ccAddr))
-            $headers[] = 'Cc: ' . implode(',', $this->ccAddr);
-
-        if (! empty($this->bccAddr))
-            $headers[] = 'Bcc: ' . implode(',', $this->bccAddr);
-
-        if (! empty($this->toAddr)) {
-            $to = implode(',', $this->toAddr);
+        if (empty($this->senderName)) {
+            $headers[] = 'From: ' . $this->fromAddr;
         } else {
-            $to = OcConfig::getNoreplyEmailAddress();
-            $this->error(__METHOD__ . ": Setting dummy TO address: $to", new Exception("Email with empty 'To' field!"));
+            $headers[] = 'From: "' . $this->senderName . '" <' . $this->fromAddr . '>';
         }
 
+        // optional addresses
+        if (!empty($this->ccAddr)) {
+            $headers[] = 'Cc: ' . implode(',', $this->ccAddr);
+        }
+        if (!empty($this->bccAddr)) {
+            $headers[] = 'Bcc: ' . implode(',', $this->bccAddr);
+        }
+        if (!empty($this->replyToAddr)) {
+            $headers[] = 'Reply-To: ' . $this->replyToAddr;
+        }
+
+        $headers[] = 'MIME-Version: 1.0';
+        $headers[] = 'Content-type: text/html; charset=utf-8';
+        $headers[] = 'X-Mailer: PHP/' . phpversion();
+
+        $to = implode(', ', $this->toAddr);
         $subject = $this->subjectPrefix . " " . $this->subject;
-        $message = $this->body;
+        $message = $this->htmlBody;
 
         return mb_send_mail($to, $subject, $message, implode("\r\n", $headers));
     }
 
+    public function setFromAddr($addr)
+    {
+        $this->fromAddr = $addr;
+        return self::isValidEmailAddr($addr);
+    }
+
+    public function setSenderName($senderName)
+    {
+        $this->senderName = $senderName;
+    }
+
     public function addToAddr($addr)
     {
-        if (self::isValidEmail($addr)) {
-            $this->toAddr[] = $addr;
-            return true;
-        } else {
-            $this->error(__METHOD__ . ': improper email address: ' . $addr, new Exception("Invalid email address!"));
-            return false;
-        }
+        $this->toAddr[] = $addr;
+        return self::isValidEmailAddr($addr);
     }
 
     public function addCcAddr($addr)
     {
-        if (self::isValidEmail($addr)) {
+        if (self::isValidEmailAddr($addr)) {
             $this->ccAddr[] = $addr;
             return true;
         } else {
-            $this->error(__METHOD__ . ': improper email address: ' . $addr, new Exception("Invalid CC email address!"));
             return false;
         }
     }
 
     public function addBccAddr($addr)
     {
-        if (self::isValidEmail($addr)) {
+        if (self::isValidEmailAddr($addr)) {
             $this->bccAddr[] = $addr;
             return true;
         } else {
-            $this->error(__METHOD__ . ': improper email address: ' . $addr, new Exception("Invalid BCC email address!"));
-            return false;
-        }
-    }
-
-    public function setFromAddr($addr)
-    {
-        if (self::isValidEmail($addr)) {
-            $this->fromAddr = $addr;
-            return true;
-        } else {
-            $this->error(__METHOD__ . ': improper email address: ' . $addr, new Exception("Invalid FROM email address!"));
             return false;
         }
     }
 
     public function setReplyToAddr($addr)
     {
-        if (self::isValidEmail($addr)) {
+        if (self::isValidEmailAddr($addr)) {
             $this->replyToAddr = $addr;
             return true;
         } else {
-            $this->error(__METHOD__ . ': improper email address: ' . $addr, new Exception("Invalid REPLAY-TO email address!"));
             return false;
-        }
-    }
-
-    public function addSubjectPrefix($newPrefix)
-    {
-        if (empty($newPrefix) || $newPrefix == "") { // because somebody may want to turn off the global prefix in config
-            return;
-        } else {
-            $this->subjectPrefix = $this->subjectPrefix . "[" . $newPrefix . "]";
         }
     }
 
     public function setSubject($subject)
     {
         $this->subject = $subject;
+        return ($subject != "");
     }
 
-    public function setBody($body, $isHtml = false)
+    public function addSubjectPrefix($newPrefix)
     {
-        $this->body = $body;
-        $this->isHtmlBody = $isHtml;
+        if (!empty($newPrefix)) { // because somebody may want to turn off the global prefix in config
+
+            $this->subjectPrefix = $this->subjectPrefix . "[" . $newPrefix . "]";
+        }
+    }
+
+    public function setHtmlBody($htmlText)
+    {
+        $this->htmlBody = $htmlText;
+    }
+
+    public function setPlainTextBody($plainText)
+    {
+        $body = htmlentities($plainText, ENT_QUOTES, "UTF-8");
+        $body = nl2br($body);
+        $this->htmlBody = '<pre>' . $body . '</pre>';
     }
 
     /**
-     * returns TRUE is given emailAddress has proper format
-     *
-     * @param
-     *            $emailAddress
-     * @return bool
+     * @param $emailAddress string|array
+     * @return bool - TRUE is the given email address(es) is/are empty have proper format
      */
-    private static function isValidEmail($emailAddress)
+    public static function isValidEmailAddr($emailAddress)
     {
+        if (is_array($emailAddress)) {
+            foreach ($emailAddress as $addr) {
+                if (!self::isValidEmailAddr($addr)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Workaround for develsite problem -- following
+        if ($emailAddress == 'root@localhost') {
+            return true;
+        }
+
         // TODO(mzylowski): Remove this if, when email refactoring will be finished:
         if ($emailAddress == "user@ocpl-devel") {
             return true;
         } // debugging purposes
+
         return Validator::isValidEmail($emailAddress);
-    }
-
-    private function error($message, Exception $e = null)
-    {
-        if (! is_null($e)) {
-            error_log(__METHOD__ . ": Stack trace:");
-            error_log($e->getTraceAsString());
-        }
-        //trigger_error($message, E_USER_NOTICE); // TMP FIX: kojoty
-    }
-
-    private function isEmailValid()
-    {
-
-        // check recipients
-        if (empty($this->toAddr) && empty($this->ccAddr) && empty($this->bccAddr)) {
-
-            // no recipient of this email
-            $this->error(__METHOD__ . ": Trying to send email with no recipients.", new Exception("No recipients on sending!"));
-            return false;
-        }
-
-        // check subject
-        if ($this->subject == '') {
-            // empty subject email
-            $this->error(__METHOD__ . ": Trying to send email without subject.", new Exception("Email with empty subjec!"));
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * prepare the string param to present as HTML message
-     *
-     * @param string $string
-     * @return string as HTML
-     */
-    private function formatToHtml($string)
-    {
-        $string = htmlentities($string, ENT_QUOTES, "UTF-8");
-        $string = '<pre>' . nl2br($string) . '</pre>';
-
-        return $string;
-    }
-
-    public function getSenderName()
-    {
-        return $this->senderName;
-    }
-
-    public function setSenderName($senderName)
-    {
-        $this->senderName = $senderName;
     }
 }

--- a/Utils/Email/EmailSender.php
+++ b/Utils/Email/EmailSender.php
@@ -13,6 +13,7 @@ use lib\Objects\GeoCache\GeoCache;
 use lib\Objects\GeoCache\GeoCacheLog;
 use lib\Objects\OcConfig\OcConfig;
 use lib\Objects\User\User;
+use Utils\Debug\Debug;
 
 class EmailSender
 {
@@ -42,10 +43,14 @@ class EmailSender
 
         $email->addSubjectPrefix("OC Admin Email");
         $email->setSubject('Error in domain: '.$spamDomain); //TODO
-        $email->setBody($message);
+        $email->setPlainTextBody($message);
 
-        if( ! $email->send() ){
-            trigger_error(__METHOD__.": Email sending failed!", E_USER_NOTICE);
+        if (!$email->send()) {
+            // The only available fallback here is logging.
+            Debug::errorLog(
+                __METHOD__.": Admin email sending failed! Message:\n" . $message,
+                false
+            );
         }
     }
 
@@ -72,7 +77,7 @@ class EmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('removed_log_title'));
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -101,7 +106,7 @@ class EmailSender
         $email->setFromAddr(OcConfig::getCogEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('octeam_comment_subject'));
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
 
         //Send copy to COG
@@ -111,7 +116,7 @@ class EmailSender
         $emailCOG->setFromAddr(OcConfig::getCogEmailAddress());
         $emailCOG->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
         $emailCOG->setSubject(tr('octeam_comment_subject_copy').' '.$admin->getUserName());
-        $emailCOG->setBody($formattedMessage->getEmailContent(), true);
+        $emailCOG->setHtmlBody($formattedMessage->getEmailContent());
         $emailCOG->send();
     }
 
@@ -130,7 +135,7 @@ class EmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('adopt_25'));
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -149,7 +154,7 @@ class EmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('adopt_18'));
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -168,7 +173,7 @@ class EmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('adopt_28'));
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -201,7 +206,7 @@ class EmailSender
             $email->setSubject(tr('ocTeamNewCache_sub').": ".tr('dummy_outside'));
         }
 
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 

--- a/lib/Objects/Admin/ReportEmailSender.php
+++ b/lib/Objects/Admin/ReportEmailSender.php
@@ -46,7 +46,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -79,7 +79,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -113,7 +113,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -165,7 +165,7 @@ class ReportEmailSender
         $subject = '[R#' . $poll->getReport()->getId() . '] ' . $subject;
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -197,7 +197,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getCogEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -240,7 +240,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -274,7 +274,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -312,7 +312,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getCogEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -351,7 +351,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getCogEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 
@@ -390,7 +390,7 @@ class ReportEmailSender
         $email->setFromAddr(OcConfig::getCogEmailAddress());
         $email->setSubject($subject);
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForReviewers());
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 }

--- a/lib/Objects/Notify/NotifyEmailSender.php
+++ b/lib/Objects/Notify/NotifyEmailSender.php
@@ -92,7 +92,7 @@ class NotifyEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject($subject);
-        $email->setBody($formattedMessage->getEmailContent(), true);
+        $email->setHtmlBody($formattedMessage->getEmailContent());
         $email->send();
     }
 }

--- a/lib/Objects/OcConfig/OcConfig.php
+++ b/lib/Objects/OcConfig/OcConfig.php
@@ -2,7 +2,7 @@
 
 namespace lib\Objects\OcConfig;
 
-
+use Utils\Email\Email;
 
 final class OcConfig extends ConfigReader
 {
@@ -241,7 +241,11 @@ final class OcConfig extends ConfigReader
 
     public function getOcteamEmailAddress()
     {
-        return $this->octeamEmailAddress;
+        $addr = self::instance()->octeamEmailAddress;
+        if (!Email::isValidEmailAddr($addr)) {
+            throw new \Exception('Invalid OC team email address setting');
+        }
+        return $addr;
     }
 
     public static function getDynFilesPath()
@@ -266,7 +270,11 @@ final class OcConfig extends ConfigReader
 
     public static function getNoreplyEmailAddress()
     {
-        return self::instance()->noreplyEmailAddress;
+        $addr = self::instance()->noreplyEmailAddress;
+        if (!Email::isValidEmailAddr($addr)) {
+            throw new \Exception('Invalid noreply email address setting');
+        }
+        return $addr;
     }
 
     public function isCacheAccesLogEnabled()
@@ -327,6 +335,10 @@ final class OcConfig extends ConfigReader
         //currently this is only a stub...
         global $mail_rt;
 
+        if (!Email::isValidEmailAddr($mail_rt)) {
+            throw new \Exception('Invalid mail_rt setting');
+        }
+
         return $mail_rt;
     }
 
@@ -352,7 +364,11 @@ final class OcConfig extends ConfigReader
 
     public static function getCogEmailAddress()
     {
-        return self::instance()->cogEmailAddress;
+        $addr = self::instance()->cogEmailAddress;
+        if (!Email::isValidEmailAddr($addr)) {
+            throw new \Exception('Invalid COG email address setting');
+        }
+        return $addr;
     }
 
     public static function getMailSubjectPrefixForSite()

--- a/lib/Objects/User/UserAuthorization.php
+++ b/lib/Objects/User/UserAuthorization.php
@@ -416,7 +416,7 @@ class UserAuthorization extends BaseObject
         $email->addSubjectPrefix(ApplicationContainer::Instance()->getOcConfig()->getMailSubjectPrefixForSite());
         $subject = tr('newpw_mail_subject') . ' ' . ApplicationContainer::Instance()->getOcConfig()->getSiteName();
         $email->setSubject($subject);
-        $email->setBody($userMessage->getEmailContent(), true);
+        $email->setHtmlBody($userMessage->getEmailContent());
         $result = $email->send();
         if (! $result) {
             error_log(__METHOD__ . ': Mail sending failure to: ' . $user->getEmail());

--- a/lib/Objects/User/UserEmailSender.php
+++ b/lib/Objects/User/UserEmailSender.php
@@ -46,14 +46,15 @@ class UserEmailSender
         $email = new Email();
         $email->addToAddr($to->getEmail());
         if ($attachSenderAddress) {
-            $email->setFromAddr($from->getEmail());
-            $email->setSenderName($from->getUserName());
+            $email->setReplyToAddr($from->getEmail());
         } else {
-            $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
-            $subject = tr('mailto_emailFrom') . ' ' . $from->getUserName() . ': ' . $subject;
+            $email->setReplyToAddr(OcConfig::getNoreplyEmailAddress());
         }
-        $email->setSubject($subject);
+        $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
+        // add additional prefix to subject
+        $subject = tr('mailto_emailFrom') . ' ' . $from->getUserName() . ': ' . $subject;
+        $email->setSubject($subject);
         $email->setHtmlBody($userMessage->getEmailContent());
         $result = $email->send();
         if (! $result) {

--- a/lib/Objects/User/UserEmailSender.php
+++ b/lib/Objects/User/UserEmailSender.php
@@ -46,16 +46,15 @@ class UserEmailSender
         $email = new Email();
         $email->addToAddr($to->getEmail());
         if ($attachSenderAddress) {
-            $email->setReplyToAddr($from->getEmail());
+            $email->setFromAddr($from->getEmail());
+            $email->setSenderName($from->getUserName());
         } else {
-            $email->setReplyToAddr(OcConfig::getNoreplyEmailAddress());
+            $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
+            $subject = tr('mailto_emailFrom') . ' ' . $from->getUserName() . ': ' . $subject;
         }
-        $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
-        $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
-        // add additional prefix to subject
-        $subject = tr('mailto_emailFrom') . ' ' . $from->getUserName() . ': ' . $subject;
         $email->setSubject($subject);
-        $email->setBody($userMessage->getEmailContent(), true);
+        $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
+        $email->setHtmlBody($userMessage->getEmailContent());
         $result = $email->send();
         if (! $result) {
             error_log(__METHOD__ . ': Mail sending failure to: ' . $to->getEmail());
@@ -92,7 +91,7 @@ class UserEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject($subject);
-        $email->setBody($userMessage->getEmailContent(), true);
+        $email->setHtmlBody($userMessage->getEmailContent());
         $result = $email->send();
         if (! $result) {
             error_log(__METHOD__ . ': Sender copy sending failure to: ' . $from->getEmail());
@@ -125,7 +124,7 @@ class UserEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('activate_mail_subject'));
-        $email->setBody($userMessage->getEmailContent(), true);
+        $email->setHtmlBody($userMessage->getEmailContent());
         $email->send();
     }
 
@@ -147,7 +146,7 @@ class UserEmailSender
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject(tr('postActivation_mail_subject'));
-        $email->setBody($userMessage->getEmailContent(), true);
+        $email->setHtmlBody($userMessage->getEmailContent());
         $email->send();
     }
 }

--- a/lib/Objects/Watchlist/WatchlistReport.php
+++ b/lib/Objects/Watchlist/WatchlistReport.php
@@ -94,7 +94,7 @@ class WatchlistReport
         $email->setFromAddr(OcConfig::getNoreplyEmailAddress());
         $email->addSubjectPrefix(OcConfig::getMailSubjectPrefixForSite());
         $email->setSubject($subject);
-        $email->setBody($report->getEmailContent(), true);
+        $email->setHtmlBody($report->getEmailContent());
         return $email->send();
     }
 }


### PR DESCRIPTION
Rewrite of Email class; fixes #1847

This proposal includes four changes of email logic:

1. Bad email address settings (e.g. COG address) will be detected in OcConfig. They throw an exception and abort the script.

2. Invalid user email addresses will no longer generate notices when sending emails. All newly entered addresses are validated, so bad addresses can only originate from broken legacy data or bugs in the validation logic. I believe that the email sending code is the wrong place for such checks, because it will not detect broken addresses to which no email has been send yet. If a check is desired, it could be made by a separate tool or cronjob.

3. Watchlist notifications for users with invalid address will be discarded. As far as I undestand the current implementation, it may continue to call Email::send() with each cronjob run.

4. If the option "include my email address" is checked in user2user email, instead of

`From: Opencaching.XX <noreply@opencaching.xx>`
`Subject: [OCXX] Message from username: subject`
`Reply-To: users@email.address`

it will send this:

`From:  "username" <users@email.address>`
`Subject: [OCXX] subject`
