### PR TITLE
use configured logo in geopath-comment notification emails; updates #1693

### DIFF
--- a/powerTrail/commentEmail.html
+++ b/powerTrail/commentEmail.html
@@ -9,7 +9,7 @@
             <table width="80%">
                 <tr>
                     <td align="center" width="80">
-                        <a href="{absolute_server_URI}"><img border="0" src="{absolute_server_URI}images/oc_logo.png" alt="Opencaching Logo"></a>
+                        <a href="{absolute_server_URI}"><img border="0" src="{absolute_server_URI}images/{oclogo}"></a>
                         <br />
                         <a href="{absolute_server_URI}" style="font-size: 11px; font-family: Verdana;">OpenCaching</a>
                     </td>

--- a/powerTrail/commentEmail.html
+++ b/powerTrail/commentEmail.html
@@ -9,7 +9,7 @@
             <table width="80%">
                 <tr>
                     <td align="center" width="80">
-                        <a href="{absolute_server_URI}"><img border="0" src="{absolute_server_URI}images/{oclogo}"></a>
+                        <a href="{absolute_server_URI}"><img border="0" src="{absolute_server_URI}images/{oclogo}" alt=""></a>
                         <br />
                         <a href="{absolute_server_URI}" style="font-size: 11px; font-family: Verdana;">OpenCaching</a>
                     </td>

--- a/powerTrail/sendEmail.php
+++ b/powerTrail/sendEmail.php
@@ -1,4 +1,7 @@
 <?php
+
+use lib\Objects\OcConfig\OcConfig;
+
 class sendEmail
 {
     public static function emailOwners($ptId, $commentType, $commentDateTime, $commentText, $action, $commentOwnerId = false, $delReason = '') {
@@ -60,6 +63,7 @@ class sendEmail
             $usr['userid'] = -1;
         if (!isset($usr['username']))
             $usr['username'] = 'SYSTEM';
+        $mailbody = mb_ereg_replace('{oclogo}', OcConfig::getHeaderLogo(), $mailbody);
         $mailbody = mb_ereg_replace('{mail_auto_generated}', tr('mail_auto_generated'), $mailbody);
         $mailbody = mb_ereg_replace('{commentDateTime}', date($siteDateTimeFormat, strtotime($commentDateTime)), $mailbody);
         $mailbody = mb_ereg_replace('{userId}', $usr['userid'], $mailbody);


### PR DESCRIPTION
Note: I believe that the &lt;img> "alt" attribute should only be supplied if the image contains essential data. E.g. consider a blind user using a screenreader. The screenreader would say "Opencaching Logo" here, which is not necessary.