### PR TITLE
cache edit refactoring: part I - incomplete template

### DIFF
--- a/editcache.php
+++ b/editcache.php
@@ -15,6 +15,7 @@ use src\Utils\Gis\Countries;
 use src\Utils\Uri\SimpleRouter;
 use src\Controllers\PictureController;
 use src\Models\GeoCache\GeoCacheCommons;
+use src\Models\GeoCache\Waypoint;
 
 require_once(__DIR__.'/lib/common.inc.php');
 
@@ -67,6 +68,7 @@ if ($error == false) {
         $target = urlencode(tpl_get_current_page());
         tpl_redirect('login.php?target=' . $target);
     } else {
+        // find geocache
         $dbc = OcDb::instance();
         $thatquery =
             "SELECT user_id, name, picturescount, mp3count, type, size, date_hidden, date_activate, date_created, longitude, latitude,
@@ -84,7 +86,7 @@ if ($error == false) {
 
         if ($cache_record = $dbc->dbResultFetch($s)) {
 
-            if ($cache_record['user_id'] == $usr['userid'] || $usr['admin']) {
+            if ($cache_record['user_id'] == $usr['userid'] || $usr['admin']) { //is-owner || OCTEAM
 
                 // from deleted editcache.inc.php:
                 $submit = 'Zapisz';
@@ -115,23 +117,25 @@ if ($error == false) {
                 $cache_attrib_pic = '<img id="attr{attrib_id}" src="{attrib_pic}" border="0" alt="{attrib_text}" title="{attrib_text}" onmousedown="toggleAttr({attrib_id}); yes_change();" /> ';
 
                 $activation_form = '
-        <tr><td colspan="2">
-        <fieldset style="border: 1px solid black; width: 80%; height: 32%; background-color: #FFFFFF;">
-            <legend>&nbsp; <strong>' . tr("submit_new_cache") . '</strong> &nbsp;</legend>
-                <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_now" value="now" {publish_now_checked}>&nbsp;<label for="publish_now">' . tr('publish_now') . '</label><br />
-                <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_later" value="later" {publish_later_checked}>&nbsp;<label for="publish_later">' . tr('publish_date') . ':</label>
-                <input class="input40" type="text" name="activate_year" onChange="yes_change();" maxlength="4" value="{activate_year}"/> -
-                                <input class="input20" type="text" name="activate_month" onChange="yes_change();" maxlength="2" value="{activate_month}"/> -
-                <input class="input20" type="text" name="activate_day" onChange="yes_change();" maxlength="2" value="{activate_day}"/>&nbsp;
-                                <select name="activate_hour" class="input40" onChange="yes_change();" >
-                    {activation_hours}
-                </select>&nbsp;–&nbsp;{activate_on_message}<br />
-                <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_notnow" value="notnow" {publish_notnow_checked}>&nbsp;<label for="publish_notnow">' . tr('dont_publish_yet') . '</label>
-                </fieldset>
-                </td>
-        </tr>
-        ';
+                    <tr><td colspan="2">
+                    <fieldset style="border: 1px solid black; width: 80%; height: 32%; background-color: #FFFFFF;">
+                        <legend>&nbsp; <strong>' . tr("submit_new_cache") . '</strong> &nbsp;</legend>
+                            <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_now" value="now" {publish_now_checked}>&nbsp;<label for="publish_now">' . tr('publish_now') . '</label><br />
+                            <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_later" value="later" {publish_later_checked}>&nbsp;<label for="publish_later">' . tr('publish_date') . ':</label>
+                            <input class="input40" type="text" name="activate_year" onChange="yes_change();" maxlength="4" value="{activate_year}"/> -
+                                            <input class="input20" type="text" name="activate_month" onChange="yes_change();" maxlength="2" value="{activate_month}"/> -
+                            <input class="input20" type="text" name="activate_day" onChange="yes_change();" maxlength="2" value="{activate_day}"/>&nbsp;
+                                            <select name="activate_hour" class="input40" onChange="yes_change();" >
+                                {activation_hours}
+                            </select>&nbsp;–&nbsp;{activate_on_message}<br />
+                            <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_notnow" value="notnow" {publish_notnow_checked}>&nbsp;<label for="publish_notnow">' . tr('dont_publish_yet') . '</label>
+                            </fieldset>
+                            </td>
+                    </tr>
+                    ';
 
+
+       // type update
                 //here we read all used information from the form if submitted, otherwise from DB
                 // wihout virtuals and webcams
                 if (isset($_POST['type'])) {
@@ -190,6 +194,7 @@ if ($error == false) {
                 }
                 // mp3 update end()
 
+      // size update
                 if (!isset($_POST['size'])) {
                     if ($cache_type == GeoCache::TYPE_VIRTUAL || $cache_type == GeoCache::TYPE_WEBCAM ||
                             $cache_type == GeoCache::TYPE_EVENT) {
@@ -228,6 +233,7 @@ if ($error == false) {
                 $search_time = isset($_POST['search_time']) ? $_POST['search_time'] : $cache_record['search_time'];
                 $way_length = isset($_POST['way_length']) ? $_POST['way_length'] : $cache_record['way_length'];
 
+       // status update
                 if ($status_old == GeoCache::STATUS_NOTYETAVAILABLE &&
                         $status == GeoCache::STATUS_NOTYETAVAILABLE) {
                     if (isset($_POST['publish'])) {
@@ -1027,13 +1033,13 @@ if ($error == false) {
                                 $tmpline1 = mb_ereg_replace('{stagehide_start}', '<!--', $tmpline1);
                             }
 
-                            if ($wp_record['status'] == GeoCache::STATUS_READY) {
+                            if ($wp_record['status'] == Waypoint::STATUS_VISIBLE) {
                                 $status_icon = "images/free_icons/accept.png";
                             }
-                            if ($wp_record['status'] == GeoCache::STATUS_UNAVAILABLE) {
+                            if ($wp_record['status'] == Waypoint::STATUS_VISIBLE_HIDDEN_COORDS) {
                                 $status_icon = "images/free_icons/error.png";
                             }
-                            if ($wp_record['status'] == GeoCache::STATUS_ARCHIVED) {
+                            if ($wp_record['status'] == Waypoint::STATUS_HIDDEN) {
                                 $status_icon = "images/free_icons/stop.png";
                             }
                             $tmpline1 = mb_ereg_replace('{status}', $status_icon, $tmpline1);

--- a/src/Controllers/CacheEditController.php
+++ b/src/Controllers/CacheEditController.php
@@ -1,0 +1,107 @@
+<?php
+namespace src\Controllers;
+
+use src\Models\GeoCache\GeoCache;
+use src\Models\GeoCache\GeoCacheAttribute;
+use src\Models\GeoCache\Mp3Attachment;
+use src\Utils\Gis\Countries;
+use src\Models\GeoCache\Waypoint;
+use src\Models\Pictures\OcPicture;
+
+class CacheEditController extends BaseController
+{
+    public function __construct(){
+        parent::__construct();
+        $this->redirectNotLoggedUsers();
+    }
+
+    public function isCallableFromRouter($actionName)
+    {
+        return true;
+    }
+
+    public function index()
+    {}
+
+    public function newCache()
+    {
+
+    }
+
+
+    /**
+     * Cache details editor
+     * @param int $cacheId
+     */
+    public function editor ($cacheId)
+    {
+        $cache = GeoCache::fromCacheIdFactory($cacheId);
+        if (is_null ($cache)) {
+            $this->displayCommonErrorPageAndExit("Unknown cache");
+        }
+
+        if (!$cache->isEditableByUser($this->loggedUser)) {
+            $this->displayCommonErrorPageAndExit("You can't edit this geocache!");
+        }
+
+        $this->view->setTemplate('cacheEdit/cacheEditor');
+        $this->view->setVar('cache', $cache);
+
+        // detect next allowed status
+        $allowedNextStatuses = $cache->getAllowedNextStatuses($this->loggedUser);
+        if (empty($allowedNextStatuses)) {
+            $this->displayCommonErrorPageAndExit("You don't have a privilages to edit this geocache!");
+        }
+        $this->view->setVar('allowedNextStatuses', $allowedNextStatuses);
+
+        $this->view->setVar('allowedTypes', $cache->getAllowedTypes());
+        $this->view->setVar('allowedSizes', $cache->getAllowedSizes());
+
+        // countries list
+        $this->view->setVar('countries', Countries::getCountriesList(true));
+
+        $this->view->setVar('selectedCountryCode', $cache->getCacheLocationObj()->getCountryCode());
+
+        $this->view->setVar('cacheDifficulties', GeoCache::CacheDifficultyLevels());
+        $this->view->setVar('terreinDifficulties', GeoCache::TerreinDifficultyLevels());
+
+        $this->view->setVar('allAttributes', GeoCacheAttribute::getAll());
+
+        $this->view->setVar('skipWaypointsSection', $cache->isMovable());
+        $this->view->setVar('allWaypoints', Waypoint::GetWaypointsForCache ($cache, false));
+
+        // waypoints have additional infor "stage" showed only for some types of geocaches
+        $this->view->setVar('waypointsHasStages', in_array($cache->getCacheType(),
+                [GeoCache::TYPE_OTHERTYPE,
+                 GeoCache::TYPE_MULTICACHE,
+                 GeoCache::TYPE_QUIZ]));
+
+        $this->view->setVar('descriptions', GeoCache::getDescriptions($cache->getCacheId()));
+
+        $this->view->setVar('pictures', OcPicture::getAllForGeocache($cache));
+
+        $this->view->setVar('skipMp3sSection', $cache->isMp3Allowed());
+        $this->view->setVar('mp3s', Mp3Attachment::getAllForGeocache($cache));
+
+        $this->view->setVar('skipActivationSection', $cache->getStatus() != GeoCache::STATUS_NOTYETAVAILABLE);
+
+        if ($this->loggedUser->getUserId() != $cache->getOwnerId()) {
+            // only owner can see the password
+            $this->view->setVar('skipPasswordSection', true);
+        } else {
+            $this->view->setVar('skipPasswordSection', !$cache->isPasswordAllowed());
+        }
+
+        $this->view->buildView();
+    }
+
+    /**
+     * Save cache data
+     * @param int $cacheId
+     */
+    public function save ($cacheId)
+    {
+
+        d($_POST);
+    }
+}

--- a/src/Controllers/ViewCacheController.php
+++ b/src/Controllers/ViewCacheController.php
@@ -426,7 +426,7 @@ class ViewCacheController extends BaseController
 
     private function processWayPoints()
     {
-        $waypointsList = Waypoint::GetWaypointsForCacheId($this->geocache);
+        $waypointsList = Waypoint::GetWaypointsForCache($this->geocache);
         $this->view->setVar('waypointsList', $waypointsList);
         $this->view->setVar('cacheWithStages',
             $this->geocache->getCacheType() == GeoCache::TYPE_OTHERTYPE ||

--- a/src/Models/GeoCache/CacheLocation.php
+++ b/src/Models/GeoCache/CacheLocation.php
@@ -51,6 +51,17 @@ class CacheLocation extends BaseObject{
         return $this->location->getDescription($separator);
     }
 
+    public function getCountryCode()
+    {
+        return $this->location->getCode(NutsLocation::LEVEL_COUNTRY);
+    }
+
+    public function getRegionCode()
+    {
+        // TODO:...
+        return $this->location->getCode(NutsLocation::LEVEL_COUNTRY);
+    }
+
     /**
      * Save (or update) current object to DB
      */

--- a/src/Models/GeoCache/GeoCacheAttribute.php
+++ b/src/Models/GeoCache/GeoCacheAttribute.php
@@ -1,0 +1,69 @@
+<?php
+namespace src\Models\GeoCache;
+
+use src\Models\BaseObject;
+use src\Utils\I18n\I18n;
+
+/**
+  *
+  */
+class GeoCacheAttribute extends BaseObject {
+
+    private $id;
+    private $textLong;      // long attribute description
+    private $textShort;     // short attribute description
+    private $iconLarge;     // icon for selected attribute
+    private $iconNo;        // icon for negative attaching
+    private $iconUndef;     // greyouted icon when not selected and not negated
+    private $category;      // ???
+
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public static function getAll()
+    {
+        $db = self::db();
+        return $db->dbFetchAllAsObjects(
+            $db->multiVariableQuery (
+                "SELECT id, text_long, icon_undef, icon_large FROM cache_attrib
+                 WHERE language = :1 ORDER BY category, id", I18n::getCurrentLang()),
+            function ($row) {
+                $obj = new self();
+                $obj->loadFromDbRow($row);
+                return $obj;
+            });
+    }
+
+
+
+    protected function loadFromDbRow($row)
+    {
+        $this->id = $row['id'];
+        $this->textLong = $row['text_long'];
+        $this->iconUndef = $row['icon_undef'];
+        $this->iconLarge = $row['icon_large'];
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getLongText ()
+    {
+        return $this->textLong;
+    }
+
+    public function getIconUndef ()
+    {
+        return $this->iconUndef;
+    }
+
+    public function getIconLarge()
+    {
+        return $this->iconLarge;
+    }
+}

--- a/src/Models/GeoCache/GeoCacheCommons.php
+++ b/src/Models/GeoCache/GeoCacheCommons.php
@@ -467,4 +467,14 @@ class GeoCacheCommons extends BaseObject {
     {
         return '/viewcache.php?wp=' . $ocWaypoint;
     }
+
+    public static function CacheDifficultyLevels()
+    {
+        return range(1, 10);
+    }
+
+    public static function TerreinDifficultyLevels()
+    {
+        return range(1, 10);
+    }
 }

--- a/src/Models/GeoCache/GeoCacheRules.php
+++ b/src/Models/GeoCache/GeoCacheRules.php
@@ -1,0 +1,94 @@
+<?php
+namespace src\Models\GeoCache;
+
+/**
+ * This class contains rules of which decide about allowed actions like:
+ * - switching the geocache status
+ * - log adding depends on log type
+ * etc.
+ *
+ * https://docs.google.com/spreadsheets/d/1BpkpmusS98HQKmyJJpJhCQtKHOltdY1b7QE6f8poW8E/edit#gid=1336776289
+ */
+class GeoCacheRules extends GeoCacheCommons {
+
+    /**
+     * Return array of geocache statuses which can be the next status based on given current status
+     *
+     * @param int $currentStatus
+     * @param boolean $isOwner
+     * @param boolean $isOcTeamMember
+     * @param boolean $isUserUnderVerification
+     *
+     * @return array of all possible next statuses (if empty no edit is allowed)
+     */
+    public static function getAllowedNextStatus ($currentStatus, $isOwner, $isOcTeamMember=false,
+        $isUserUnderVerification=false)
+    {
+        if (!$isOwner && !$isOcTeamMember) {
+            // Only owner or OcTea can switch status
+            return [];
+        }
+
+        $next = [];
+        switch ($currentStatus) {
+
+            case self::STATUS_READY:
+            case self::STATUS_UNAVAILABLE:
+
+                $next[] = self::STATUS_READY;
+                $next[] = self::STATUS_UNAVAILABLE;
+                $next[] = self::STATUS_ARCHIVED;
+                if ($isOcTeamMember) {
+                    $next[] = self::STATUS_BLOCKED;
+                }
+                return $next;
+
+            case self::STATUS_ARCHIVED:
+                $next[] = self::STATUS_ARCHIVED;
+                if ($isOcTeamMember) {
+                    $next[] = self::STATUS_BLOCKED;
+                    $next[] = self::STATUS_READY;
+                }
+                return $next;
+
+            case self::STATUS_WAITAPPROVERS:
+                $next[] = self::STATUS_WAITAPPROVERS;
+                if ($isOcTeamMember) {
+                    $next[] = self::STATUS_READY;
+                    $next[] = self::STATUS_BLOCKED;
+                }
+                return $next;
+
+            case self::STATUS_NOTYETAVAILABLE:
+                $next[] = self::STATUS_UNAVAILABLE;
+                $next[] = self::STATUS_ARCHIVED;
+                $next[] = self::STATUS_NOTYETAVAILABLE;
+
+                if (!$isUserUnderVerification) {
+                    $next[] = self::STATUS_READY;
+                } else {
+                    $next[] = self::STATUS_WAITAPPROVERS;
+                }
+
+                if ($isOcTeamMember) {
+                    $next[] = self::STATUS_READY;
+                    $next[] = self::STATUS_BLOCKED;
+                }
+                return $next;
+
+            case self::STATUS_BLOCKED:
+                if ($isOcTeamMember) {
+                    $next[] = self::STATUS_READY;
+                    $next[] = self::STATUS_UNAVAILABLE;
+                    $next[] = self::STATUS_ARCHIVED;
+                    $next[] = self::STATUS_NOTYETAVAILABLE;
+                    $next[] = self::STATUS_BLOCKED;
+                }
+                return $next;
+        }
+
+        // never should be here...`
+        return [];
+    }
+
+}

--- a/src/Models/GeoCache/Waypoint.php
+++ b/src/Models/GeoCache/Waypoint.php
@@ -162,8 +162,7 @@ class Waypoint extends WaypointCommons
         return nl2br($this->description);
     }
 
-    public static function GetWaypointsForCacheId(GeoCache $geoCache, $skipHiddenWps=true){
-
+    public static function GetWaypointsForCache(GeoCache $geoCache, $skipHiddenWps=true){
 
         if($geoCache->getCacheType() == GeoCache::TYPE_MOVING){
             // mobiles can't have waypoints...

--- a/src/Models/GeoCache/WaypointCommons.php
+++ b/src/Models/GeoCache/WaypointCommons.php
@@ -61,4 +61,32 @@ class WaypointCommons extends BaseObject {
         self::ICONS[$type];
     }
 
+    public static function getStatusIcon($status)
+    {
+        switch ($status) {
+            case self::STATUS_VISIBLE:
+                return '/images/free_icons/accept.png';
+            case self::STATUS_VISIBLE_HIDDEN_COORDS:
+                return '/images/free_icons/error.png';
+            case self::STATUS_HIDDEN:
+                return '/images/free_icons/stop.png';
+            default:
+                return '';
+        }
+    }
+
+    public static function statusTranslationKy($status)
+    {
+        switch ($status) {
+            case self::STATUS_VISIBLE:
+                return 'wp_status1';
+            case self::STATUS_VISIBLE_HIDDEN_COORDS:
+                return 'wp_status2';
+            case self::STATUS_HIDDEN:
+                return 'wp_status3';
+            default:
+                return '';
+        }
+    }
+
 }

--- a/src/Models/User/User.php
+++ b/src/Models/User/User.php
@@ -652,7 +652,7 @@ class User extends UserCommons
             return true;
         }
 
-        //get published geocaches count
+        // get published geocaches count
         $activeCachesNum = $this->db->multiVariableQueryValue(
             "SELECT COUNT(*) FROM `caches`
              WHERE `user_id` = :1 AND status = 1",

--- a/src/Utils/Gis/Countries.php
+++ b/src/Utils/Gis/Countries.php
@@ -36,4 +36,10 @@ class Countries
     {
         return array_search($countryCode, self::getCountriesList());
     }
+
+
+    public static function getFlagImg ($countryCode)
+    {
+        return '/images/flags/'.strtolower($countryCode).'.gif';
+    }
 }

--- a/src/Views/cacheEdit/cacheEditor.tpl.php
+++ b/src/Views/cacheEdit/cacheEditor.tpl.php
@@ -1,0 +1,498 @@
+<?php
+use src\Controllers\PictureController;
+use src\Models\GeoCache\GeoCache;
+use src\Models\GeoCache\Waypoint;
+use src\Utils\Gis\Countries;
+use src\Utils\I18n\I18n;
+use src\Utils\I18n\Languages;
+use src\Utils\Uri\SimpleRouter;
+use src\Models\Pictures\OcPicture;
+
+/** @var $v View */
+?>
+<script>
+
+  function validateBeforeSubmit() {
+
+    // name can't be empty
+
+
+  }
+
+</script>
+
+<div class="content2-container">
+
+    <div class="content2-pagetitle">
+        {{edit_cache}}:
+        <a href="<?=$v->cache->getCacheUrl()?>"><?=$v->cache->getCacheName()?></a>
+    </div>
+
+
+    <form action="/cacheEdit/save/<?=$v->cache->getCacheId()?>" method="post" enctype="application/x-www-form-urlencoded"
+          name="editcache_form" dir="ltr">
+
+        <!-- BAR: cache base info  -->
+        <div class="content2-container bg-blue02">
+            <p class="content-title-noshade-size1">
+              <img src="/images/blue/basic2.png" class="icon32" alt=""/>
+              {{basic_information}}
+            </p>
+        </div>
+
+        <!-- cache status -->
+        <div class="form-group-sm">
+            <label for="cacheStatus">{{status_label}}:</label>
+            <select id="cacheStatus" name="status" onChange="yes_change();" class="form-control input200" {disablestatusoption}>
+                <?php foreach ($v->allowedNextStatuses as $statusId) { ?>
+                <option value="<?=$statusId?>" <?=($v->cache->getStatus() == $statusId) ? 'selected="selected"':''?>>
+                    <?=tr(GeoCache::CacheStatusTranslationKey($statusId))?>
+                </option>
+                <?php } //foreach-allowedNextStatuses ?>
+            </select>
+        </div>
+
+        <!-- cache name -->
+        <div class="form-group-sm">
+            <label for="cacheName" class="content-title-noshade">{{name_label}}:</label>
+            <input id="cacheName" type="text" name="name" value="<?=$v->cache->getCacheName()?>" maxlength="60"
+                   class="form-control input400" onChange="yes_change();" />
+        </div>
+
+        <!-- cache type -->
+        <div class="form-group-sm">
+            <label for="cacheType" class="content-title-noshade">{{cache_type}}:</label>
+            <select id="cacheType" name="type" class="form-control input200">
+                <?php foreach ($v->allowedTypes as $typeId) { ?>
+                <option value="<?=$typeId?>" <?=($v->cache->getCacheType() == $typeId) ? 'selected="selected"':''?>>
+                    <?=tr(GeoCache::CacheTypeTranslationKey($typeId))?>
+                </option>
+                <?php } //foreach-allowedNextStatuses ?>
+           </select>
+        </div>
+
+        <!-- cache size -->
+        <div class="form-group-sm">
+            <label for="cacheSize" class="content-title-noshade">{{cache_size}}:</label>
+            <select id="cacheSize" name="size" class="form-control input200">
+                <?php foreach ($v->allowedSizes as $sizeId) { ?>
+                <option value="<?=$sizeId?>" <?=($v->cache->getSizeId() == $sizeId) ? 'selected="selected"':''?>>
+                    <?=tr(GeoCache::CacheSizeTranslationKey($sizeId))?>
+                </option>
+                <?php } //foreach-allowedNextStatuses ?>
+           </select>
+        </div>
+
+        <!-- cache coordinates -->
+        <div class="form-group-sm">
+            <span class="content-title-noshade">{{coordinates}}:</span>
+            <?php $v->callChunk('coordsForm', $v->cache->getCoordinates(), 'coordsEdit'); ?>
+        </div>
+
+        <!-- cache country -->
+        <div class="form-group-sm">
+            <label for="cacheCountry" class="content-title-noshade">{{country_label}}:</label>
+            <select id="cacheCountry" name="size" class="form-control input200">
+                <?php foreach ($v->countries as $countryCode) { ?>
+                <option value="<?=$countryCode?>" <?=($v->selectedCountryCode == $countryCode) ? 'selected="selected"':''?>>
+                    <?=tr($countryCode)?>
+                </option>
+                <?php } //foreach-countries ?>
+           </select>
+        </div>
+
+        <!-- cache region -->
+        <div class="form-group-sm">
+            <label for="cacheRegion" class="content-title-noshade">{{regiononly}}:</label>
+            <select id="cacheRegion" name="size" class="form-control input200">
+           </select>
+           <button class="btn btn-default btn-sm" onclick="return extractregion()">{{region_from_coord}}</button>
+        </div>
+
+
+        <!-- cache difficulties -->
+        <div class="form-group-sm">
+            <p class="content-title-noshade">{{difficulty_level}}:</p>
+            {{task_difficulty}}:
+                <select name="difficulty" class="form-control input50">
+                    <?php foreach ($v->cacheDifficulties as $cacheDifficulty) { ?>
+                        <option value="<?=$cacheDifficulty?>"
+                                <?=($v->cache->getDifficulty() == $cacheDifficulty) ? 'selected="selected"':''?>>
+                        <?=$cacheDifficulty/2?>
+                        </option>
+                    <?php } //foreach-countries ?>
+                </select>
+                &nbsp;&nbsp;
+            {{terrain_difficulty}}:
+                <select name="terrain" class="form-control input50">
+                    <?php foreach ($v->terreinDifficulties as $terreinDifficulty) { ?>
+                        <option value="<?=$terreinDifficulty?>"
+                        <?=($v->cache->getTerrain() == $terreinDifficulty) ? 'selected="selected"':''?>>
+                        <?=$terreinDifficulty/2?>
+                        </option>
+                    <?php } //foreach-countries ?>
+                </select>
+        </div>
+        <div>
+            <div class="notice">
+                {{difficulty_problem}}
+                <a href="/difficultyForm.php" target="_BLANK">{{rating_system}}</a>.
+            </div>
+        </div>
+
+        <!-- additional cache info: time, distance -->
+        <div class="form-group-sm">
+            <p class="content-title-noshade">{{additional_information}} ({{optional}}):</p>
+                {{time}}:
+                <input type="text" name="search_time" maxlength="10" class="form-control input50"
+                       value="<?=$v->cache->getSearchTimeFormattedString(false)?>"/> h
+                &nbsp;&nbsp;
+                {{length}}:
+                <input type="text" name="way_length" maxlength="10" class="form-control input40"
+                       value="<?=$v->cache->getWayLenghtFormattedString(false)?>"/> km
+                &nbsp;
+        </div>
+        <div>
+            <div class="notice">{{time_distance_hint}}</div>
+        </div>
+
+
+        <!-- foreign waypoints -->
+        <div class="form-group-sm">
+            <p class="content-title-noshade">{{foreign_waypoint}} ({{optional}}):</p>
+
+            <table class="table compact-horizontal">
+                <tr>
+                    <td>Geocaching.com:</td>
+                    <td><input type="text" name="wp_gc" maxlength="7" size="7" class="form-control input70 uppercase"
+                               value="<?=$v->cache->getOtherWaypointIds()['gc']?>" /></td>
+                    <td>&nbsp;Navicache.com:</td>
+                    <td><input type="text" name="wp_nc" maxlength="6" size="6" class="form-control input70 uppercase"
+                               value="<?=$v->cache->getOtherWaypointIds()['nc']?>" /></td>
+                </tr>
+                <tr>
+                    <td>Terracaching.com:</td>
+                    <td><input type="text" name="wp_tc" maxlength="7" size="7" class="form-control input70 uppercase"
+                               value="<?=$v->cache->getOtherWaypointIds()['tc']?>" /></td>
+                    <td>&nbsp;GPSGames.org:</td>
+                    <td><input type="text" name="wp_ge" maxlength="6" size="6" class="form-control input70 uppercase"
+                               value="<?=$v->cache->getOtherWaypointIds()['ge']?>" /></td>
+                </tr>
+            </table>
+            <div class="notice">{{foreign_waypoint_info}}</div>
+        </div>
+
+
+        <!-- BAR: cache attributes  -->
+        <div class="content2-container bg-blue02">
+          <p class="content-title-noshade-size1">
+            <img src="/images/blue/attributes.png" class="icon32" alt=""/>&nbsp;{{cache_attributes}}
+          </p>
+        </div>
+
+        <!-- attributes -->
+        <div>
+          <?php foreach ($v->allAttributes as /** @var $attr GeoCacheAttribute */ $attr) {
+              if (in_array($attr->getId(), $v->cache->getCacheAttributesList() )){   // TODO: ache->getCacheAttributesList() doesn't work!!!
+                  $icon = $attr->getIconLarge();
+              } else {
+                  $icon = $attr->getIconUndef();
+              } ?>
+            <img id="<?=$attr->getId()?>" src="/<?=$icon?>" alt="<?=$attr->getLongText()?>"
+                 title="<?=$attr->getLongText()?>" onmousedown="toggleAttr({attrib_id});" />
+          <?php } // foreach-attribiutes ?>
+
+          <div class="notice">{{attributes_desc_hint}}</div>
+        </div>
+
+
+        <!-- BAR: cache descriptions  -->
+        <div class="content2-container bg-blue02">
+          <p class="content-title-noshade-size1">
+            <img src="/images/blue/describe.png" class="icon32" alt=""/>
+            &nbsp;{{descriptions}}
+          </p>
+        </div>
+
+        <!-- add new description -->
+        <div class="content2-newline">
+            <p class="content-title-noshade">
+                <a class="btn btn-sm btn-primary"  href="/newdesc.php?cacheid={cacheid_urlencode}" onclick="return check_if_proceed();">
+                    <img src="/images/actions/list-add-20.png" align="middle" border="0" alt="" title="Dodaj nowy opis"/>
+                    &nbsp;
+                    {{add_new_desc}}
+                </a>
+            </p>
+        </div>
+
+        <!-- list of descriptions -->
+        <div>
+            <?php foreach ($v->descriptions as $descId => $descLang) { ?>
+                <div>
+                    <img src="<?=Countries::getFlagImg($descLang)?>" class="icon16" alt="">
+                    &nbsp;
+                    <?=Languages::LanguageNameFromCode($descLang, I18n::getCurrentLang())?>
+                    &nbsp;&nbsp;
+                    <a class="btn btn-sm btn-success" href="/editdesc.php?descid=<?=$descId?>"
+                       onclick="return check_if_proceed();">
+                        <img src="/images/actions/edit-16.png" border="0" align="middle" alt="">
+                        <?=tr('edit')?>
+                    </a>
+                    &nbsp;&nbsp;
+                    <a class="btn btn-sm" href="/removedesc.php?cacheid=<?=$v->cache->getCacheId()?>&desclang=<?=$descLang?>"
+                       onclick="return check_if_proceed();">
+                       <img src="/images/log/16x16-trash.png" border="0" align="middle" class="icon16" alt="">
+                       <?=tr('delete')?>
+                    </a>
+                </div>
+          <?php } // foreach-attribiutes ?>
+        </div>
+
+
+        <!-- waypoints -->
+        <?php if (!$v->skipWaypointsSection) { ?>
+            <!-- BAR: waypoints -->
+            <div class="content2-container bg-blue02">
+                <p class="content-title-noshade-size1">
+                    <img src="/images/blue/compas.png" class="icon32" alt=""/>
+                    &nbsp;{{additional_waypoints}}
+                </p>
+            </div>
+
+            <div class="content2-newline">
+                <p class="content-title-noshade">
+                    <a class="btn btn-sm btn-primary" onclick="return check_if_proceed();" href="/newwp.php?cacheid={cacheid}" >
+                      <img src="/images/actions/list-add-20.png" align="middle" border="0" alt=""/>
+                      &nbsp;
+                      {{add_new_waypoint}}
+                    </a>
+                </p>
+            </div>
+
+            <!-- waypoints list -->
+            <?php if (!empty($v->allWaypoints)) { ?>
+                <div>
+                    <table id="gradient" cellpadding="5" width="97%" border="1"
+                           style="border-collapse: collapse; font-size: 11px; line-height: 1.6em; color: #000000; ">
+                        <tr>
+                            <?php if ($v->waypointsHasStages) { ?>
+                                <th align="center" valign="middle" width="30"><b><?=tr('stage_wp')?></b></th>
+                            <?php } //if-waypointsHasStages ?>
+                            <th width="32"><b><?=tr('symbol_wp')?></b></th>
+                            <th width="32"><b><?=tr('type_wp')?></b></th>
+                            <th width="32"><b><?=tr('coordinates_wp')?></b></th>
+                            <th><b><?=tr('describe_wp')?></b></th>
+                            <th width="22"><b><?=tr('status_wp')?></b></th>
+                            <th width="22"><b><?=tr('edit')?></b></th>
+                            <th width="22"><b><?=tr('delete')?></b></th>
+                        </tr>
+
+                        <?php foreach ($v->allWaypoints as /** @var $wp Waypoint */ $wp) {
+                            $wpTypeName = tr(Waypoint::typeTranslationKey($wp->getType()));
+                        ?>
+                          <tr>
+                              <?php if ($v->waypointsHasStages) { ?>
+                              <td align="center" valign="middle"><?=$wp->getStage()?></td>
+                              <?php } //if-waypointsHasStages ?>
+                              <td align="center" valign="middle">
+                                  <img src="/<?=$wp->getIconName()?>" alt="<?=$wpTypeName?>" title="<?=$wpTypeName?>" />
+                              </td>
+                              <td align="center" valign="middle"><?=$wpTypeName?></td>
+                              <td align="center" valign="middle">
+                                  <b><span style="color: rgb(88,144,168)"><?=$wp->getCoordinates()->getAsText()?></span></b>
+                              </td>
+                              <td align="center" valign="middle"><?=$wp->getDesc4Html()?></td>
+                              <td align="center" valign="middle">
+                                  <img src="<?=Waypoint::getStatusIcon($wp->getStatus())?>"
+                                       alt="<?=tr(Waypoint::statusTranslationKy($wp->getStatus()))?>"
+                                       title="<?=tr(Waypoint::statusTranslationKy($wp->getStatus()))?>" />
+                              </td>
+                              <td align="center" valign="middle">       <?php //TODO!!!  JS code  ?>
+                                  <a class="links" onclick="return check_if_proceed();"  href="/editwp.php?wpid={wpid}">
+                                      <img src="/images/actions/edit-16.png" alt="" />
+                                  </a>
+                              </td>
+                              <td align="center" valign="middle">       <?php //TODO!!!  JS code  ?>
+                                  <a class="links" href="/editwp.php?wpid={wpid}&delete"
+                                     onclick="if (confirm(\'' . tr('ec_delete_wp') . '\')) {return check_if_proceed();} else {return false;};">
+                                     <img src="/images/log/16x16-trash.png" align="middle" class="icon16" alt="" />
+                                  </a>
+                              </td>
+                          </tr>
+                        <?php } // foreach-attribiutes ?>
+                  </table>
+                  <div class="notice">{{waypoints_about_info}}</div>
+                </div>
+
+            <?php } else { //if-no-waypoints ?>
+
+                <div class="notice"><?=tr('nowp_notice')?></div>
+
+            <?php } // if-no-waypoints ?>
+        <?php } //if-skipWaypointsSection ?>
+
+
+        <!-- BAR: pictures -->
+        <div class="content2-container bg-blue02">
+            <p class="content-title-noshade-size1">
+                <img src="/images/blue/picture.png" class="icon32" alt=""/>
+                &nbsp;&nbsp;
+                {{pictures_label}}
+            </p>
+        </div>
+
+        <div class="content2-newline">
+            <p class="content-title-noshade">
+                <a class="btn btn-sm btn-primary" href="/newpic.php?objectid=<?=$v->cache->getCacheId()?>&type=2&def_seq={def_seq}"  <?php //TODO: def_seq = max_def_seq +1...?>
+                   onclick="return check_if_proceed();">
+                   <img src="/images/actions/list-add-20.png" align="middle" border="0" alt="" />
+                   &nbsp;
+                    {{add_new_pict}}
+                </a>
+            </p>
+        </div>
+
+        <!-- list of descriptions -->
+        <div>
+            <?php foreach ($v->pictures as /** @var $pic OcPicture */ $pic) { ?>
+                <div class="form-group-sm">
+                    [TODO:SEQ]
+                    <img src="/images/free_icons/picture.png" class="icon32" alt="" />
+                    &nbsp;
+                    <a href="<?=$pic->getUrl()?>" target="_blank">
+                      <?=$pic->getTitle()?>
+                    </a>
+                    &nbsp;&nbsp;
+                    <a class="btn btn-sm btn-success" href="/editpic.php?uuid=<?=$pic->getUuid()?>" onclick="return check_if_proceed();">
+                      <img src="/images/actions/edit-16.png" align="middle" alt="" title="" />
+                      <?=tr('edit')?>
+                    </a>
+                    &nbsp;&nbsp;
+                    <a class="btn btn-sm" href="<?=SimpleRouter::getLink(PictureController::class, 'remove',[$pic->getUuid()])?>" onclick="">
+                        <img src="/images/log/16x16-trash.png" border="0" align="middle" class="icon16" alt="" title="" />
+                        <?=tr('delete')?>
+                    </a>
+                </div>
+            <?php } //foreach- ?>
+        </div>
+
+
+        <!-- BAR: mp3s -->
+        <?php if ($v->skipMp3sSection) { ?>
+            <div class="content2-container bg-blue02">
+                <p class="content-title-noshade-size1">
+                  <img src="/images/blue/podcache-mp3.png" class="icon32" alt=""/>
+                  &nbsp;&nbsp;{{mp3_label}}
+                </p>
+            </div>
+
+            <div class="content2-newline">
+                <p class="content-title-noshade">
+                    <a class="btn btn-sm btn-primary" href="/newmp3.php?objectid={cacheid_urlencode}&type=2&def_seq_m={def_seq_m}"
+                       onclick="return check_if_proceed();">
+                       <img src="/images/actions/list-add-20.png" align="middle" border="0" alt=""/>
+                       &nbsp;
+                       {{add_new_mp3}}
+                    </a>
+                </p>
+             </div>
+
+            <!-- list of mp3s -->
+            <div>
+                <?php if (!empty ($v->cache->getMp3List())) { ?>
+
+                    <?php foreach ($v->cache->getMp3List() as $mp3) { ?>
+                    <div>
+                    {seq_drop_mp3}
+                    <img src="/images/free_icons/sound.png" class="icon32" alt="" />
+                    &nbsp;
+                    <a target="_BLANK" href="{link}">{title}</a>
+                    &nbsp;&nbsp;
+                    <a class="btn btn-sm btn-success" href="/editmp3.php?uuid={uuid}" onclick="return check_if_proceed();">
+                      <img src="/images/actions/edit-16.png" align="middle" alt="" title="" />
+                      <?=tr('edit')?>
+                    </a>
+
+                    <a class="btn btn-sm"  href="removemp3.php?uuid={uuid}" onclick="">
+                      <img src="/images/log/16x16-trash.png" border="0" align="middle" class="icon16" alt="" title="" />
+                      <?=tr('delete')?>
+                    </a>
+                    <?php } // ?>
+
+                <?php } else { // if-empty-mp3List ?>
+                  <div class="notice"><?=tr('no_mp3_files')?></div>
+                <?php } // if-empty-mp3List ?>
+            </div>
+
+        <?php } //if-skipMp3sSection ?>
+
+
+        <!-- BAR: others -->
+        <div class="content2-container bg-blue02">
+            <p class="content-title-noshade-size1">
+                <img src="/images/blue/crypt.png" class="icon32"/>{{other}}
+            </p>
+        </div>
+
+        <div>
+            <fieldset class="form-group-sm">
+                <legend>&nbsp; <strong>{{date_hidden_label}}</strong> &nbsp;</legend>
+                <input class="form-control input30" type="text" name="hidden_day" maxlength="2" value="{date_day}" onChange="yes_change();" />
+                -
+                <input class="form-control input30" type="text" name="hidden_month" maxlength="2" value="{date_month}" onChange="yes_change();" />
+                -
+                <input class="form-control input50" type="text" name="hidden_year" maxlength="4" value="{date_year}" onChange="yes_change();" />
+            </fieldset>
+            <div class="notice">{{event_hidden_hint}}</div>
+        </div>
+
+        <!-- activation section -->
+        <?php if (!$v->skipActivationSection) { ?>
+            <div>
+                <fieldset>
+                    <legend>&nbsp;<?=tr("submit_new_cache")?>&nbsp;</legend>
+                    <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_now" value="now" {publish_now_checked}>
+                    &nbsp;
+                    <label for="publish_now"><?=('publish_now')?></label>
+                    <br />
+                    <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_later" value="later" {publish_later_checked}>
+                    &nbsp;
+                    <label for="publish_later"><?=tr('publish_date')?>:</label>
+                    <input class="input40" type="text" name="activate_year" onChange="yes_change();" maxlength="4" value="{activate_year}"/>
+                     -
+                    <input class="input20" type="text" name="activate_month" onChange="yes_change();" maxlength="2" value="{activate_month}"/>
+                     -
+                    <input class="input20" type="text" name="activate_day" onChange="yes_change();" maxlength="2" value="{activate_day}"/>
+                    &nbsp;
+                    <select name="activate_hour" class="input40" onChange="yes_change();" >
+                        {activation_hours}
+                    </select>
+                    &nbsp;–&nbsp;{activate_on_message}
+                    <br />
+                    <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_notnow" value="notnow" {publish_notnow_checked}>
+                    &nbsp;
+                    <label for="publish_notnow"><?=tr('dont_publish_yet')?></label>
+                </fieldset>
+            </div>
+        <?php } // if-skipActivationSection ?>
+
+        <!-- password section -->
+        <?php if ($v->skipPasswordSection) { ?>
+            <div>
+                <fieldset>
+                    <legend>&nbsp;{{log_password}}&nbsp;</legend>
+                    <input class="form-control input120" type="text" name="log_pw" id="log_pw" value="{log_pw}"
+                           maxlength="20" onChange="yes_change();" />
+                    ({{no_password_label}})
+                </fieldset>
+                <div class="notice" style="width:500px;">{{please_read}}</div>
+            </div>
+        <?php } //if-skipPasswordSection ?>
+
+
+        <div class="callout callout-warning">{{creating_cache}}</div>
+
+        <button type="submit" name="submit" value="{submit}" class="btn btn-primary">{{store}}</button>
+    </form>
+
+</div>

--- a/src/Views/chunks/coordsForm.tpl.php
+++ b/src/Views/chunks/coordsForm.tpl.php
@@ -14,6 +14,8 @@ use src\Models\Coordinates\Coordinates;
  * Additionally, to handle if coords are ready check the value of hidden input with id: <$inputPrefix>FinalCoordsReady.
  * Also note thet OnChange event is triggered on this input when its value is changed
  *
+ * Example of use:
+ *   <?php $v->callChunk('coordsForm', $v->cache->getCoordinates(), 'coordsEdit'); ?>
  */
 
 return function (Coordinates $initCoords = null, $inputPrefix='') {


### PR DESCRIPTION
I've started the cache edit refactor as there are a few issues around this:
- problem with support for new types of caches (OCUS)
- other minor issues (ask me for details)

Currently this is side work - nothing is changed from user perspective - old script is workin until we decide that the new one is ready.

Finally the same template will be use for newcache and editcache dialogs.
I don't want to introduce many new features now - rather rewrite this code (editcache/newcache). 
Then adding the new features will be much easier.

This commit contains new template but there are still many open tasks - especially there is needed new JS code etc. I'd like to commit this to split the change on smaller parts.