### PR TITLE
Db update deployment test1

### DIFF
--- a/Utils/Database/Updates/101_deployment_test_1.php
+++ b/Utils/Database/Updates/101_deployment_test_1.php
@@ -1,0 +1,26 @@
+<?php
+
+// created on 2019-01-25 by following5
+
+namespace Utils\Database\Updates;
+
+return new class extends UpdateScript
+{
+    public function getProperties()
+    {
+        return [
+            'uuid' => 'EBC06680-3262-1718-D41E-28EA261325DE',  // do not change
+            'run' => 'auto',  // must be 'auto' for all regular updates
+        ];
+    }
+
+    public function run()
+    {
+        // Dummy update, just for testing the code deployment
+    }
+
+    public function rollback()
+    {
+        // Dummy update, just for testing the code deployment
+    }
+};


### PR DESCRIPTION
This is a test for automatic DB updating.

1. Add the DB updater (util.sec/dbupdate.php) to the [deployment scripts](https://github.com/opencaching/opencaching-pl/tree/master/docs/system) at OC PL, UK and NL.
2. Merge this change.

"101_deployment_test_1" then should run automatically, so the Admin.DbUpdate page should show that it did run. If not, please DO NOT run it manually. Instead, we must fix the problem and then test again.
