### PR TITLE
Small fix for Nano and GeoPath

### DIFF
--- a/src/Models/CacheSet/CacheSetCommon.php
+++ b/src/Models/CacheSet/CacheSetCommon.php
@@ -143,6 +143,7 @@ class CacheSetCommon extends BaseObject
             5 => 1,     # Large [from 3 to 10 litres]
             6 => 0.5,   # Very large [more than 10 litres]
             7 => 0,     # no container
+            8 => 3,     # Nano
         ];
         $sizePoints = $sizePointsArray[$cache->getSizeId()];
 


### PR DESCRIPTION
When add a nano cache to existing GeoPath generates a error.

This fix should solve that.