### PR TITLE
fix issue: "Fatal error Cannot use src\\Models\\OcConfig\\OcConfig as…

### DIFF
--- a/src/Views/articles/s8.tpl.php
+++ b/src/Views/articles/s8.tpl.php
@@ -10,7 +10,6 @@
         <?php
 use src\Utils\Database\XDb;
 use src\Utils\Cache\OcMemCache;
-use src\Models\OcConfig\OcConfig;
 use src\Utils\I18n\I18n;
 
 # This page took >60 seconds to render! Added daily caching.


### PR DESCRIPTION
… OcConfig because the name is already in use at line 327"