### PR TITLE
improve image galleries layout; fixes #1565

### DIFF
--- a/getLogEntries.php
+++ b/getLogEntries.php
@@ -269,7 +269,13 @@ foreach ($logEntries as $record) {
             WHERE `object_id`=:1 AND `object_type`=1";
         $s = $dbc->multiVariableQuery($thatquery, $record['logid']);
 
-        while( $pic_record = $dbc->dbResultFetch($s)) {
+        $pictures = 0;
+        while ($pic_record = $dbc->dbResultFetch($s)) {
+
+            if (++$pictures > 4) {
+                $logpicturelines .= '<div style="clear:both"></div>';
+                $pictures -= 4;
+            }
 
             if (!isset($showspoiler)){
                $showspoiler = '';

--- a/tpl/stdstyle/viewcache/viewcache.css
+++ b/tpl/stdstyle/viewcache/viewcache.css
@@ -127,7 +127,7 @@ div#viewcache-description * {
 }
 
 div#viewcache-utility                   { font-size: 12px; }
-div.viewcache-pictureblock              { float: left; }
+div.viewcache-pictureblock              { display: inline-block; }
 div.viewcache-pictureblock span.title   { display: block; max-width: 175px; padding-left: 10px; padding-right: 5px;clear: left; font-size: 125%;}
 
 #waypoints-table {

--- a/tpl/stdstyle/viewcache/viewcache.tpl.php
+++ b/tpl/stdstyle/viewcache/viewcache.tpl.php
@@ -894,9 +894,6 @@ use Controllers\MainMapController;
                     </div>
                     <span class="title"><?=$pic->title?></span>
                 </div>
-                <?php if ($key%4 == 3) { //add after every 4 pics ?>
-                <div style="clear:both"></div>
-                <?php } ?>
             <?php } //foreach ?>
         </div>
     </div>

--- a/viewlogs.php
+++ b/viewlogs.php
@@ -410,7 +410,13 @@ if ($error == false) {
                 if (!isset($showspoiler)) {
                     $showspoiler = '';
                 }
+                $pictures = 0;
                 while ( $pic_record = $dbc->dbResultFetch($s) ){
+
+                    if (++$pictures > 4) {
+                        $logpicturelines .= '<div style="clear:both"></div>';
+                        $pictures -= 4;
+                    }
 
                     $thisline = $logpictureline;
 


### PR DESCRIPTION
There were issues in all image galleries.

Here are examples with very different image sizes, to illustrate the change.

Log images before:
![log-before](https://user-images.githubusercontent.com/1614754/51872474-de4a8d00-2359-11e9-8681-14020b7349d8.png)

Log images after:
![logs-after](https://user-images.githubusercontent.com/1614754/51872481-e4406e00-2359-11e9-98ce-40fa3923efd6.png)

Cache images before:
![cache-before](https://user-images.githubusercontent.com/1614754/51872372-7136f780-2359-11e9-91b2-e20f89f883d1.png)

Cache images after:
![cache-after](https://user-images.githubusercontent.com/1614754/51872378-76944200-2359-11e9-8f97-ecad57cd1159.png)



