### PR TITLE
fix __DIR__ typo in editwp

### DIFF
--- a/editwp.php
+++ b/editwp.php
@@ -68,7 +68,7 @@ if ($error == false) {
 
                 $tplname = 'editwp';
                 require_once(__DIR__.'/lib/caches.inc.php');
-                require(__DRI__.'/src/Views/newcache.inc.php');
+                require(__DIR__.'/src/Views/newcache.inc.php');
 
                 $wp_type = isset($_POST['type']) ? $_POST['type'] : $wp_record['type'];
                 //build typeoptions


### PR DESCRIPTION
Fast fix for this: 

```
ErrorException: Use of undefined constant __DRI__ - assumed &#039;__DRI__&#039; (this will throw an Error in a future version of PHP)
#0 /srv/ocpl/editwp.php(71): src\Utils\Debug\ErrorHandler::handleError(2, &#039;Use of undefine...&#039;, &#039;/srv/ocpl/editw...&#039;, 71, Array)
#1 {main}
```