### PR TITLE
new interface for passing settings to OKAPI

### DIFF
--- a/Controllers/UpdateController.php
+++ b/Controllers/UpdateController.php
@@ -4,6 +4,7 @@ namespace Controllers;
 
 use Utils\Database\DbUpdates;
 use Utils\Lock\Lock;
+use Utils\I18n\I18n;
 use okapi\Facade;
 
 /**
@@ -43,6 +44,7 @@ class UpdateController extends BaseController
         echo "\n";
 
         // OKAPI update
+        $this->updateOkapiSettings();
         Facade::database_update();
 
         $messages = ob_get_clean();
@@ -78,5 +80,40 @@ class UpdateController extends BaseController
         }
 
         return $messages;
+    }
+
+    /**
+     * Create settings file for OKAPI
+     */
+    private function updateOkapiSettings()
+    {
+        global $oc_nodeid, $sql_errormail, $emailaddr, $debug_page, $dynbasepath;
+        global $OKAPI_server_URI, $absolute_server_URI;
+        global $dbserver, $dbname, $dbusername, $dbpasswd;
+        global $picdir, $picurl;
+        global $config;
+
+        // See explanation in /okapi_settings.php.
+
+        $settings = [
+            'ADMINS' => ($config['okapi']['admin_emails'] ? $config['okapi']['admin_emails'] : array($sql_errormail, 'rygielski@mimuw.edu.pl', 'following@online.de')),
+            'DATA_LICENSE_URL' => $config['okapi']['data_license_url'],
+            'FROM_FIELD' => $emailaddr,
+            'SITELANG' => I18n::getDefaultLang(),
+            'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
+            'IMAGES_DIR' => rtrim($picdir, '/'),
+            'IMAGES_URL' => rtrim($picurl, '/').'/',
+            'IMAGE_MAX_UPLOAD_SIZE' => (int) $config['limits']['image']['filesize'] * 1024 * 1024,
+            'IMAGE_MAX_PIXEL_COUNT' => $config['limits']['image']['height'] * $config['limits']['image']['width'],
+            'OC_NODE_ID' => $oc_nodeid,
+            'OC_COOKIE_NAME' => $config['cookie']['name'].'_auth',
+            //'OCPL_ENABLE_GEOCACHE_ACCESS_LOGS' => isset($enable_cache_access_logs) ? $enable_cache_access_logs : false
+            'OCPL_ENABLE_GEOCACHE_ACCESS_LOGS' => false,
+            'VAR_DIR' => rtrim($dynbasepath, '/'),
+            'TILEMAP_FONT_PATH' => $config['okapi']['tilemap_font_path'],
+        ];
+        $json = json_encode($settings);
+
+        file_put_contents(__DIR__.'/../var/okapi_settings.json', $json);
     }
 }

--- a/okapi_settings.php
+++ b/okapi_settings.php
@@ -25,38 +25,29 @@ function get_okapi_settings()
     # OKAPI defines only *one* global variable, named 'rootpath'.
     # You may access it to get a proper path to your own settings file.
 
-    require(__DIR__.'/lib/settingsGlue.inc.php');  # (into the *local* scope)
+    require(__DIR__.'/lib/settings.inc.php');  # (into the *local* scope)
 
-    return array(
+    $json = file_get_contents(__DIR__.'/var/okapi_settings.json');
+    $dynamicSettings = json_decode($json, true);
+
+    return [
         # These first section of settings is OKAPI-specific, OCPL's
         # settings.inc.php file does not provide them. For more
         # OKAPI-specific settings, see okapi/settings.php file.
 
         'OC_BRANCH' => 'oc.pl',
         'EXTERNAL_AUTOLOADER' => __DIR__.'/lib/ClassPathDictionary.php',
-        # Copy the rest from settings.inc.php:
+        'USE_SQL_SUBQUERIES' => true,
 
-        'DATA_LICENSE_URL' => $config['okapi']['data_license_url'],
-        'ADMINS' => ($config['okapi']['admin_emails'] ? $config['okapi']['admin_emails'] : array($sql_errormail, 'rygielski@mimuw.edu.pl', 'following@online.de')),
-        'FROM_FIELD' => $emailaddr,
-        'DEBUG' => $debug_page,
+        # These settings will stay in local configuration
+
         'DB_SERVER' => $dbserver,
         'DB_NAME' => $dbname,
         'DB_USERNAME' => $dbusername,
         'DB_PASSWORD' => $dbpasswd,
-        'SITELANG' => 'en', //TODO: how to read it from I18n class?
-        'SITELANGS' => array_map('strtolower', $config['defaultLanguageList']),
-        'SITE_URL' => isset($OKAPI_server_URI) ? $OKAPI_server_URI : $absolute_server_URI,
-        'VAR_DIR' => rtrim($dynbasepath, '/'),
-        'TILEMAP_FONT_PATH' => $config['okapi']['tilemap_font_path'],
-        'IMAGES_DIR' => rtrim($picdir, '/'),
-        'IMAGES_URL' => rtrim($picurl, '/').'/',
-        'IMAGE_MAX_UPLOAD_SIZE' => $config['limits']['image']['filesize'] * 1024 * 1024,
-        'IMAGE_MAX_PIXEL_COUNT' => $config['limits']['image']['height'] * $config['limits']['image']['width'],
-        'OC_NODE_ID' => $oc_nodeid,
-        'OC_COOKIE_NAME' => $config['cookie']['name'].'_auth',
-        //'OCPL_ENABLE_GEOCACHE_ACCESS_LOGS' => isset($enable_cache_access_logs) ? $enable_cache_access_logs : false
-        'OCPL_ENABLE_GEOCACHE_ACCESS_LOGS' => false,
-        'USE_SQL_SUBQUERIES' => true,
-    );
+        'DEBUG' => $debug_page,
+    ]
+        # Load the rest from OCPL settings (add the associative arrays):
+
+        + $dynamicSettings;
 }

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,0 +1,1 @@
+Deny From All


### PR DESCRIPTION
Creates <s>var/okapi_settings.inc.php</s> `var/okapi_settings.json` with each code deployment, which is included to `/okapi_settings.inc.php`. This allows maximum OKAPI performance, no matter how expensive it may be to provide the OCPL settings.

It also reduces code dependencies between OCPL and OKAPI.