### PR TITLE
Fix missing 'creator' field in viewcache when cache was adopted

### DIFF
--- a/src/Models/GeoCache/GeoCache.php
+++ b/src/Models/GeoCache/GeoCache.php
@@ -644,7 +644,7 @@ class GeoCache extends GeoCacheCommons
      */
     public function isAdopted()
     {
-        return $this->founder && $this->founder->getUserId() != $this->ownerId;
+        return $this->founderId && $this->founderId != $this->ownerId;
     }
 
     public function getOwnerId()


### PR DESCRIPTION
Signed-off-by: Michał Żyłowski <michal@zylowski.net>

Hello,
Some times ago there was a feature for adopted caches. In viewcache page were two fields: creator and owner. Now only owner is visible. After reading `git history` this seems to be a bug after some viewcache refactor.

I added a missing call for getFounder method. And the effect is:
![image](https://user-images.githubusercontent.com/13780868/81612270-dabb0800-93dc-11ea-8d63-764bcce9b101.png)
