### PR TITLE
Interactive Map

### DIFF
--- a/config/map.default.php
+++ b/config/map.default.php
@@ -80,6 +80,12 @@ $map['startPageMapZoom'] = 5;
 $map['startPageMapDimensions'] = [250, 260];
 
 /**
+ * A family of marker styling used in interactive map.
+ * Currently supported values: 'simple'
+ */
+$map['markersFamily'] = 'simple';
+
+/**
  * Links to external maps used at least at viewpage
  * (to disable map - just add key $map['external']['OSMapa']['enabled'] = false;)
  *

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -3028,4 +3028,7 @@ $translations = array(
     'gpMyCandidates_offerRefused' => 'Offer refused',
 
     'edit_description' => 'Edit description',
+
+    'map_popup_next' => 'Next',
+    'map_popup_previous' => 'Previous'
 );

--- a/public/views/chunks/interactiveMap/interactiveMap.css
+++ b/public/views/chunks/interactiveMap/interactiveMap.css
@@ -1,0 +1,289 @@
+@charset "UTF-8";
+
+.interactiveMap_cursor {
+    cursor: crosshair
+}
+
+.interactiveMap_layerSwitcher {
+  top: 5px;
+  right: 5px;
+}
+
+.interactiveMap_layerSwitcher select {
+  padding: 7px;
+  margin: 5px;
+  border: none;
+  background-color: rgba(255,255,255,0.5);
+  color: #555;
+}
+
+/* all 3 classes to be sure that it overrride OL defaults */
+div.interactiveMap_attribution .ol-attribution.ol-control.ol-attribution {
+  bottom: 5px;
+  right: 5px;
+  background-color: rgba(238,238,238, .4);
+}
+
+/* for OL scale overriding default classes
+   is a best way to customize look of scale */
+.ol-scale-line {
+  bottom: 5px;
+  background-color: transparent;
+}
+
+@media screen and (max-width: 800px) {
+  .ol-scale-line {
+    left: 5px;
+  }
+}
+
+@media screen and (min-width: 800px) {
+  .ol-scale-line {
+    left: 50%;;
+    transform: translateX(-50%);
+  }
+}
+
+.ol-scale-line-inner {
+  /* this is a real scale line */
+  color: #000;
+  font-size: 0.7rem;
+  background-color: rgb(238,238,238);
+  opacity: 0.4;
+  border-width: 2px;
+  border-color: #000;
+  border-style: none solid none solid;
+}
+
+.interactiveMap_gpsLocator {
+  bottom: 130px;
+  right: 5px;
+}
+
+.interactiveMap_compassDiv {
+  top: 70px;
+  right: 5px;
+}
+
+.interactiveMap_mapZoom {
+  bottom: 30px;
+  right: 5px;
+  display: flex;
+  flex-direction: column;
+}
+
+.interactiveMap_mapZoom img,
+.interactiveMap_gpsLocator img,
+.interactiveMap_compassDiv img {
+  width: 25px;
+  height: 25px;
+  margin: 5px;
+}
+
+.interactiveMap_mousePosition {
+  bottom: 5px;
+  left: 5px;
+  background-color: rgb(238,238,238,0.4);
+  color: #555;
+  padding: 2px 10px;
+  font-size: 0.8rem;
+}
+
+.interactiveMap_infoMsg {
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+
+  display: flex;
+  flex-direction: row;
+
+  padding: 2px 10px;
+  font-size: 0.8rem;
+}
+
+.interactiveMap_infoMsgClose {
+  margin-left: 10px;
+  cursor: pointer;
+  color: #888;
+}
+
+.interactiveMap_popup {
+  position: absolute;
+  background-color: white;
+  -webkit-filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
+  filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
+  padding: 8px 15px 8px 8px;
+  border-radius: 5px;
+  border: 1px solid #cccccc;
+  bottom: 12px;
+  left: -48px;
+  min-width: 300px;
+  font-size: 1.0em;
+}
+
+.interactiveMap_popup:after, .interactiveMap_popup:before {
+  top: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.interactiveMap_popup:after {
+  border-top-color: white;
+  border-width: 10px;
+  left: 48px;
+  margin-left: -10px;
+}
+.interactiveMap_popup:before {
+  border-top-color: #cccccc;
+  border-width: 11px;
+  left: 48px;
+  margin-left: -11px;
+}
+.interactiveMap_popup .imp-closer {
+  text-decoration: none;
+  position: absolute;
+  top: 0px;
+  right: 2px;
+}
+.interactiveMap_popup .imp-closer:after {
+  content: "✖";
+  font-size: 15px;
+  cursor: pointer;
+  color: #000;
+}
+
+.interactiveMap_popup .imp-navi .imp-backward {
+    float: left;
+}
+
+.interactiveMap_popup .imp-navi .imp-forward {
+    float: right;
+}
+
+.interactiveMap_popup .imp-navi .imp-backward,
+.interactiveMap_popup .imp-navi .imp-forward {
+    padding: 0 3px;
+    font-weight: bold;
+}
+
+.interactiveMap_popup .imp-navi .imp-backward img,
+.interactiveMap_popup .imp-navi .imp-forward img {
+    width: 20px;
+    height: auto;
+    cursor: pointer;
+}
+
+.interactiveMap_popup .imp-navi .imp-backward img {
+    -moz-transform: scaleX(-1);
+    -o-transform: scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+    filter: FlipH;
+    -ms-filter: "FlipH";
+}
+
+/* a lot of log entries starts with a paragraph*/
+.interactiveMap_popup  p {
+    font-size: inherit !important;
+}
+
+.interactiveMap_popup .imp-cache .imp-icon, .interactiveMap_popup .imp-cache .imp-icon img,
+.interactiveMap_popup .imp-cache-log .imp-cache-icon, .interactiveMap_popup .imp-cache-log .imp-cache-icon img,
+.interactiveMap_popup .imp-cache-log .imp-log-icon, .interactiveMap_popup .imp-cache-log .imp-log-icon img {
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+}
+
+.interactiveMap_popup .imp-cache .imp-icon, .interactiveMap_popup .imp-cache .imp-icon img,
+.interactiveMap_popup .imp-cache-log .imp-cache-icon, .interactiveMap_popup .imp-cache-log .imp-cache-icon img {
+    width: 19px;
+    height: 19px;
+}
+
+.interactiveMap_popup .imp-cache .imp-wp {
+    float: right;
+    font-weight: normal;
+    font-size: 90% !important;
+}
+
+.interactiveMap_popup .imp-cache .imp-details {
+    font-size: 85%;
+}
+
+.interactiveMap_popup .imp-cache .imp-details img {
+    width: 10px;
+    height: 10px;
+}
+
+.interactiveMap_popup .imp-cache .imp-counter {
+    text-align: right;
+}
+
+.interactiveMap_popup .imp-cache .imp-label {
+    font-weight: bold;
+}
+
+.interactiveMap_popup .imp-cache-log .imp-block {
+    margin-top: 10px;
+}
+
+.interactiveMap_popup .imp-cache-log .imp-content {
+    font-weight: normal;
+}
+
+.interactiveMap_popup .imp-cache-log .imp-user {
+   font-weight: bold;
+}
+
+.interactiveMap_popup .imp-guide {
+    font-size: 13px;
+    font-weight: bold;
+    text-align: left;
+}
+
+.interactiveMap_popup .imp-guide .imp-desc {
+    max-height: 5em;
+    overflow: hidden;
+}
+
+.interactiveMap_popup .imp-table {
+    display: table;
+    width: 100%;
+}
+
+.interactiveMap_popup .imp-table .imp-row {
+    display: table-row;
+}
+
+.interactiveMap_popup .imp-table .imp-cell,
+.interactiveMap_popup .imp-table .imp-narrow-cell {
+    display: table-cell;
+    padding: 1px 5px;
+}
+
+.interactiveMap_popup .imp-table .imp-narrow-cell {
+    width: 1%;
+    white-space: nowrap;
+}
+
+.interactiveMap_popup .imp-cache .imp-icon,
+.interactiveMap_popup .imp-cache-log .imp-cache-icon,
+.interactiveMap_popup .imp-cache-log .imp-log-icon {
+    padding-bottom: 2px;
+}
+
+.interactiveMap_popup .ipm-section {
+    margin-bottom: 5px;
+}
+
+.interactiveMap_popup .imp-table .ipm-section {
+    padding: 0px 0px 1px 0px;
+    font-size: 0.8em;
+    font-weight: bold;
+    border-bottom: 1px solid #c0c0c0;
+    text-align: center;
+}

--- a/public/views/chunks/interactiveMap/interactiveMap.js
+++ b/public/views/chunks/interactiveMap/interactiveMap.js
@@ -1,0 +1,1365 @@
+/**
+ * This is a global object and an entry point to InteractiveMap collection
+ */
+var InteractiveMapServices = {
+    /**
+     * returns InteractiveMap object with given mapId
+     * or if params is an object, creates a new one with given id and params
+     */
+    getInteractiveMap: function(mapId, params) {
+        var result = null;
+        if (
+            typeof mapId !== "undefined"
+        ) {
+            if (typeof window["_interactiveMaps"] === "undefined") {
+                window["_interactiveMaps"] = [];
+            }
+            if (
+                typeof window["_interactiveMaps"][mapId]
+                    === "undefined"
+            ) {
+                if (typeof params === "object") {
+                    window["_interactiveMaps"][mapId] =
+                        new InteractiveMap(mapId, params);
+                    result = window["_interactiveMaps"][mapId];
+                }
+            } else {
+                result = window["_interactiveMaps"][mapId];
+            }
+        }
+        return result;
+    },
+
+    /**
+     * returns OpenLayers map object used as a base of this chunk instance
+     */
+    getMapObject: function(mapId) {
+        return (
+            typeof mapId !== "undefined"
+            && typeof window["_interactiveMaps"] !== "undefined"
+            && typeof window["_interactiveMaps"][mapId] !== "undefined"
+            ? window["_interactiveMaps"][mapId].map
+            : null
+        );
+    },
+
+    /**
+     * returns the name of currently selected map (layer) name
+     */
+    getSelectedLayerName: function(mapId) {
+        var map = this.getMapObject(mapId);
+
+        var visibleLayers = [];
+        if (map) {
+            map.getLayers().forEach(function(layer) {
+                if (
+                    !OcLayerServices.isOcInternalLayer(layer)
+                    && layer.getVisible()
+                ) {
+                    visibleLayers.push(OcLayerServices.getOcLayerName(layer));
+                }
+            });
+        }
+
+        if (visibleLayers.length <= 0) {
+            console.err('--- no visible layer ?! ---');
+            return '';
+        }
+        if (visibleLayers.length > 1) {
+            console.err('--- many visible layers ?! ---');
+        }
+
+        return visibleLayers.pop();
+    },
+
+    /**
+     * add callback which will be called on map layer change
+     * callback should be a function with one input parameter: "selectedLayerName"
+     */
+    addMapLayerSwitchCallback: function(mapId, callback) {
+        var correct = true;
+        if (typeof mapId === "undefined") {
+            console.error('mapId is required!');
+            correct = false;
+        }
+        if (typeof callback !== "function") {
+            console.error('callback must be a function!');
+            correct = false;
+        }
+
+        if (correct) {
+            var map = this.getMapObject(mapId);
+            if (map) {
+                if (typeof map.layerSwitchCallbacks !== "array") {
+                    map.layerSwitchCallbacks = []
+                }
+                map.layerSwitchCallbacks.push(callback);
+            }
+        }
+    },
+
+    /**
+     * Reorders sections of map with given id, see the InteractiveMap
+     * corresponding method.
+     */
+    reorderSections: function (mapId, orders) {
+        var correct = true;
+        if (typeof mapId === "undefined") {
+            console.error('mapId is required!');
+            correct = false;
+        }
+        if (typeof orders !== "object") {
+            console.error('orders must be an object!');
+            correct = false;
+        }
+        if (correct) {
+            var map = this.getInteractiveMap(mapId);
+            if (map) {
+                map.reorderSections(orders);
+            }
+        }
+    },
+
+    /**
+     * Toggles visibility of section of map with given id, see the
+     * InteractiveMap corresponding method.
+     */
+    toggleSectionVisibility: function(mapId, section) {
+        var correct = true;
+        if (typeof mapId === "undefined") {
+            console.error('mapId is required!');
+            correct = false;
+        }
+        if (typeof section === "undefined") {
+            console.error('section is required!');
+            correct = false;
+        }
+        if (correct) {
+            var map = this.getInteractiveMap(mapId);
+            if (map) {
+                map.toggleSectionVisibility(section);
+            }
+        }
+    },
+
+    /**
+     * Highlights a feature match given parameters: markerType, id
+     * (cache or log) and section of map with given id, see the InteractiveMap
+     * corresponding method.
+     */
+    highlightFeature: function(mapId, markerType, localId, section) {
+        var correct = true;
+        if (typeof mapId === "undefined") {
+            console.error('mapId is required!');
+            correct = false;
+        }
+        if (typeof markerType === "undefined") {
+            console.error('markerType is required!');
+            correct = false;
+        }
+        if (typeof localId === "undefined") {
+            console.error('localId is required!');
+            correct = false;
+        }
+        if (correct) {
+            var interactiveMap = this.getInteractiveMap(mapId);
+            if (interactiveMap) {
+                interactiveMap.highlightFeature(markerType, localId, section);
+            }
+        }
+    },
+
+    /**
+     * Tones down (de-emphasizes) previously highlighted feature of map with
+     * given id, see the InteractiveMap corresponding method.
+     */
+    toneDownFeature: function(mapId) {
+        var correct = true;
+        if (typeof mapId === "undefined") {
+            console.error('mapId is required!');
+            correct = false;
+        }
+        if (correct) {
+            var interactiveMap = this.getInteractiveMap(mapId);
+            if (interactiveMap) {
+                interactiveMap.toneDownFeature();
+            }
+        }
+    },
+
+    styler: { // styles in OL format
+        fgColor: [100, 100, 255, 1], // main foreground color in OL format
+        bgColor: [238, 238, 238, 0.4], // main background color in OL format
+    }
+
+};
+
+// =================================================================
+
+/**
+ * An InteractiveMap prototype
+ */
+function InteractiveMap(id, params) {
+    this.id = id;
+    this.targetDiv = undefined;
+    this.centerOn = undefined;
+    this.mapStartZoom = undefined;
+    this.forceMapZoom = undefined;
+    this.startExtent = undefined;
+    this.mapLayersConfig = getMapLayersConfig();
+    this.selectedLayerKey = undefined;
+    this.infoMessage = undefined;
+    this.markersData = undefined;
+    this.sectionsProperties = undefined;
+    this.sectionsNames = undefined;
+    this.markerMgrs = undefined;
+    this.markersFamily = undefined;
+
+    // defaults for controls and markers
+    this.enableScaleLine = true;
+    this.enableLayerSwitcher = true;
+    this.enableZoomControls = true;
+    this.enableCompass = true;
+    this.enableGPSLocator = true;
+    this.enableCooordsUnderCursor = true;
+    this.enableInfoMessage = true;
+    this.enableMarkers = true;
+    this.enablePopup = true;
+    this.enableHighlight = true;
+
+    this.compiledPopupTpls = [];
+    this.layerSwitchCallbacks = [];
+    // rewrite params entries to corresponding attributes
+    if (typeof params === "object") {
+        for (var p in params) {
+            if (this.hasOwnProperty(p)) {
+                this[p] = params[p];
+            }
+        }
+    }
+}
+
+/**
+ * Initializes OL map, controls, markers etc.
+ */
+InteractiveMap.prototype.init = function() {
+    var mapDiv = $('#' + this.targetDiv);
+    var attributionDiv = $('<div class="interactiveMap_attribution"></div>');
+    mapDiv.addClass("interactiveMap_cursor");
+
+    this.map = new ol.Map({
+        target: this.targetDiv,
+        view: new ol.View({
+            center: ol.proj.fromLonLat(
+                [this.centerOn.lon, this.centerOn.lat]
+            ),
+            zoom: this.mapStartZoom,
+        }),
+        controls: ol.control.defaults({
+            attributionOptions: {
+                collapsible: false,
+                target: attributionDiv[0],
+            },
+            zoom: false,
+            rotate: false,
+        }),
+    });
+
+    // add attribution control
+    this.map.addControl(new ol.control.Control({
+        element: attributionDiv[0],
+    }));
+
+    if (this.enableScaleLine) {
+        // note: scaleLine has two css OL classes:
+        // .ol-scale-line .ol-scale-line-inner
+        this.map.addControl(new ol.control.ScaleLine({ minWidth: 100 }));
+    }
+
+    if (this.startExtent) {
+        // fit map to given extent
+        var sw = ol.proj.fromLonLat([
+            this.startExtent.sw.lon, this.startExtent.sw.lat
+        ]);
+        var ne = ol.proj.fromLonLat([
+            this.startExtent.ne.lon, this.startExtent.ne.lat]
+        );
+        this.map.getView().fit([sw[0], sw[1], ne[0], ne[1]], { nearest:true });
+    }
+
+    if (this.enableLayerSwitcher) {
+        // init layer switcher
+        this._layerSwitcherInit();
+    }
+    if (this.enableZoomControls) {
+        // init zoom controls
+        this._mapZoomControlsInit();
+    }
+    if (this.enableCompass) {
+        // init map compass (north-up reset button)
+        this._compassControlInit();
+    }
+    if (this.enableGPSLocator) {
+        // init localization control
+        this._gpsLocatorInit();
+    }
+    if (this.enableCoordsUnderCursor) {
+        // init mouse position coords
+        this._coordsUnderCursorInit();
+    }
+    if (this.enableInfoMessage) {
+        // init infoMessage control
+        this._infoMessageInit();
+    }
+
+    if (this.enableMarkers) {
+        // load markers data and create features
+        this._loadMarkers();
+    }
+}
+
+/**
+ * Initializes layer switcher control with preconfigured map layers
+ */
+InteractiveMap.prototype._layerSwitcherInit = function() {
+    var switcherDiv = $(
+        "<div class='ol-control interactiveMap_layerSwitcher'></div>"
+    );
+
+    // prepare dropdown object
+    var switcherDropdown = $('<select></select>');
+
+    switcherDiv.append(switcherDropdown);
+
+    var instance = this;
+
+    // add layers from config to map
+    $.each(this.mapLayersConfig, function(key, layer) {
+        OcLayerServices.setOcLayerName(layer, key);
+        layer.set('wrapX', true);
+        layer.set('zIndex', 1);
+
+        if (key == instance.selectedLayerKey) {
+            switcherDropdown.append(
+                '<option value=' + key + ' selected>' + key + '</option>'
+            );
+            layer.setVisible(true);
+        } else {
+            switcherDropdown.append(
+                '<option value=' + key + '>' + key + '</option>'
+            );
+            layer.setVisible(false);
+        }
+        instance.map.addLayer(layer);
+    });
+
+    // add switcher to map
+    this.map.addControl(
+        new ol.control.Control({ element: switcherDiv[0] })
+    );
+
+    // init switcher change callback
+    switcherDropdown.change(function(evt) {
+        var selectedLayerName = switcherDropdown.val();
+        instance.map.getLayers().forEach(function(layer) {
+            // first skip OC-internal layers (prefix oc_)
+            if (!OcLayerServices.isOcInternalLayer(layer)) {
+                // this is external layer (like OSM)
+                layer.setVisible(
+                    OcLayerServices.getOcLayerName(layer) == selectedLayerName
+                );
+            } else {
+                // this is OC-generated layer
+                if (layer.getVisible() != true) {
+                    layer.setVisible(true);
+                }
+            }
+        });
+
+        // run callback if present
+        if (typeof instance.layerSwitchCallbacks === 'undefined') {
+            $.each(instance.layerSwitchCallbacks, function(key, callback) {
+                callback(selectedLayerName);
+            });
+        }
+    });
+}
+
+/**
+ * Initializes GPS locator control
+ */
+InteractiveMap.prototype._gpsLocatorInit = function() {
+    if (!("geolocation" in navigator)) {
+        console.log('Geolocation not supported by browser.')
+        return;
+    }
+    var gpsDiv = $("<div class='ol-control interactiveMap_gpsLocator'></div>");
+    var gpsImg = $(
+        '<img id="interactiveMap_gpsPositionImg" '
+        + 'src="/images/icons/gps.svg" alt="gps">'
+    );
+
+    gpsDiv.append(gpsImg);
+
+    this.map.addControl(
+        new ol.control.Control({ element: gpsDiv[0] })
+    );
+
+    var geolocationObj = new GeolocationOnMap(
+        this.map, '.interactiveMap_gpsLocator'
+    );
+    gpsImg.click(function() {
+        geolocationObj.getCurrentPosition();
+    });
+}
+
+/**
+ * Initializes Map zoom control
+ */
+InteractiveMap.prototype._mapZoomControlsInit = function() {
+    var zoomDiv = $('<div class="ol-control interactiveMap_mapZoom"></div>');
+    var zoomIn = $('<img src="/images/icons/plus.svg" alt="+">');
+    var zoomOut = $('<img src="/images/icons/minus.svg" alt="-">');
+
+    zoomDiv.append(zoomIn);
+    zoomDiv.append(zoomOut);
+
+    this.map.addControl(
+        new ol.control.Control({ element: zoomDiv[0] })
+    );
+
+    var instance = this;
+
+    zoomIn.click(function() {
+        var view = instance.map.getView();
+        var zoom = view.getZoom();
+        view.setZoom(zoom + 1)
+    });
+
+    zoomOut.click(function() {
+        var view = instance.map.getView()
+        var zoom = view.getZoom();
+        view.setZoom(zoom - 1)
+    });
+}
+
+/**
+ * Initializes Compass control
+ */
+InteractiveMap.prototype._compassControlInit = function() {
+    var compassDiv = $('<div class="ol-control interactiveMap_compassDiv"></div>');
+    var compass = $('<img src="/images/icons/arrow.svg" alt="+">');
+    compassDiv.append(compass);
+
+    this.map.addControl(
+        new ol.control.Control({ element: compassDiv[0] })
+    );
+
+    var instance = this;
+    compassDiv.click(function() {
+        instance.map.getView().setRotation(0);
+    });
+
+    this.map.on('moveend', function (evt) {
+        var rotation = evt.map.getView().getRotation();
+        compass.css('transform', 'rotate(' + rotation + 'rad)');
+    });
+}
+
+/**
+ * Initializes a control showing coordinates under cursor
+ */
+InteractiveMap.prototype._coordsUnderCursorInit = function() {
+    if ($(window).width() < 800) {
+        console.log(
+            'CordsUnderCursor control skipped because of window width.'
+        );
+        return;
+    }
+
+    this.curPos = {};
+    this.curPos.positionDiv = $(
+        '<div class="ol-control interactiveMap_mousePosition"></div>'
+    );
+
+    this.map.addControl(
+        new ol.control.Control({ element: this.curPos.positionDiv[0] })
+    );
+
+    this.curPos.lastKnownCoords = null;
+    this.curPos.coordsFormat = CoordinatesUtil.FORMAT.DEG_MIN;
+
+    var instance = this;
+    this.map.on('pointermove', function(event) {
+        if (
+            !CoordinatesUtil.cmp(
+                instance.curPos.lastKnownCoords, event.coordinate
+            )
+        ) {
+            instance.curPos.lastKnownCoords = event.coordinate;
+            instance.curPos.positionDiv.html(
+                CoordinatesUtil.toWGS84(
+                    instance.map,
+                    instance.curPos.lastKnownCoords,
+                    instance.curPos.coordsFormat
+                )
+            );
+        }
+    });
+
+    // switch coords format on dbl-click
+    this.curPos.positionDiv.dblclick(function() {
+        switch(instance.curPos.coordsFormat) {
+            case CoordinatesUtil.FORMAT.DEG_MIN:
+                instance.curPos.coordsFormat =
+                    CoordinatesUtil.FORMAT.DEG_MIN_SEC;
+                break;
+            case CoordinatesUtil.FORMAT.DEG_MIN_SEC:
+                instance.curPos.coordsFormat = CoordinatesUtil.FORMAT.DECIMAL;
+                break;
+            case CoordinatesUtil.FORMAT.DECIMAL:
+            default:
+                instance.curPos.coordsFormat = CoordinatesUtil.FORMAT.DEG_MIN;
+                break;
+        }
+    });
+}
+
+/**
+ * Initializes a control showing info message
+ */
+InteractiveMap.prototype._infoMessageInit = function() {
+    var infoMsgId = this.id + '_infoMsg';
+
+    var msgDiv = $(
+        '<div id="' + infoMsgId
+        + '" class="ol-control interactiveMap_infoMsg"></div>'
+    );
+    var closeBtn = $('<div class="interactiveMap_infoMsgClose">✖</div>');
+    msgDiv.append(closeBtn);
+
+    this.map.addControl(
+        new ol.control.Control( { element: msgDiv[0] } )
+    );
+
+    if (this.infoMessage ) {
+        msgDiv.prepend(this.infoMessage);
+        msgDiv.show();
+    } else {
+        msgDiv.hide(0);
+    }
+
+    closeBtn.click(function() {
+        $('#' + infoMsgId).hide();
+    });
+}
+
+/**
+ * Loads markers from markersData, creates corresponding features and organizes
+ * them in section-related sources and layers.
+ * Then creates an InteractiveMapPopup instance and assignes it with the OL map.
+ */
+InteractiveMap.prototype._loadMarkers = function() {
+    this.markersBaseZIndex = 100;
+
+    if (!this.markersData || this.markersData.length == 0) {
+        return;
+    }
+
+    var frontViewFeatures = {};
+    var sources = {};
+    var currentZIndex = this.markersBaseZIndex;
+    var allExtent;
+    var renderOrderingReverse = true;
+    var instance = this;
+    Object.keys(this.markersData).forEach(function(section) {
+        var featuresArr = [];
+        var props = (
+            typeof instance.sectionsProperties !== "undefined"
+            && typeof instance.sectionsProperties[section] !== "undefined"
+            ? instance.sectionsProperties[section]:
+            undefined
+        );
+        // set zIndex according to section order if defined
+        var zIndex = currentZIndex;
+        if (props && typeof props["order"] !== "undefined") {
+            zIndex = instance.markersBaseZIndex - parseInt(props["order"]);
+        } else {
+            currentZIndex++;
+        }
+        // true (default) if section is visible
+        var visible =
+            props && typeof props["visible"] !== "undefined"
+            ? props["visible"]
+            : true;
+        Object.keys(instance.markersData[section]).forEach(function(markerType) {
+            instance.markersData[section][markerType].forEach(
+                function(markerData, id) {
+                    var feature = instance.markerMgrs[markerType].markerFactory(
+                        instance.map, markerType, id, markerData, section
+                    );
+                    if (visible) {
+                        var geom = feature.getGeometry();
+                        if (typeof geom["getCoordinates"] === "function") {
+                            var coords = geom.getCoordinates();
+                            var key = "" + coords[0] + "," + coords[1];
+                            var isFirst = (
+                                typeof frontViewFeatures[key] === "undefined"
+                            );
+                            if (
+                                !isFirst
+                                && (
+                                    renderOrderingReverse
+                                    ? frontViewFeatures[key].zIndex < zIndex
+                                    : frontViewFeatures[key].zIndex <= zIndex
+                                )
+                            ) {
+                                frontViewFeatures[key].feature.set(
+                                    "isFirst", false
+                                );
+                                isFirst = true;
+                            }
+                            if (isFirst) {
+                                feature.set("isFirst", true);
+                                frontViewFeatures[key] = {
+                                    feature: feature,
+                                    zIndex: zIndex
+                                }
+                            }
+                        }
+                    }
+                    featuresArr.push(feature);
+                }
+            );
+        });
+        sources[section] = {
+            src: new ol.source.Vector({ features: featuresArr }),
+            zIndex: zIndex,
+            visible: visible
+        }
+        if (!allExtent) {
+            allExtent = sources[section].src.getExtent();
+        } else {
+            allExtent = ol.extent.extend(
+                allExtent, sources[section].src.getExtent()
+            );
+        }
+    });
+
+    Object.keys(sources).forEach(function(section) {
+        var source = sources[section];
+        var markersLayer = new ol.layer.Vector ({
+            zIndex: source.zIndex,
+            visible: source.visible,
+            source: source.src,
+            ocLayerName: 'oc_markers_' + section,
+            renderOrder: function(f1, f2) {
+                return (
+                    renderOrderingReverse
+                    ? (
+                        (f1["ol_uid"] > f2["ol_uid"])
+                        ? -1
+                        : +(f1["ol_uid"] < f2["ol_uid"])
+                    )
+                    : (
+                        (f1["ol_uid"] < f2["ol_uid"])
+                        ? -1
+                        : +(f1["ol_uid"] > f2["ol_uid"])
+                    )
+                );
+            }
+        });
+        instance.map.addLayer(markersLayer);
+    });
+
+    // zoom map to see all markers
+    if (!this.forceMapZoom && !ol.extent.isEmpty(allExtent)) {
+        // there are markers
+        this.map.getView().fit(allExtent);
+    }
+
+    if (this.enableHighlight) {
+        // source, layer and marker for highlightning,
+        // placed at the bottom of active oc layers
+        var highlightedSource = new ol.source.Vector();
+
+        var highlightedPointMarker_ocData = {
+            id: this.id,
+            lat: 0,
+            lon: 0
+        };
+        this._highlightedPointMarker = createOCMarkerFeature(
+            "_highlighted",
+            "_highlighted" + this.id,
+            highlightedPointMarker_ocData,
+            new HighlightedMarker(this.map, highlightedPointMarker_ocData)
+        );
+        highlightedSource.addFeature(this._highlightedPointMarker);
+
+        this._highlightedLayer = new ol.layer.Vector ({
+            zIndex: Math.min(this.markersBaseZIndex, currentZIndex) - 10,
+            visible: false,
+            source: highlightedSource,
+            ocLayerName: 'oc__highlighted',
+        });
+        this.map.addLayer(this._highlightedLayer);
+    }
+
+    if (this.enablePopup) {
+        // most top, foreground source and layer, where popped up features will
+        // be temporarily placed
+        this.foregroundSource = new ol.source.Vector();
+
+        var foregroundLayer = new ol.layer.Vector ({
+            zIndex: 500,
+            visible: true,
+            source: this.foregroundSource,
+            ocLayerName: 'oc__foreground',
+        });
+
+        this.map.addLayer(foregroundLayer);
+
+        this._popup = new InteractiveMapPopup()
+        this._popup.addToMap(this);
+    }
+}
+
+/**
+ * Returns a feature identified by given parameters: markerType, feature local
+ * id (cache or log id f.ex.) and section; null is returned if not found.
+ */
+InteractiveMap.prototype._getFeature = function(markerType, localId, section) {
+    var result = null;
+    var featureId = createFeatureId(
+        markerType, localId, section ? section : "_DEFAULT_"
+    );
+
+    this.map.getLayerGroup().getLayersArray().some(function(layer) {
+        if (OcLayerServices.isOcInternalLayer(layer)) {
+            result = layer.getSource().getFeatureById(featureId);
+        }
+        return (result != null);
+    });
+
+    return result;
+}
+
+/**
+ * Reorders sections basing on given orders array, by setting z-index
+ */
+InteractiveMap.prototype.reorderSections = function(orders) {
+    var instance = this;
+    this.map.getLayerGroup().getLayersArray().forEach(function(layer) {
+        var match = /^oc_markers_(.+)/.exec(layer.get('ocLayerName'));
+        if (match != null) {
+            var section= match[1];
+            if (orders[section] !== undefined) {
+                layer.setZIndex(instance.markersBaseZIndex - orders[section]);
+            }
+        }
+    });
+    this.map.renderSync();
+}
+
+/**
+ * Toggles visibility of given section
+ */
+InteractiveMap.prototype.toggleSectionVisibility = function(section) {
+    var instance = this;
+    this.map.getLayerGroup().getLayersArray().some(function(layer) {
+        var match = /^oc_markers_(.+)/.exec(layer.get('ocLayerName'));
+        if (match != null && match[1] == section) {
+            layer.setVisible(!layer.getVisible());
+            if (typeof instance._popup !== "undefined") {
+                instance.map.once("postrender", function(evt) {
+                    instance._popup.adjustFeaturesByLayer(layer);
+                });
+            }
+            return true;
+        }
+    });
+}
+
+/**
+ * Highlights a feature identified by given parameters, if found
+ */
+InteractiveMap.prototype.highlightFeature = function(
+    markerType, localId, section
+) {
+    if (
+        this.enableHighlight
+        && typeof this._highlightedPointMarker !== "undefined"
+        && typeof this._highlightedLayer !== "undefined"
+    ) {
+        var feature = this._getFeature(markerType, localId, section);
+        if (feature) {
+            var coords = feature.getGeometry().getCoordinates();
+            if (coords) {
+                this._highlightedPointMarker.getGeometry().setCoordinates(
+                    coords
+                );
+                this._highlightedLayer.setVisible(true);
+            }
+        }
+    }
+}
+
+/**
+ * Tones down previously highlighted feature
+ */
+InteractiveMap.prototype.toneDownFeature = function() {
+    if (
+        this.enableHighlight
+        && typeof this._highlightedLayer !== "undefined"
+    ) {
+        this._highlightedLayer.setVisible(false);
+    }
+}
+
+// =================================================================
+
+/**
+ * An InteractiveMapPopup prototype
+ */
+function InteractiveMapPopup() {
+    this.popup = new ol.Overlay({
+        element: $('<div class="interactiveMap_popup"></div>')[0],
+        positioning: 'bottom-center',
+        stopEvent: true,
+        insertFirst: false,
+        offset: [0, -50],
+        autoPan: true,
+        autoPanAnimation: {
+            duration: 250
+        },
+        offsetYAdjusted: false,
+    });
+    this.features = [];
+    this.featureIndex = -1;
+    this.offsetYAdjusted = false;
+}
+
+/**
+ * Assigns this popup instance to given InteractiveMap instance, setting 'click'
+ * event handler.
+ */
+InteractiveMapPopup.prototype.addToMap = function(interactiveMap) {
+    this.interactiveMap = interactiveMap
+    this.interactiveMap.map.addOverlay(this.popup);
+    var instance = this;
+    this.interactiveMap.map.on('click', function(evt) {
+        instance._mapClickEvent(evt);
+    });
+}
+
+/**
+ * Should be called after any oc layer visibility change to adjust current
+ * features available in popup to the changed visibility. A layer where
+ * visibility has been changed is passed as a parameter.
+ */
+InteractiveMapPopup.prototype.adjustFeaturesByLayer = function(layer) {
+    var s = layer.getSource();
+    if (s && this.features.length > 0) {
+        var instance = this;
+        var oldFeatureSource = this.currentFeatureSource;
+        instance._clearFeature();
+        instance.interactiveMap.map.once("postrender", function(evt) {
+            var features = instance._getMapFeatures(
+                instance.interactiveMap.map.getPixelFromCoordinate(
+                    instance.popup.getPosition()
+                )
+            ).filter(function(feature) {
+                return (
+                    feature.getId()
+                    && (
+                        layer.getVisible()
+                        || !s.getFeatureById(feature.getId())
+                    )
+                );
+            });
+            if (!layer.getVisible() && s === oldFeatureSource) {
+                // currently displayed pop feature is hidden in layer,
+                // so reset index
+                instance.featureIndex = -1;
+            } else {
+                // currently displayed pop feature is still visible,
+                // so determine its index in new array of features
+                var currentFeature = instance.features[instance.featureIndex];
+                features.some(function(feature, index) {
+                    if (feature == currentFeature) {
+                        // set new index before desired feature,
+                        // to be correctly used in _switchPopupContent
+                        instance.featureIndex = index -1;
+                        return true;
+                    }
+                });
+            }
+            instance.features = features;
+            if (instance.features.length > 0) {
+                instance._switchPopupContent(true);
+            } else {
+                instance.popup.setPosition(undefined);
+            }
+        });
+    };
+}
+
+/**
+ * Returns map features being under given pixel, with exclusion of foreground
+ * (popup) layer.
+ */
+InteractiveMapPopup.prototype._getMapFeatures = function(pixel) {
+    var result = [];
+
+    var fC;
+    var instance = this;
+    this.interactiveMap.map.forEachFeatureAtPixel(pixel, function(feature) {
+        if (
+            feature.getId()
+            && (feature.get('ocData')) != undefined
+            && !instance.interactiveMap.foregroundSource.getFeatureById(
+                feature.getId()
+            )
+        ) {
+            var canAdd = true;
+            if (fC == undefined) {
+                // save the first feature coordinates
+                fC = feature.getGeometry().getCoordinates();
+            } else {
+                // add another features only if coordinates match the first one
+                var nFC = feature.getGeometry().getCoordinates();
+                canAdd = (
+                    (nFC[0] == fC[0]) && (nFC[1] == fC[1])
+                    || feature.getGeometry().intersectsCoordinate(fC)
+                );
+            }
+            if (canAdd) {
+                result.push(feature);
+            }
+        }
+    });
+
+    return result;
+}
+
+/**
+ * Clears from popup currently selected feature, movin it from the foreground
+ * source to its original one.
+ */
+InteractiveMapPopup.prototype._clearFeature = function(feature) {
+    if (feature === undefined && this.featureIndex >= 0) {
+        feature = this.features[this.featureIndex];
+    }
+    if (feature !== undefined && this.currentFeatureSource !== undefined) {
+        this.interactiveMap.foregroundSource.removeFeature(feature);
+        feature.set("isFirst", false);
+        this.currentFeatureSource.addFeature(feature);
+        this.currentFeatureSource = undefined;
+    }
+}
+
+/**
+ * Should be called on popup hide or just before possible show, to clear all
+ * variables and states related to previously displayed popup.
+ */
+InteractiveMapPopup.prototype._onHide = function() {
+    this._clearFeature();
+    this.featureIndex = -1;
+    this.features = [];
+    this.offsetYAdjusted = false;
+}
+
+/**
+ * An event handler to be assigned to OL map 'click' event.
+ * Checks all features being under clicked pixel and selects them if coordinates
+ * match the first one selected.
+ * If an array of selected features is not empty, the popup is shown.
+ */
+InteractiveMapPopup.prototype._mapClickEvent = function(evt) {
+    this._onHide();
+
+    var features = this._getMapFeatures(evt.pixel);
+    if (features.length > 0) {
+        this.features = features;
+        this._switchPopupContent(true);
+    } else {
+        this.popup.setPosition(undefined);
+    }
+}
+
+/**
+ * Computes popup offset Y to place it in a right place above current
+ * popup features. The computing result is based if applicable on 'popupOffsetY'
+ * attribute of features' markers, which are consecutively computed if missing.
+ */
+InteractiveMapPopup.prototype._computePopupOffsetY = function() {
+    var result;
+
+    this.features.forEach(function(feature) {
+        var ocData = feature.get("ocData");
+
+        var ocMarker = feature.get('ocMarker');
+        if (
+            ocMarker != undefined
+            && typeof(ocMarker['currentStyle']) != "undefined"
+        ) {
+            if (typeof(ocMarker.currentStyle['popupOffsetY']) === "undefined") {
+                ocMarker.computePopupOffsetY();
+            }
+            if (typeof(ocMarker.currentStyle['popupOffsetY']) !== "undefined") {
+                if (
+                    result == undefined
+                    || result > ocMarker.currentStyle.popupOffsetY
+                ) {
+                    result = ocMarker.currentStyle.popupOffsetY;
+                }
+            }
+        } else {
+            var im;
+            var s = feature.getStyle();
+            if (typeof(s["getImage"]) == "function") {
+                im = s.getImage();
+            }
+            if (im && im instanceof ol.style.Icon) {
+                var anc = im.getAnchor();
+                var offset = -(anc[1] * im.getScale()) - 2;
+                if (result == undefined || result > offset) {
+                    result = offset;
+                }
+            }
+        }
+    });
+
+    return result;
+}
+
+/**
+ * Selects the next or previous feature from features being under a popup point
+ * when the map was clicked. The selection depends on a 'forward' parameter.
+ * If there is no feature previously selected, the first one is chosen. Next,
+ * the content and position of popup is set according to the selected feature
+ * values.
+ */
+InteractiveMapPopup.prototype._switchPopupContent = function(forward) {
+    var oldFeature;
+    var i = this.featureIndex;
+    if (i >= 0) {
+        oldFeature = this.features[i];
+        // (+/-1) modulo features.length, negative value workaround
+        i = (
+                ((forward ? (i + 1) : (i - 1)) % this.features.length)
+                + this.features.length
+            ) % this.features.length;
+    } else if (i < 0) {
+        i = 0;
+    }
+
+    var feature = this.features[i];
+    var ocData = feature.get("ocData");
+
+    if (!this.offsetYAdjusted) {
+        var popupOffsetY = this._computePopupOffsetY();
+        if (popupOffsetY) {
+            this.popup.setOffset([0, popupOffsetY]);
+        }
+        this.offsetYAdjusted = true;
+    }
+
+    // move currect feature to the foreground layer, replacing the previous
+    // one
+    var featureId = feature.getId();
+    if (featureId) {
+        var instance = this;
+        this.interactiveMap.map.getLayerGroup().getLayersArray().some(
+            function(layer) {
+                if (/^oc_[^_].*/.test( layer.get('ocLayerName') )) {
+                    var s = layer.getSource();
+                    if (s.getFeatureById(featureId) === feature) {
+                        if (oldFeature != undefined) {
+                            instance._clearFeature(oldFeature);
+                        }
+                        s.removeFeature(feature);
+                        feature.set("isFirst", true);
+                        instance.interactiveMap.foregroundSource.addFeature(
+                            feature
+                        );
+                        instance.currentFeatureSource = s;
+                        return true;
+                    }
+                }
+            }
+        );
+    }
+
+    var markerSection = ocData.markerSection;
+    var markerType = ocData.markerType;
+    var markerId = ocData.markerId;
+
+    if (!this.interactiveMap.compiledPopupTpls[markerType]) {
+        var popupTpl =
+            $('script[type="text/x-handlebars-template"].' + markerType).html();
+        this.interactiveMap.compiledPopupTpls[markerType] =
+            Handlebars.compile(popupTpl);
+    }
+
+    var markerContext =
+        this.interactiveMap.markersData[markerSection][markerType][markerId];
+    if (
+        typeof this.interactiveMap.sectionsNames !== "undefined"
+        && typeof this.interactiveMap.sectionsNames[markerSection]
+            !== "undefined"
+    ) {
+        markerContext['sectionName'] =
+            this.interactiveMap.sectionsNames[markerSection];
+    }
+    if (this.features.length > 1) {
+        markerContext['showNavi'] = true;
+    } else {
+        markerContext['showNavi'] = undefined;
+    }
+    $(this.popup.getElement()).html(
+        this.interactiveMap.compiledPopupTpls[markerType](markerContext)
+    );
+
+    var instance = this;
+    $(".imp-closer").click(function(evt) {
+        instance._onHide();
+        instance.popup.setPosition(undefined);
+    });
+
+    if (this.features.length > 1) {
+        $(".imp-navi .imp-backward > img").click(function(evt) {
+            instance._switchPopupContent(false);
+        });
+        $(".imp-navi .imp-forward > img").click(function(evt) {
+            instance._switchPopupContent(true);
+        });
+    }
+
+    this.featureIndex = i;
+    this.popup.setPosition(feature.getGeometry().getCoordinates());
+}
+
+// =================================================================
+// Utils and helper objects
+// =================================================================
+
+/* this is util used fo coords formatting */
+var CoordinatesUtil = {
+    FORMAT: Object.freeze({
+        DECIMAL: 1,     /* decimal degrees: N 40.446321° W 79.982321° */
+        DEG_MIN: 2,     /* degrees decimal minutes: N 40° 26.767′ W 79° 58.933′ */
+        DEG_MIN_SEC: 3, /* degrees minutes seconds: N 40° 26′ 46″ W 79° 58′ 56″ */
+    }),
+
+    cmp: function(coordsA, coordsB) {
+        return (
+            Array.isArray(coordsA) &&
+            Array.isArray(coordsB) &&
+            coordsA[0] == coordsB[0] &&
+            coordsA[1] == coordsB[1]
+        );
+    },
+
+    toWGS84: function (map, coords, outFormat) {
+        if (outFormat == undefined) {
+            // set default output format
+            outFormat = this.FORMAT.DEG_MIN;
+        }
+
+        // convert coords from map coords to WGS84
+        mapCoordsCode = map.getView().getProjection().getCode();
+        wgs84Coords = ol.proj.transform(coords, mapCoordsCode, 'EPSG:4326');
+        lon = wgs84Coords[0];
+        lat = wgs84Coords[1];
+
+        lonHemisfere = (lon < 0)?"W":"E";
+        latHemisfere = (lat < 0)?"S":"N";
+
+        lonParts = this.getParts(lon);
+        latParts = this.getParts(lat);
+
+        switch(outFormat) {
+            case this.FORMAT.DEG_MIN:
+                return (
+                    latHemisfere + " " + Math.floor(latParts.deg) + "° "
+                    + latParts.min.toFixed(3) + "' "
+                    + lonHemisfere + " " + Math.floor(lonParts.deg) + "° "
+                    + lonParts.min.toFixed(3) + "'"
+                );
+
+            case this.FORMAT.DECIMAL:
+                return (
+                    latHemisfere + " " + latParts.deg.toFixed(5) + "° "
+                    + lonHemisfere + " " + lonParts.deg.toFixed(5) + "°"
+                );
+
+            case this.FORMAT.DEG_MIN_SEC:
+                return (
+                    latHemisfere + " " + Math.floor(latParts.deg) + "° "
+                    + Math.floor(latParts.min) + "' "
+                    + latParts.sec.toFixed(2) + '" '
+                    + lonHemisfere + " " + Math.floor(lonParts.deg) + "° "
+                    + Math.floor(lonParts.min) + "' "
+                    + lonParts.sec.toFixed(2) + '"'
+                );
+        }
+    },
+
+    getParts: function(coordinate) {
+        var deg = Math.abs(coordinate);
+        var min = 60 * (deg - Math.floor(deg));
+        var sec = 60 * (min - Math.floor(min));
+        return {deg: deg, min: min, sec: sec};
+    },
+};
+
+/**
+ * Object used in processing geolocation on the map
+ * It allows to show current position read from GPS
+ */
+function GeolocationOnMap(map, iconSelector) {
+
+    this.map = map
+    this.positionMarkersCollection = new ol.Collection();
+    this.positionMarkersLayer = null;
+
+    this.STATUS = Object.freeze({
+      INIT:              '', /* initial state */
+      IN_PROGRESS:       'rgb(255,255,177,.5)', /* position reading in progress */
+      POSITION_ACQUIRED: 'rgb(170,255,127,.5)', /* positions has been read */
+      ERROR:             'rgb(0,255,255,.5)', /* some error occured */
+    })
+
+
+    this.getCurrentPosition = function() {
+        console.log('get position...')
+
+        if (!("geolocation" in navigator)) {
+          console.error('Geolocation not supported by browser!');
+          this.changeGeolocIconStatus(obj.STATUS.ERROR);
+          return;
+        }
+
+        this.changeGeolocIconStatus(this.STATUS.IN_PROGRESS);
+
+        navigator.geolocation.getCurrentPosition(
+                this.getSuccessCallback(),
+                this.getErrorCallback(),
+                { enableHighAccuracy: true }
+        );
+    }
+
+    // set new status and its icon
+    this.changeGeolocIconStatus = function(newStatus) {
+        $(iconSelector).css('background-color', newStatus);
+    }
+
+    this.getSuccessCallback = function() {
+
+        var obj = this;
+
+        return function(position) {
+            console.log('position read: ', position);
+
+            obj.changeGeolocIconStatus(obj.STATUS.POSITION_ACQUIRED);
+
+            lat = position.coords.latitude;
+            lon = position.coords.longitude;
+
+            currCoords = ol.proj.fromLonLat([lon, lat]);
+            accuracy = position.coords.accuracy;
+
+            view = obj.map.getView();
+            view.setCenter(currCoords);
+            view.setZoom(obj.calculateZoomForAccuracy(accuracy));
+
+            // draw position marker
+            var accuracyFeature = new ol.Feature({
+              geometry: new ol.geom.Circle(currCoords, accuracy),
+            });
+
+            accuracyFeature.setStyle([
+                new ol.style.Style({ //circle
+                    stroke: new ol.style.Stroke({
+                      color: DynamicMapServices.styler.fgColor,
+                      width: 2}),
+                }),
+                new ol.style.Style({ //center marker
+                  geometry: function(feature){
+                    return new ol.geom.Point(feature.getGeometry().getCenter());
+                  },
+                  image: new ol.style.RegularShape({
+                    stroke: new ol.style.Stroke({
+                      color: DynamicMapServices.styler.fgColor,
+                      width: 2
+                    }),
+                    points: 4,
+                    radius: 10,
+                    radius2: 0,
+                    angle: Math.PI / 4
+                  })
+                }),
+                ]
+            )
+
+            obj.positionMarkersCollection.clear();
+            obj.positionMarkersCollection.push(accuracyFeature);
+
+            if (obj.positionMarkersLayer == null) {
+              obj.positionMarkersLayer = new ol.layer.Vector({
+                map: obj.map,
+                source: new ol.source.Vector({
+                  features: obj.positionMarkersCollection,
+                }),
+              });
+            }
+        }
+    }
+
+    this.getErrorCallback = function() {
+        var obj = this;
+
+        return function(positionError) {
+            console.error('OC Map: positions reading error!', positionError);
+
+            if (positionError.code === 1) { // Permission denied
+                // User has denied geolocation - return to initial state
+                obj.changeGeolocIconStatus(obj.STATUS.INIT);
+            } else {
+                // Indicate actual problem with getting position
+                obj.changeGeolocIconStatus(obj.STATUS.ERROR);
+            }
+        }
+    }
+
+    this.calculateZoomForAccuracy = function(accuracy) {
+        // accuracy is in meters
+
+        if (accuracy <   300) return 16;
+        if (accuracy <   600) return 15;
+        if (accuracy <  1200) return 14;
+        if (accuracy <  2400) return 13;
+        if (accuracy <  5000) return 12;
+        if (accuracy < 10000) return 11;
+        return 10; // otherwise
+    }
+
+    return this;
+}
+
+var OcLayerServices = {
+
+    isOcInternalLayer: function (layer){
+      return ( /^oc_.*/.test( layer.get('ocLayerName') ));
+    },
+
+    setOcLayerName: function (layer, name){
+      layer.set('ocLayerName', name);
+    },
+
+    getOcLayerName: function(layer) {
+      return layer.get('ocLayerName');
+    }
+
+};

--- a/public/views/chunks/interactiveMap/markers/ocMarker.js
+++ b/public/views/chunks/interactiveMap/markers/ocMarker.js
@@ -1,0 +1,79 @@
+function createOCMarkerFeature(type, id, ocData, ocMarker, section) {
+    if (typeof section === "undefined") {
+        section = "_DEFAULT_";
+    }
+    var feature = new ol.Feature({
+        geometry: new ol.geom.Point(
+            ol.proj.fromLonLat([parseFloat(ocData.lon), parseFloat(ocData.lat)])
+        ),
+        ocData: {
+            markerSection: section,
+            markerType: type,
+            markerId: id
+        },
+    });
+    feature.setId(createFeatureId(type, ocData.id, section));
+    if (typeof ocMarker["getFeatureStyle"] === "function") {
+        ocMarker.feature = feature;
+        feature.set('ocMarker', ocMarker);
+        feature.setStyle(function(feature, resolution) {
+            return ocMarker.getFeatureStyle(resolution)
+        });
+    }
+    return feature;
+}
+
+/**
+ * Creates id for feature, basing on given parameters
+ */
+function createFeatureId(markerType, localId, section) {
+    if (typeof section === "undefined") {
+        section = "_DEFAULT_";
+    }
+    return section + '_' + markerType + '_' + localId;
+}
+
+/**
+ * A most top marker prototype. It is not advisable to instatiate it directly,
+ * rather instatiate one of derived subclasses
+ */
+function OCMarker(map, ocData) {
+    this.map = map;
+    this.ocData = ocData;
+    this.feature = undefined;
+    this.currentStyle = undefined;
+}
+
+/**
+ * Computes offset for possible popup placement, basing on current styles
+ */
+OCMarker.prototype.computePopupOffsetY = function() {
+    if (
+        this.currentStyle != undefined
+        && typeof(this.currentStyle["style"]) !== "undefined"
+    ) {
+        if (typeof(this.currentStyle.style["length"]) !== "undefined") {
+            var self = this;
+            this.currentStyle.style.forEach(function(s) {
+                var im  = s.getImage();
+                if (im && im instanceof ol.style.Icon) {
+                    var anchor = im.getAnchor();
+                    var scale = im.getScale();
+                    var cOfsY = -(anchor[1] * scale)
+                    if (
+                        typeof(self.currentStyle["popupOffsetY"]) === "undefined"
+                        || self.currentStyle.popupOffsetY > cOfsY
+                    ) {
+                        self.currentStyle.popupOffsetY = cOfsY;
+                    }
+                }
+            });
+        } else if (typeof(this.currentStyle.style["getImage"]) == "function") {
+            var im  = this.currentStyle.style.getImage();
+            if (im && im instanceof ol.style.Icon) {
+                var anchor = im.getAnchor();
+                this.currentStyle.popupOffsetY = -(anchor[1] * im.getScale());
+            }
+        }
+    }
+}

--- a/public/views/chunks/interactiveMap/markers/simple/cacheMarker.js
+++ b/public/views/chunks/interactiveMap/markers/simple/cacheMarker.js
@@ -1,0 +1,31 @@
+/**
+ * Marker for displaying a cache
+ */
+function CacheMarker(map, ocData) {
+    OCMarker.call(this, map, ocData);
+}
+
+CacheMarker.prototype = Object.create(OCMarker.prototype);
+
+CacheMarker.prototype.constructor = CacheMarker;
+
+/**
+ * Creates and returns style of the marker, based on server-side set icon
+ */
+CacheMarker.prototype.getFeatureStyle = function(resolution) {
+    if (this.currentStyle == undefined) {
+        this.currentStyle = {
+            style: new ol.style.Style({
+                image: new ol.style.Icon({
+                    anchor: [0.5, 0.5],
+                    anchorXUnits: 'fraction',
+                    anchorYUnits: 'fraction',
+                    src: this.ocData.icon,
+                    scale: 0.6,
+                })
+            }),
+            popupOffsetY: undefined
+        };
+    }
+    return this.currentStyle.style;
+}

--- a/public/views/chunks/interactiveMap/markers/simple/highlightedMarker.js
+++ b/public/views/chunks/interactiveMap/markers/simple/highlightedMarker.js
@@ -1,0 +1,32 @@
+/**
+ * Marker for displaying highlight for another feature
+ */
+function HighlightedMarker(map, ocData) {
+    OCMarker.call(this, map, ocData);
+}
+
+HighlightedMarker.prototype = Object.create(OCMarker.prototype);
+
+HighlightedMarker.prototype.constructor = HighlightedMarker;
+
+/**
+ * Creates and returns style of the marker: a green square
+ */
+HighlightedMarker.prototype.getFeatureStyle = function(resolution) {
+    if (this.currentStyle == undefined) {
+        this.currentStyle = {
+            style: new ol.style.Style({
+                image: new ol.style.RegularShape({
+                    stroke: new ol.style.Stroke({
+                        color: 'green',
+                        width: 2
+                    }),
+                    points: 4,
+                    radius: 15,
+                    angle: Math.PI / 4
+                })
+            })
+        };
+    }
+    return this.currentStyle.style;
+}

--- a/public/views/chunks/interactiveMap/markers/simple/logMarker.js
+++ b/public/views/chunks/interactiveMap/markers/simple/logMarker.js
@@ -1,0 +1,31 @@
+/**
+ * Marker for displaying a log of a cache
+ */
+function LogMarker(map, ocData) {
+    OCMarker.call(this, map, ocData);
+}
+
+LogMarker.prototype = Object.create(OCMarker.prototype);
+
+LogMarker.prototype.constructor = LogMarker;
+
+/**
+ * Creates and returns style of the marker, based on server-side set log icon
+ */
+LogMarker.prototype.getFeatureStyle = function(resolution) {
+    if (this.currentStyle == undefined) {
+        this.currentStyle = {
+            style: new ol.style.Style({
+                image: new ol.style.Icon({
+                    anchor: [0.5, 0.5],
+                    anchorXUnits: 'fraction',
+                    anchorYUnits: 'fraction',
+                    src: this.ocData.logIcon,
+                    scale: 1,
+                })
+            }),
+            popupOffsetY: undefined
+        };
+    }
+    return this.currentStyle.style;
+}

--- a/public/views/myNbhInteractive/common.css
+++ b/public/views/myNbhInteractive/common.css
@@ -1,0 +1,166 @@
+@charset "UTF-8";
+
+.content2-container {
+	font-size: 12px;
+}
+
+.nbh-pageheader {
+	color: rgb(88, 144, 168);
+	font-weight: bold;
+	font-size: 1.3em;
+}
+
+.nbh-nodisplay {
+	display: none;
+}
+
+.nbh-nowrap {
+	white-space: nowrap;
+}
+
+fieldset {
+	border: 1px solid #d3d3d3 !important;
+	border-radius: 3px !important;
+	padding: 10px 30px;
+	min-width: 40%;
+	display: inline-box;
+}
+
+legend {
+	font-size: 14px;
+}
+
+.ui-icon-background {
+	background-color: #fff !important;
+}
+
+#nbh-custom-handle {
+	width: 3em;
+	height: 1.6em;
+	top: 50%;
+	margin-top: -.8em;
+	margin-left: -1.6em;
+	text-align: center;
+	line-height: 1.6em;
+}
+
+.nbh-map {
+	height: 400px;
+	width: 100%;
+}
+
+.nbh-usermap {
+	height: 350px;
+	padding: 5px;
+	border: 1px solid #ccc;
+	border-radius: 3px;
+}
+
+#nbh-startdraw-btn {
+	display: inline-block;
+}
+
+#nbh-coords-line {
+	display: none;
+}
+#nbh-delete-dialog-icon {
+	float: left;
+	margin: 12px 12px 20px 0;
+}
+
+.nbh-block {
+	display: inline-block;
+	vertical-align: top;
+}
+
+.nbh-half {
+	width: 49%;
+}
+
+.nbh-full {
+	width: 99%;
+}
+
+.nbh-line-container>a, .nbh-desc-container>a, .lightTipped>a {
+	text-decoration: none;
+}
+
+.lightTip {
+	margin: 0px 10px 0px 60px !important;
+}
+
+.nbh-block-placeholder {
+	border: 1px dotted #ccc;
+	border-radius: 3px;
+	margin: 10px 1em 1em 0;
+	height: 30px;
+	width: 49%;
+	display: inline-block;
+	vertical-align: top;
+	background-color: rgb(156, 186, 214);
+}
+
+.nbh-block-header {
+	background-color: #f9fcfc;
+	padding: 5px;
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	color: rgb(88, 144, 168);
+	font-weight: bold;
+	font-size: 1.2em;
+	margin: 10px 0px 0px 0px;
+	cursor: move;
+}
+
+.nbh-back-btn {
+	display: inline !important;
+	font-weight: normal;
+}
+.nbh-sm-buttons,
+.nbh-md-buttons {
+	float: right;
+}
+
+.nbh-line-container {
+	padding: 2px;
+	width: 99%;
+}
+
+.nbh-desc-container {
+	padding: 5px;
+	display: table-cell;
+	vertical-align: middle;
+	line-height: 1.5em;
+	vertical-align: middle;
+}
+
+.nbh-image-container {
+	display: table-cell;
+	vertical-align: middle;
+	padding: 5px;
+}
+
+.nbh-arrow-north {
+	width: 10px;
+}
+
+.nbh-eye {
+	background-image: url("/images/misc/eye-uni.svg");
+	width: 16px;
+	height: 13px;
+	display: inline-block;
+	background-repeat: no-repeat;
+	background-size: 14px 13px;
+	vertical-aling: middle;
+	margin-bottom: -3px;
+}
+
+.nbh-top-config-btns {
+	background-color: #df4e49;
+	padding: 3px 10px;
+	border-radius: 3px;
+	margin-bottom: 5px;
+}
+.nbh-button-right {
+	float: right;
+}

--- a/public/views/myNbhInteractive/config.js
+++ b/public/views/myNbhInteractive/config.js
@@ -1,0 +1,50 @@
+// Slider to choose MyNbh caches item
+$(function() {
+	var handle = $("#nbh-custom-handle");
+	$("#nbh-slider").slider({
+		value : cachesCount,
+		min : minCaches,
+		max : maxCaches,
+		create : function() {
+			handle.text($(this).slider("value"));
+		},
+		slide : function(event, ui) {
+			handle.text(ui.value);
+			$("#input-caches").val(ui.value);
+		}
+	});
+});
+
+// Buttons to choose MyNbh style
+$(function() {
+	$(".nbh-radio").checkboxradio();
+	$("fieldset").controlgroup();
+});
+
+// Delete Nbh button
+$("#nbh-delete-btn").click(function(e) {
+	e.preventDefault();
+	$("#nbh-delete-dialog-confirm").dialog("open");
+});
+
+// Delete Nbh - confirm dialog
+$(function() {
+	$("#nbh-delete-dialog-confirm").dialog({
+		autoOpen : false,
+		resizable : false,
+		modal : true,
+		hide : 250,
+		closeText : cancelButton,
+		buttons : [ {
+			text : deleteButton,
+			click : function() {
+				window.location = deleteLink;
+			},
+		}, {
+			text : cancelButton,
+			click : function() {
+				$(this).dialog("close");
+			}
+		} ]
+	});
+});

--- a/public/views/myNbhInteractive/config_draw.js
+++ b/public/views/myNbhInteractive/config_draw.js
@@ -1,0 +1,307 @@
+class ConfigDraw {
+
+    constructor(map, minRadius, maxRadius) {
+        if (map == null || ! map instanceof ol.Map) {
+            throw "Invalid map parameter";
+        }
+
+        this.map = map;
+        this.minRadius = minRadius;
+        this.maxRadius = maxRadius;
+
+        this.configDrawCommonStyles = {
+            'Circle': [
+                new ol.style.Style({
+                    fill: new ol.style.Fill({
+                        color: [255, 255, 0, 0.35]
+                    }),
+                    stroke: new ol.style.Stroke({
+                        color: [0, 0, 0, 0.8],
+                        width: 1
+                    }),
+                }),
+            ]
+        };
+        this.configDrawCommonStyles['GeometryCollection'] =
+            this.configDrawCommonStyles['Circle'].concat(
+                new ol.style.Style({
+                    image: new ol.style.Circle({
+                        radius: 5,
+                        fill: new ol.style.Fill({
+                            color: [255, 255, 255, 1]
+                        }),
+                        stroke: new ol.style.Stroke({
+                            color: [0, 0, 0, 1],
+                            width: 1
+                        }),
+                    }),
+                })
+            );
+
+        this.configDrawModifyStyles = Object.assign(
+            {}, this.configDrawCommonStyles
+        );
+        this.configDrawModifyStyles['Point'] = [
+            new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: 4,
+                    fill: new ol.style.Fill({
+                        color: [255, 255, 255, 1]
+                    }),
+                    stroke: new ol.style.Stroke({
+                        color: [0, 0, 0, 1],
+                        width: 1
+                    }),
+                }),
+            }),
+        ];
+
+        const instance = this;
+        this.configSource = new ol.source.Vector();
+        this.configLayer = new ol.layer.Vector({
+            source: this.configSource,
+            zIndex: 1000,
+            style: function(feature, resolution) {
+                return instance.configDrawModifyStyles[
+                    feature.getGeometry().getType()
+                ];
+            },
+        });
+        this.configLayer.set('ocLayerName', 'oc_mynbh_config');
+
+        this.modify = new ol.interaction.Modify({
+            source: this.configSource,
+            style: function(feature, resolution) {
+                return instance.configDrawModifyStyles[
+                    feature.getGeometry().getType()
+                ];
+            },
+        });
+
+        this.snap = new ol.interaction.Snap({
+            source: this.configSource
+        });
+
+        this.hooks = {};
+    }
+
+    setHooks(hooks) {
+        if (hooks != null && typeof(hooks) === "object") {
+            this.hooks = hooks;
+        }
+    }
+
+    addHook(name, hook) {
+        this.hooks[name] = hook;
+    }
+
+    init(initLatLon, initRadius) {
+        this.map.addLayer(this.configLayer);
+        this.map.addInteraction(this.snap);
+
+        if (initLatLon && initRadius) {
+            let currentGeometry = this._configGeometry(
+                this._computeShapePoints(initLatLon, initRadius)
+            );
+            this.configSource.addFeature(new ol.Feature({
+                geometry: currentGeometry,
+                style: this.configDrawCommonStyles['GeometryCollection']
+            }));
+            this.map.getView().fit(currentGeometry.getExtent());
+            this._startModifications();
+        } else {
+            const instance = this;
+            this.draw = new ol.interaction.Draw({
+                type: 'Circle',
+                source: this.configSource,
+                stopClick: true,
+                style: function(feature, resolution) {
+                    return instance.configDrawCommonStyles[
+                        feature.getGeometry().getType()
+                    ];
+                },
+                freehand: true,
+                geometryFunction: this._configGeometry
+            });
+
+            this.draw.on("drawend", function(ev) {
+                return instance._drawComplete(ev.feature);
+            });
+        }
+    }
+
+    startDrawing() {
+        if (this.draw) {
+            this.map.addInteraction(this.draw);
+        }
+    }
+
+    _configGeometry(coordinates, geometry) {
+        let center = coordinates[0];
+        let last = coordinates[1];
+        let dx = center[0] - last[0];
+        let dy = center[1] - last[1];
+        let radius = Math.sqrt(dx * dx + dy * dy);
+        if (!geometry) {
+            geometry = new ol.geom.GeometryCollection();
+        }
+        geometry.setGeometries([
+            new ol.geom.Point(center),
+            new ol.geom.Circle(center, radius)
+        ]);
+        return geometry;
+    }
+
+    _drawComplete(feature) {
+        feature.setStyle(this.configDrawCommonStyles['GeometryCollection']);
+        this._applyRestrictions(feature);
+        this._callUpdateConfigHook(feature);
+        this.map.removeInteraction(this.draw);
+        this._startModifications();
+    }
+
+    _callUpdateConfigHook(feature, newCoords, newRadius) {
+        if (typeof(this.hooks["updateConfig"]) === "function") {
+            if (!newCoords || !newRadius) {
+                [ newCoords, newRadius ] =
+                    this._computeNewConfigParams(feature);
+            }
+            this.hooks["updateConfig"](newCoords[0], newCoords[1], newRadius);
+        }
+    }
+
+    _getConfigShapes(feature, onlyCircle = false) {
+        let circle, point;
+        feature.getGeometry().getGeometries().forEach(function(g) {
+            if (g.getType() == 'Circle') {
+                circle = g;
+            } else if (!onlyCircle && g.getType() == 'Point') {
+                point = g;
+            }
+        });
+        return onlyCircle ? circle : [ circle, point ];
+    }
+
+    _applyRestrictions(feature) {
+        let circle = this._getConfigShapes(feature, true);
+        let radius = this._radiusToKm(circle);
+        let adjust = false;
+        if (radius > this.maxRadius) {
+            radius = this.maxRadius;
+            adjust = true;
+        } else if (radius < this.minRadius) {
+            radius = this.minRadius;
+            adjust = true;
+        }
+        if (adjust) {
+            feature.setGeometry(this._configGeometry(
+                this._computeShapePoints(circle.getCenter(), radius, false)
+            ));
+        }
+    }
+
+    _startModifications() {
+        this.map.addInteraction(this.modify);
+        const instance = this;
+        this.map.on('pointermove', function(ev) {
+            return instance._pointerMoveOnModify(ev);
+        });
+        this.modify.on('modifyend', function(ev) {
+            if (ev.features.getLength() > 0) {
+                let feature = ev.features.item(0);
+                instance._applyRestrictions(feature);
+                instance._callUpdateConfigHook(feature);
+            }
+        });
+    }
+
+    _pointerMoveOnModify(ev) {
+        const classNames = [
+            'dynamicMap_cursorResize', 'dynamicMap_cursorMove'
+        ];
+        let c = ev.coordinate;
+        let mf = this.map.getView().getResolution() * 10;
+
+        let ft = this.configSource.getFeatures();
+        if (ft.length) {
+            let [circle, point] = this._getConfigShapes(ft[0]);
+            let className, dist;
+            if (circle) {
+                let radius = circle.getRadius();
+                dist = this._computeDist(circle.getCenter(), c);
+                if (dist >= (radius - mf) && dist <= (radius + mf)) {
+                    className = classNames[0];
+                }
+            }
+            if (!className && point) {
+                if (!dist) {
+                    dist = this._computeDist(point.getCoordinates(), c);
+                }
+                if (dist <= mf) {
+                    className = classNames[1];
+                }
+            }
+            let classAdded = false;
+            let currentClasses = this.map.getTargetElement().classList;
+            classNames.forEach(function(cn) {
+                if (!className || className != cn) {
+                    currentClasses.remove(cn);
+                } else {
+                    classAdded = (className && currentClasses.contains(cn));
+                }
+            });
+            if (className && !classAdded) {
+                currentClasses.add(className);
+            }
+        }
+    }
+
+    _computeNewConfigParams(feature) {
+        let circle = this._getConfigShapes(feature, true);
+        let newCoords = this._toLatLon(circle.getCenter());
+        let newRadius = this._radiusToKm(circle);
+        return [ newCoords, newRadius ];
+    }
+
+    _computeDist(startCoords, finalCoords) {
+        let dx = startCoords[0] - finalCoords[0];
+        let dy = startCoords[1] - finalCoords[1];
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    _computeShapePoints(centerCoords, radiusInKm, coordsAreLatLon = true) {
+        let centerLatLon =
+            coordsAreLatLon ? centerCoords : this._toLatLon(centerCoords);
+        let centerPoint =
+            coordsAreLatLon ? this._fromLatLon(centerCoords) : centerCoords;
+        let factor = 1/Math.cos(centerLatLon[0] * Math.PI / 180);
+        let radiusPoint = ol.extent.getTopRight(
+            (new ol.geom.Circle(
+                centerPoint, radiusInKm * 1000 * factor
+            )).getExtent()
+        );
+        radiusPoint[1] = centerPoint[1];
+        return [ centerPoint, radiusPoint ];
+    }
+
+    _radiusToKm(circle) {
+        let centerLatLon = this._toLatLon(circle.getCenter());
+        let factor = 1/Math.cos(centerLatLon[0] * Math.PI / 180);
+        return Math.round( ( circle.getRadius() / factor ) / 1000 );
+    }
+
+    _fromLatLon(latlonPoint) {
+        return ol.proj.transform(
+            (latlonPoint.constructor === Array)
+            ? [ latlonPoint[1], latlonPoint[0] ]
+            : [ latlonPoint.lon, latlonPoint.lat ],
+            "EPSG:4326",
+            "EPSG:3857"
+        );
+    }
+
+    _toLatLon(xyPoint) {
+        let lonlat = ol.proj.transform(xyPoint, "EPSG:3857", "EPSG:4326");
+        return [ lonlat[1], lonlat[0] ];
+    }
+}

--- a/public/views/myNbhInteractive/myNeighbourhood-full.css
+++ b/public/views/myNbhInteractive/myNeighbourhood-full.css
@@ -1,0 +1,13 @@
+@charset "UTF-8";
+
+.nbh-icon {
+	height: 32px;
+}
+
+.nbh-line-container:hover, tr:hover {
+	background-color: #f5f5f5;
+}
+
+.nbh-min-only {
+	display: none;
+}

--- a/public/views/myNbhInteractive/myNeighbourhood-min.css
+++ b/public/views/myNbhInteractive/myNeighbourhood-min.css
@@ -1,0 +1,13 @@
+@charset "UTF-8";
+
+.nbh-icon {
+	height: 16px;
+}
+
+.nbh-line-container:nth-child(odd), tr:nth-child(odd) {
+	background-color: #f5f5f5;
+}
+
+.nbh-full-only {
+	display: none;
+}

--- a/public/views/myNbhInteractive/myNeighbourhood.js
+++ b/public/views/myNbhInteractive/myNeighbourhood.js
@@ -1,0 +1,83 @@
+$(".nbh-sort-list").sortable({
+    handle : ".nbh-block-header",
+    opacity : 0.7,
+    placeholder : "nbh-block-placeholder",
+    update : function(event, ui) {
+        let postData = $(this).sortable("serialize");
+
+        if (InteractiveMapServices.getInteractiveMap("nbhmap")) {
+            // get current order of sections
+            var orders = {};
+            var n = 0;
+            $(this).sortable("toArray").forEach(function(v) {
+                orders[v.replace('item_', '')] = n++;
+            });
+            // reorder map sections to move the highest section features to front
+            InteractiveMapServices.reorderSections("nbhmap", orders);
+        }
+
+        $.ajax({
+            url : changeOrderUri,
+            type : "post",
+            data : {
+                order : postData
+            }
+        });
+    }
+});
+
+$(".nbh-hide-toggle").on("click", function() {
+    let icon = $(this);
+    icon.closest(".nbh-block").find(".nbh-block-content").toggleClass(
+        'nbh-nodisplay');
+    let hidden = icon.closest(".nbh-block").find(".nbh-block-content")
+        .hasClass("nbh-nodisplay");
+    let itemId = icon.closest(".nbh-block").attr('id');
+    let section = icon.closest(".nbh-block").attr('section');
+    $.ajax({
+        url : changeDisplayAjaxUri,
+        type : "post",
+        data : {
+            hide : hidden,
+            item : itemId
+        }
+    })
+    if (InteractiveMapServices.getInteractiveMap("nbhmap")) {
+        if (this.id == "nbh-map-hide") {
+            InteractiveMapServices.getMapObject("nbhmap").updateSize();
+        } else {
+            InteractiveMapServices.toggleSectionVisibility("nbhmap", section);
+        }
+    }
+});
+
+$(".nbh-size-toggle").on("click", function() {
+	let icon = $(this);
+	icon.closest(".nbh-block").toggleClass("nbh-half nbh-full");
+	let sizeClass = icon.closest(".nbh-block").hasClass("nbh-full");
+	let itemId = icon.closest(".nbh-block").attr('id');
+	$.ajax({
+		url : changeSizeAjaxUri,
+		type : "post",
+		data : {
+			size : sizeClass,
+			item : itemId
+		}
+	});
+	if (this.id == "nbh-map-resize") {
+        var map = InteractiveMapServices.getMapObject("nbhmap");
+        if (map) {
+            map.updateSize();
+        }
+	}
+});
+
+$("div[id^='mynbh_item_'").mouseenter(function() {
+    var id = this.id.substring("mynbh_item_".length);
+    var parts = id.split('_');
+    InteractiveMapServices.highlightFeature("nbhmap", parts[1], parts[2], parts[0]);
+});
+
+$("div[id^='mynbh_item_'").mouseleave(function() {
+    InteractiveMapServices.toneDownFeature("nbhmap");
+});

--- a/src/Controllers/MyNbhInteractiveController.php
+++ b/src/Controllers/MyNbhInteractiveController.php
@@ -1,0 +1,744 @@
+<?php
+namespace src\Controllers;
+
+use src\Utils\Uri\SimpleRouter;
+use src\Utils\Uri\Uri;
+use src\Models\ChunkModels\PaginationModel;
+use src\Models\ChunkModels\InteractiveMap\CacheMarkerModel;
+use src\Models\ChunkModels\InteractiveMap\InteractiveMapModel;
+use src\Models\ChunkModels\InteractiveMap\LogMarkerModel;
+use src\Models\Coordinates\Coordinates;
+use src\Models\Neighbourhood\MyNbhSets;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Models\User\UserPreferences\UserPreferences;
+use src\Utils\Text\UserInputFilter;
+use src\Models\User\UserPreferences\NeighbourhoodPref;
+
+class MyNbhInteractiveController extends BaseController
+{
+    // an URL path to public resources
+    const PUBLIC_SRC_PATH = '/views/myNbhInteractive/';
+
+    // a path to templates
+    const TEMPLATES_PATH = 'myNbhInteractive/';
+
+    // If true, only OC Team Members, Adv Users and Sys Admins has access here
+    const VALIDATION_MODE = true;
+
+    // Minimum MyNeighbourhood radius (in km)
+    const NBH_RADIUS_MIN = 1;
+
+    // Maximum MyNeighbourhood radius (in km)
+    const NBH_RADIUS_MAX = 150;
+
+    // Minimum caches/log per page
+    const CACHES_PER_PAGE_MIN = 2;
+
+    // Minimum caches/log per page
+    const CACHES_PER_PAGE_MAX = 10;
+
+    // Maximum additional Neighbourhoods user can have
+    const MAX_NEIGHBOURHOODS = 5;
+
+    // Caches/Logs per page (on details pages)
+    const ITEMS_PER_DETAIL_PAGE = 25;
+
+    /** @var string */
+    private $infoMsg = null;
+
+    /** @var string */
+    private $errorMsg = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    private function accessControl()
+    {
+        if (
+            !$this->isUserLogged()
+            || self::VALIDATION_MODE && !(
+                $this->loggedUser->hasOcTeamRole()
+                || $this->loggedUser->hasAdvUserRole()
+                || $this->loggedUser->hasSysAdminRole()
+            )
+        ) {
+            $this->view->redirect(
+                Uri::setOrReplaceParamValue('target', Uri::getCurrentUri(), '/'));
+            exit();
+        }
+    }
+
+    /**
+     * Displays main MyNeighbourhood page
+     *
+     * @param int $nbhSeq - MyNbh number (seq). 0 = default user's Nbh
+     */
+    public function index($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        $neighbourhoodsList =
+            Neighbourhood::getNeighbourhoodsList($this->loggedUser);
+        if (empty($neighbourhoodsList)) {
+            // User doesn't have any MyNeighbourhoods set, so redirect to config
+            $this->view->redirect(
+                SimpleRouter::getLink(self::class, 'config')
+            );
+            exit();
+        }
+        $selectedNbh = (int) $nbhSeq;
+        if (! array_key_exists($selectedNbh, $neighbourhoodsList)) {
+            // Selected MyNeighbourhood not found
+            if ($selectedNbh == 0) {
+                // User has no Home Coords -> redirect to config
+                $this->view->redirect(
+                    SimpleRouter::getLink(self::class, 'config')
+                );
+            } else {
+                // Redirect to default MyNeighbourhood
+                $this->view->redirect(
+                    SimpleRouter::getLink(self::class, 'index', 0)
+                );
+            }
+            exit();
+        }
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+        $nbhItemSet = new MyNbhSets(
+            $neighbourhoodsList[$selectedNbh]->getCoords(),
+            $neighbourhoodsList[$selectedNbh]->getRadius()
+        );
+        $latestCaches = $nbhItemSet->getLatestCaches(
+            $preferences['style']['caches-count'], 0, false
+        );
+        $upcomingEvents = $nbhItemSet->getUpcomingEvents(
+            $preferences['style']['caches-count'], 0
+        );
+        $ftfCaches = $nbhItemSet->getLatestCaches(
+            $preferences['style']['caches-count'], 0, true
+        );
+        $latestLogs = $nbhItemSet->getLatestLogs(
+            $preferences['style']['caches-count'], 0
+        );
+        $topRatedCaches = $nbhItemSet->getTopRatedCaches(
+            $preferences['style']['caches-count'], 0
+        );
+        $latestTitled = $nbhItemSet->getLatestTitledCaches(
+            $preferences['style']['caches-count'], 0
+        );
+        $this->view->setVar('latestCaches', $latestCaches);
+        $this->view->setVar('upcomingEvents', $upcomingEvents);
+        $this->view->setVar('FTFCaches', $ftfCaches);
+        $this->view->setVar('latestLogs', $latestLogs);
+        $this->view->setVar('topRatedCaches', $topRatedCaches);
+        $this->view->setVar('latestTitled', $latestTitled);
+        $this->view->setVar('neighbourhoodsList', $neighbourhoodsList);
+        $this->view->setVar('selectedNbh', $selectedNbh);
+        $this->view->setVar('preferences', $preferences);
+        $this->view->setVar('user', $this->loggedUser);
+
+        $this->view->addHeaderChunk('openLayers5');
+
+        $mapModel = new InteractiveMapModel();
+        foreach ($preferences['items'] as $sectionName => $sectionConfig) {
+            $sectionCaches = null;
+            switch ($sectionName) {
+                case Neighbourhood::ITEM_LATESTCACHES:
+                    $sectionCaches = $latestCaches;
+                    break;
+                case Neighbourhood::ITEM_UPCOMINGEVENTS:
+                    $sectionCaches = $upcomingEvents;
+                    break;
+                case Neighbourhood::ITEM_FTFCACHES:
+                    $sectionCaches = $ftfCaches;
+                    break;
+                case Neighbourhood::ITEM_TITLEDCACHES:
+                    $sectionCaches = $latestTitled;
+                    break;
+                case Neighbourhood::ITEM_RECOMMENDEDCACHES:
+                    $sectionCaches = $topRatedCaches;
+                    break;
+                default:
+                    break;
+            }
+            if ($sectionCaches) {
+                $mapModel->addMarkersWithExtractor(
+                    CacheMarkerModel::class,
+                    $sectionCaches,
+                    function($row) use ($sectionName) {
+                        $marker = CacheMarkerModel::fromGeocacheFactory(
+                            $row, $this->loggedUser
+                        );
+                        $marker->section = $sectionName;
+                        return $marker;
+                    }
+                );
+            }
+            $mapModel->setSectionProperties($sectionName, [
+                "visible" => $sectionConfig['show'],
+                "order" => $sectionConfig['order'],
+            ]);
+        }
+
+        $mapModel->addMarkersWithExtractor(
+            LogMarkerModel::class,
+            $latestLogs,
+            function($row) {
+                $marker = LogMarkerModel::fromGeoCacheLogFactory(
+                    $row, $this->loggedUser
+                );
+                $marker->section = Neighbourhood::ITEM_LATESTLOGS;
+                return $marker;
+            }
+        );
+
+        $mapModel->setSectionsKeys(Neighbourhood::SECTIONS);
+
+        $this->view->setVar('mapModel', $mapModel);
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'myNeighbourhood',
+            true, [ 'myNeighbourhood.js' ] , true
+        );
+        $this->view->setVar('controller', self::class);
+        $this->view->setVar('templatesPath', self::TEMPLATES_PATH);
+        $this->view->setVar('publicSrcPath', self::PUBLIC_SRC_PATH);
+        $this->view->buildView();
+    }
+
+    private function setPublicResourcesAndTemplate(
+        $preferences, $template,
+        $addStyled = true, $javascripts = [], $loadJQueryUI = false
+    ) {
+        $this->view->addLocalCss(
+            Uri::getLinkWithModificationTime(
+                self::PUBLIC_SRC_PATH . 'common.css'
+            )
+        );
+        if ($addStyled) {
+            $this->view->addLocalCss(
+                Uri::getLinkWithModificationTime(
+                    self::PUBLIC_SRC_PATH . 'myNeighbourhood-'
+                    . $preferences['style']['name'] . '.css'
+                )
+            );
+        }
+        $this->view->addLocalCss(
+            Uri::getLinkWithModificationTime('/css/lightTooltip.css')
+        );
+        if (!empty($javascripts)) {
+            if (!is_array($javascripts)) {
+                $javascripts = [ $javascripts ];
+            }
+            foreach ($javascripts as $js) {
+                $this->view->addLocalJs(
+                    Uri::getLinkWithModificationTime(
+                        self::PUBLIC_SRC_PATH . $js
+                    ),
+                    true,
+                    true
+                );
+            }
+        }
+        if ($loadJQueryUI) {
+            $this->view->loadJQueryUI();
+        }
+        $this->view->setVar('controller', self::class);
+        $this->view->setTemplate(self::TEMPLATES_PATH . $template);
+    }
+
+    private function getSectionRequestCommons($nbhSeq = 0)
+    {
+        $this->redirectNotLoggedUsers();
+        $selectedNbh = (int) $nbhSeq;
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+        $neighbourhoodsList =
+            Neighbourhood::getNeighbourhoodsList($this->loggedUser);
+        if (! array_key_exists($selectedNbh, $neighbourhoodsList)) {
+            // Selected MyNeighbourhood not found
+            $this->view->redirect(
+                SimpleRouter::getLink(self::class, 'index')
+            );
+            exit();
+        }
+        $coords = $neighbourhoodsList[$selectedNbh]->getCoords();
+        $nbhItemSet = new MyNbhSets(
+            $coords,
+            $neighbourhoodsList[$selectedNbh]->getRadius()
+        );
+        $paginationModel = new PaginationModel(self::ITEMS_PER_DETAIL_PAGE);
+        return [
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ];
+    }
+
+    private function setSectionCommonVars(
+        $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+    ) {
+        $this->view->setVar('neighbourhoodsList', $neighbourhoodsList);
+        $this->view->setVar('paginationModel', $paginationModel);
+        $this->view->setVar('selectedNbh', $selectedNbh);
+        $this->view->setVar('user', $this->loggedUser);
+        $this->view->setVar('coords', $coords);
+    }
+
+    /**
+     * Displays latest caches detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function latestCaches($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount(
+            $nbhItemSet->getLatestCachesCount(false)
+        );
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar(
+            'caches', $nbhItemSet->getLatestCaches($limit, $offset, false)
+        );
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_LatestCaches'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays most recommended caches detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function mostRecommended($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount(
+            $nbhItemSet->getTopRatedCachesCount()
+        );
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar(
+            'caches', $nbhItemSet->getTopRatedCaches($limit, $offset)
+        );
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_RecommendedCaches'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays FTF caches detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function ftfCaches($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount(
+            $nbhItemSet->getLatestCachesCount(true)
+        );
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar(
+            'caches', $nbhItemSet->getLatestCaches($limit, $offset, true)
+        );
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_FTFCaches'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays titled caches detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function titledCaches($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount(
+            $nbhItemSet->getLatestTitledCachesCount()
+        );
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar(
+            'caches', $nbhItemSet->getLatestTitledCaches($limit, $offset)
+        );
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_TitledCaches'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays upcomming events detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function upcommingEvents($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $nbhItemSet, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount(
+            $nbhItemSet->getUpcomingEventsCount()
+        );
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar(
+            'caches', $nbhItemSet->getUpcomingEvents($limit, $offset)
+        );
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_UpcommingEvents'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays latest logs detailed page for Nbh selected as $nbhSeq
+     *
+     * @param int $nbhSeq
+     */
+    public function latestLogs($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        list (
+            $selectedNbh, $preferences, $neighbourhoodsList,
+            $coords, $logset, $paginationModel
+        ) = $this->getSectionRequestCommons($nbhSeq);
+
+        $paginationModel->setRecordsCount($logset->getLatestLogsCount());
+        list ($limit, $offset) = $paginationModel->getQueryLimitAndOffset();
+        $this->view->setVar('logs', $logset->getLatestLogs($limit, $offset));
+        $this->setSectionCommonVars(
+            $neighbourhoodsList, $paginationModel, $selectedNbh, $coords
+        );
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'detail_LatestLogs'
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Displays MyNeighbour config
+     *
+     * @param number $nbhSeq - number of MyNbh (seq). 0 = default user's Nbh
+     */
+    public function config($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        $selectedNbh = (int) $nbhSeq;
+
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+
+        $neighbourhoodsList =
+            Neighbourhood::getNeighbourhoodsList($this->loggedUser);
+        if (
+            $selectedNbh != - 1
+            && ! array_key_exists($selectedNbh, $neighbourhoodsList)
+        ) {
+            $selectedNbh = 0;
+        }
+        if (array_key_exists($selectedNbh, $neighbourhoodsList)) {
+            $this->view->setVar('coordsOK', 1);
+        } else {
+            $this->view->setVar('coordsOK', 0);
+        }
+        $this->view->setVar('neighbourhoodsList', $neighbourhoodsList);
+        $this->view->setVar('selectedNbh', $selectedNbh);
+        $this->view->setVar('preferences', $preferences);
+        $this->view->setVar('maxnbh', self::MAX_NEIGHBOURHOODS);
+        $this->view->setVar('minCaches', self::CACHES_PER_PAGE_MIN);
+        $this->view->setVar('maxCaches', self::CACHES_PER_PAGE_MAX);
+        $this->view->setVar('minRadius', self::NBH_RADIUS_MIN);
+        $this->view->setVar('maxRadius', self::NBH_RADIUS_MAX);
+        $this->view->setVar('errorMsg', $this->errorMsg);
+        $this->view->setVar('infoMsg', $this->infoMsg);
+
+        $this->view->addHeaderChunk('openLayers5');
+
+        $mapModel = new InteractiveMapModel();
+        $mapModel->setZoom(6);
+        $this->view->setVar('mapModel', $mapModel);
+        $this->setPublicResourcesAndTemplate(
+            $preferences, 'config',
+            false, [ 'config.js', 'config_draw.js' ], true
+        );
+        $this->view->buildView();
+    }
+
+    /**
+     * Saves new/modified MyNbh. Called by MyNbh config form
+     *
+     * @param number $nbhSeq - number of MyNbh (seq). 0 = default user's Nbh
+     */
+    public function save($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        $error = null;
+        $seq = null;
+        $definedNbh = count(
+            Neighbourhood::getAdditionalNeighbourhoodsList($this->loggedUser)
+        );
+        // Store MyNeighbourhood data
+        if (
+            isset($_POST['lon'])
+            && isset($_POST['lat'])
+            && isset($_POST['radius'])
+        ) {
+            $coords = Coordinates::FromCoordsFactory(
+                $_POST['lat'], $_POST['lon']
+            );
+            $radius = (int) $_POST['radius'];
+            if ($radius > self::NBH_RADIUS_MAX) {
+                $radius = self::NBH_RADIUS_MAX;
+            } elseif ($radius < self::NBH_RADIUS_MIN) {
+                $radius = self::NBH_RADIUS_MIN;
+            }
+            if ($coords !== null) {
+                if ($nbhSeq == 0) {
+                    // Update Home Coords and radius
+                    if (
+                        ! $this->loggedUser->updateUserNeighbourhood(
+                            $coords, $_POST['radius']
+                        )
+                    ) {
+                        // Error during save MyNbh (should never happen, but...)
+                        $error = tr('myn_save_error');
+                    }
+                } elseif (
+                    isset($_POST['name'])
+                    && ($nbhSeq > 0 || $definedNbh < self::MAX_NEIGHBOURHOODS)
+                ) {
+                    // Save additional neighbourhood
+                    $seq = ($nbhSeq < 0) ? null : $nbhSeq;
+                    $name = trim($_POST['name']);
+                    $name = UserInputFilter::purifyHtmlString($name);
+                    $name = strip_tags($name);
+                    $name = mb_strcut($name, 0, 16);
+                    if (mb_strlen($name) < 1) {
+                        // Name too short
+                        $name = 'X';
+                    }
+                    if (
+                        ! Neighbourhood::storeUserNeighbourhood(
+                            $this->loggedUser, $coords, $radius, $name, $seq
+                        )
+                    ) {
+                        // Error during save additional MyNbh
+                        // (should never happen, but...)
+                        $error = tr('myn_save_error');
+                    }
+                } else {
+                    // Incorrect $_POST - without name or user exceeded
+                    // max total nbh's
+                    $error = tr('myn_coords_error');
+                }
+            } else { // Coords are not OK
+                $error = tr('myn_coords_error');
+            }
+        } else { // User not choose coords | radius
+            $error = tr('myn_coords_error');
+        }
+        // Store user preferences
+        if (
+            $nbhSeq == 0
+            && isset($_POST['caches-perpage'])
+            && isset($_POST['style'])
+            && ($_POST['style'] == 'full' || $_POST['style'] == 'min')
+        ) {
+            $cachesPerpage = (int) $_POST['caches-perpage'];
+            if ($cachesPerpage > self::CACHES_PER_PAGE_MAX) {
+                $cachesPerpage = self::CACHES_PER_PAGE_MAX;
+            } elseif ($cachesPerpage < self::CACHES_PER_PAGE_MIN) {
+                $cachesPerpage = self::CACHES_PER_PAGE_MIN;
+            }
+            $preferences =
+                UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+            $preferences['style']['name'] = $_POST['style'];
+            $preferences['style']['caches-count'] = $cachesPerpage;
+            if (
+                ! UserPreferences::savePreferencesJson(
+                    NeighbourhoodPref::KEY, json_encode($preferences)
+                )
+            ) {
+                // Error during storing user preferences
+                $error = tr('myn_save_error');
+            }
+        }
+        if (is_null($error)) {
+            $this->infoMsg = tr('myn_save_success');
+        } else {
+            $this->errorMsg = $error;
+        }
+        $this->config($seq == null ? 0 : $seq);
+    }
+
+    /**
+     * Deletes My Nbh - called by form in config
+     *
+     * @param number $nbhSeq - MyNbh number (seq). 0 = default user's Nbh
+     */
+    public function delete($nbhSeq = 0)
+    {
+        $this->accessControl();
+
+        $success = true;
+        if ($nbhSeq > 0) { // User cannot delete HomeCoords!
+            if (
+                ! Neighbourhood::removeUserNeighbourhood(
+                    $this->loggedUser, $nbhSeq
+                )
+            ) {
+                $success = false;
+            }
+        } else {
+            // User try to delete Home Coords
+            $success = false;
+        }
+        if ($success) {
+            $this->infoMsg = tr('myn_delete_success');
+        } else {
+            $this->errorMsg = tr('myn_delete_error');
+        }
+        $this->config(0);
+        exit();
+    }
+
+    /**
+     * Saves changed order of MyNbh sections. Called via Ajax by MyNbh main page
+     */
+    public function changeOrderAjax()
+    {
+        $this->checkUserLoggedAjax();
+        $this->paramAjaxCheck('order');
+        $order = [];
+        parse_str($_POST['order'], $order);
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+        $counter = 1;
+        foreach ($order['item'] as $itemOrder) {
+            $preferences['items'][$itemOrder]['order'] = $counter;
+            $counter += 1;
+        }
+        if (
+            ! UserPreferences::savePreferencesJson(
+                NeighbourhoodPref::KEY, json_encode($preferences)
+            )
+        ) {
+            $this->ajaxErrorResponse('Error saving UserPreferences');
+        }
+        $this->ajaxSuccessResponse();
+    }
+
+    /**
+     * Saves changed size of MyNbh section. Called via Ajax by MyNbh main page
+     */
+    public function changeSizeAjax()
+    {
+        $this->checkUserLoggedAjax();
+        $this->paramAjaxCheck('size');
+        $this->paramAjaxCheck('item');
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+        $itemNr = ltrim($_POST['item'], 'item_');
+        $preferences['items'][$itemNr]['fullsize'] = filter_var(
+            $_POST['size'], FILTER_VALIDATE_BOOLEAN
+        );
+        if (
+            ! UserPreferences::savePreferencesJson(
+                NeighbourhoodPref::KEY, json_encode($preferences)
+            )
+        ) {
+            $this->ajaxErrorResponse('Error saving UserPreferences');
+        }
+        $this->ajaxSuccessResponse();
+    }
+
+    /**
+     * Saves display status of MyNbh section. Called via Ajax by MyNbh main page
+     */
+    public function changeDisplayAjax()
+    {
+        $this->checkUserLoggedAjax();
+        $this->paramAjaxCheck('hide');
+        $this->paramAjaxCheck('item');
+        $preferences =
+            UserPreferences::getUserPrefsByKey(NeighbourhoodPref::KEY)->getValues();
+        $itemNr = ltrim($_POST['item'], 'item_');
+        $preferences['items'][$itemNr]['show'] = ! filter_var(
+            $_POST['hide'], FILTER_VALIDATE_BOOLEAN
+        );
+        if (
+            ! UserPreferences::savePreferencesJson(
+                NeighbourhoodPref::KEY, json_encode($preferences)
+            )
+        ) {
+            $this->ajaxErrorResponse('Error saving UserPreferences');
+        }
+        $this->ajaxSuccessResponse();
+    }
+
+    public function isCallableFromRouter($actionName)
+    {
+        return true;
+    }
+
+    /**
+     * Check if $_POST[$paramName] is set. If not - generates 400 AJAX response
+     *
+     * @param string $paramName
+     */
+    private function paramAjaxCheck($paramName)
+    {
+        if (! isset($_POST[$paramName])) {
+            $this->ajaxErrorResponse('No parameter: ' . $paramName, 400);
+            exit();
+        }
+    }
+}

--- a/src/Models/ChunkModels/InteractiveMap/AbstractMarkerModelBase.php
+++ b/src/Models/ChunkModels/InteractiveMap/AbstractMarkerModelBase.php
@@ -1,0 +1,42 @@
+<?php
+namespace src\Models\ChunkModels\InteractiveMap;
+
+use \ReflectionClass;
+
+/**
+ * This is a base class for all interactive map markers.
+ */
+abstract class AbstractMarkerModelBase
+{
+    public $id;             // id of marker
+    public $lat;            // lat. of marker
+    public $lon;            // lon. of marker
+    public $icon;           // icon of marker
+    public $section;        // [optional] section the marker belongs to
+
+    public function getMarkerTypeName()
+    {
+        $str = (new ReflectionClass(static::class))->getShortName();
+        return preg_replace('/Model$/', '', lcfirst($str));
+    }
+
+    public function getMarkerJsData()
+    {
+        return json_encode($this, JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * Check if all necessary data is set in this marker class
+     * @return boolean
+     */
+    public function checkMarkerData()
+    {
+        return true
+        && isset($this->id)
+        && isset($this->lat)
+        && isset($this->lon)
+        && isset($this->icon)
+        ;
+    }
+
+}

--- a/src/Models/ChunkModels/InteractiveMap/CacheMarkerModel.php
+++ b/src/Models/ChunkModels/InteractiveMap/CacheMarkerModel.php
@@ -1,0 +1,129 @@
+<?php
+namespace src\Models\ChunkModels\InteractiveMap;
+
+use src\Models\GeoCache\GeoCache;
+use src\Models\GeoCache\GeoCacheLogCommons;
+use src\Models\User\User;
+use src\Utils\Text\Formatter;
+
+/**
+ * This is model of geocache marker
+ */
+
+class CacheMarkerModel extends AbstractMarkerModelBase
+{
+    // id/lat/lon/icon inherited from parent!
+
+    public $wp;
+    public $link;
+    public $name;
+    public $username;
+    public $userProfile;
+
+    public $isEvent;
+    public $eventStartDate;
+    public $size;
+    public $rating;
+    public $ratingId;
+    public $founds;
+    public $notFounds;
+    public $ratingVotes;
+    public $recommendations;
+    public $titledDesc;
+    public $isStandingOut;
+    public $powerTrailName;
+    public $powerTrailIcon;
+    public $powerTrailUrl;
+
+    public $cacheType;
+    public $cacheStatus;
+    public $logStatus;
+    public $isOwner;
+
+    /**
+     * Creates marker model from Geocache model
+     * @param GeoCache $c
+     * @param User $user
+     * @return CacheMarkerModel
+     */
+    public static function fromGeocacheFactory(GeoCache $c, User $user=null)
+    {
+        $marker = new self();
+        $marker->importDataFromGeoCache( $c, $user);
+        return $marker;
+    }
+
+    protected function importDataFromGeoCache(GeoCache $c, User $user=null)
+    {
+        // Abstract-Marker data
+        $this->id = $c->getCacheId();
+        $this->icon = $c->getCacheIcon($user);
+        $this->lat = $c->getCoordinates()->getLatitude();
+        $this->lon = $c->getCoordinates()->getLongitude();
+
+        $this->wp = $c->getGeocacheWaypointId();
+        $this->link = $c->getCacheUrl();
+        $this->name = $c->getCacheName();
+        $this->username = $c->getOwner()->getUserName();
+        $this->userProfile = $c->getOwner()->getProfileUrl();
+
+        $this->isEvent= $c->isEvent();
+        if ($this->isEvent) {
+            $this->eventStartDate = Formatter::date($c->getDatePlaced());
+        }
+        $this->size = tr($c->getSizeTranslationKey());
+        $this->ratingVotes = $c->getRatingVotes();
+        $this->rating = (
+            $this->ratingVotes < 3
+            ? tr('not_available')
+            : $c->getRatingDesc()
+        );
+        $this->ratingId = $c->getRatingId();
+        $this->founds = $c->getFounds();
+        $this->notFounds = $c->getNotFounds();
+        $this->recommendations = $c->getRecommendations();
+        $this->isTitled = $c->isTitled();
+        if ($c->isTitled() ) {
+            global $titled_cache_period_prefix; //TODO: move it to the ocConfig
+            $this->titledDesc = tr($titled_cache_period_prefix.'_titled_cache');
+        }
+        $this->isStandingOut = ($this->titledDesc || $this->recommendations);
+        if ($c->isPowerTrailPart()) {
+            $this->powerTrailName = $c->getPowerTrail()->getName();
+            $this->powerTrailIcon = $c->getPowerTrail()->getFootIcon();
+            $this->powerTrailUrl = $c->getPowerTrail()->getPowerTrailUrl();
+        }
+
+        $this->cacheType = $c->getCacheType();
+        $this->cacheStatus = $c->getStatus();
+        $this->logStatus = $c->getLogStatus($user);
+        $this->isOwner =
+            ($user != null && $user->getUserId() == $c->getOwner()->getUserId());
+    }
+
+    /**
+     * Check if all necessary data is set in this marker class
+     * @return boolean
+     */
+    public function checkMarkerData()
+    {
+        return parent::checkMarkerData()
+        && isset($this->wp)
+        && isset($this->link)
+        && isset($this->name)
+        && isset($this->username)
+        && isset($this->userProfile)
+        && isset($this->isEvent)
+        && isset($this->size)
+        && isset($this->founds)
+        && isset($this->notFounds)
+        && isset($this->ratingVotes)
+        && isset($this->ratingId)
+        && isset($this->recommendations)
+        && isset($this->cacheType)
+        && isset($this->cacheStatus)
+        && isset($this->isOwner)
+        ;
+    }
+
+}

--- a/src/Models/ChunkModels/InteractiveMap/InteractiveMapModel.php
+++ b/src/Models/ChunkModels/InteractiveMap/InteractiveMapModel.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace src\Models\ChunkModels\InteractiveMap;
+
+use src\Models\Coordinates\Coordinates;
+use src\Models\OcConfig\OcConfig;
+use src\Utils\Debug\Debug;
+
+/**
+ * This is model of an interactive map
+ * This class contains data which describes the map
+ */
+class InteractiveMapModel
+{
+    // Default section name if none is used explicitly. Please be careful not to
+    // use this value for real meaningful section naming
+    const DEFAULT_SECTION = "_DEFAULT_";
+
+    private $ocConfig;
+
+    /** @var Coordinates */
+    private $coords;         // center of the map
+
+    private $swCorner;       // for initial extent
+    private $neCorner;       // for initial extent
+    private $startExtent;  // set if sw/ne corner coords are present
+
+    private $zoom;           // zoom of the map, int,
+    private $forceZoom;      // force given zoom even if some markers will be hidden
+    private $mapLayerName;   // name of the default map layer
+
+    private $infoMessage;    // short message to display at map
+
+    /**
+     * A family of marker styling used in interactive map view.
+     */
+    private $markersFamily;
+
+    /**
+     * Markers data placed within sections
+     */
+    private $markerModels = [];
+
+    /**
+     * Additional properties of sections, convinient for external use
+     */
+    private $sectionsProperties = [];
+
+    /**
+     * An array of (section key => translation key) for sections used in
+     * markerModels
+     */
+    private $sectionsKeys = [];
+
+    public function __construct()
+    {
+
+        $this->ocConfig = OcConfig::instance();
+
+        $this->coords = OcConfig::getMapDefaultCenter();
+
+        $this->zoom = OcConfig::getStartPageMapZoom();
+        $this->forceZoom = false;
+        $this->startExtent = false;
+        $this->mapLayerName = 'OSM';
+    }
+
+    /**
+     * Add markers of one type
+     *
+     * @param string $markerClass - class returned by Extractor by 'CacheSetMarkerModel::class'
+     * @param array $dataRows - rows of data - every row describes one marker
+     * @param callable $rowExtractor - function which can create marekrClass based on given row
+     */
+    public function addMarkersWithExtractor(
+        $markerClass, array $dataRows, callable $rowExtractor
+    ) {
+        foreach ($dataRows as $row) {
+
+            $markerModel = call_user_func($rowExtractor, $row);
+
+            if (!($markerModel instanceof $markerClass)) {
+                Debug::errorLog(
+                    "Extractor returns something different than $markerClass"
+                );
+                return;
+            }
+
+            if (!is_subclass_of($markerModel, AbstractMarkerModelBase::class)) {
+                Debug::errorLog(
+                    "Marker class $markerClass is not a child of "
+                    . AbstractMarkerModelBase::class
+                );
+                return;
+            }
+
+            $this->addMarker($markerModel);
+        } // foreach
+    }
+
+    /**
+     * Add one marker to internal base of markers
+     *
+     * @param AbstractMarkerModelBase $model
+     */
+    public function addMarker(AbstractMarkerModelBase $model)
+    {
+        $type = $model->getMarkerTypeName();
+
+        if (!$model->checkMarkerData()) {
+            $type = $model->getMarkerTypeName();
+            Debug::errorLog("Marker of $type has incomplete data!");
+        }
+        $section = (
+            isset($model->section) ? $model->section : self::DEFAULT_SECTION
+        );
+        if (!isset($this->markerModels[$section][$type])) {
+            $this->markerModels[$section][$type] = [];
+        }
+        $this->markerModels[$section][$type][] = $model;
+    }
+
+    /**
+     * Read OC map config from config and return map config JS
+     */
+    public static function getMapLayersJsConfig(){
+        return OcConfig::getMapJsConfig();
+    }
+
+    public function getMarkersDataJson(){
+        return json_encode($this->markerModels, JSON_PRETTY_PRINT);
+    }
+
+    public function getMarkerSections(){
+        return array_keys($this->markerModels);
+    }
+
+    public function getMarkerTypes($section = null) {
+        $result = [];
+        if ($section != null) {
+            $result =
+                isset($this->markerModels[$section])
+                ? array_keys($this->markerModels[$section])
+                : [];
+        } else {
+            foreach($this->markerModels as $s) {
+                foreach($s as $markerType => $markers) {
+                    if (!in_array($markerType, $result)) {
+                        $result[] = $markerType;
+                    }
+                }
+            }
+            /*
+            // an alternative way but seems to be too complicated:
+            array_walk($this->markerModels, function($v) use (&$result) {
+                $result = array_merge($result, array_keys($v));
+            });
+            $result = array_values(array_unique($result));
+            */
+        }
+        return $result;
+    }
+
+    /**
+     * @return Coordinates
+     */
+    public function getCoords(){
+        return $this->coords;
+    }
+
+    public function getZoom(){
+        return $this->zoom;
+    }
+
+    public function isZoomForced()
+    {
+        return $this->forceZoom;
+    }
+
+    public function getSelectedLayerName(){
+        return $this->mapLayerName;
+    }
+
+    public function setZoom($zoom)
+    {
+        $this->zoom = $zoom;
+        $this->forceZoom = true;
+    }
+
+    public function setInitLayerName($name){
+        $this->mapLayerName = $name;
+    }
+
+    public function forceDefaultZoom()
+    {
+        $this->forceZoom = true;
+    }
+
+    public function setCoords(Coordinates $cords)
+    {
+        $this->coords = $cords;
+    }
+
+    public function setStartExtent(Coordinates $swCorner, Coordinates $neCorner)
+    {
+        $this->swCorner = $swCorner;
+        $this->neCorner = $neCorner;
+        $this->startExtent = true;
+    }
+
+    public function getStartExtentJson()
+    {
+        if($this->startExtent){
+            $sw = $this->swCorner->getAsOpenLayersFormat();
+            $ne = $this->neCorner->getAsOpenLayersFormat();
+            return "{ sw:$sw, ne:$ne }";
+        }else{
+            return "null";
+        }
+    }
+
+    public function setInfoMessage($msg)
+    {
+        $this->infoMessage = $msg;
+    }
+
+    public function getInfoMessage()
+    {
+        return $this->infoMessage;
+    }
+
+    /**
+     * Since it is pre-configured, only a getter is available now
+     */
+    public function getMarkersFamily()
+    {
+        return OcConfig::getMapMarkersFamily();
+    }
+
+    public function setSectionProperties($section, $properties)
+    {
+        $this->sectionsProperties[$section] = $properties;
+    }
+
+    public function getSectionsPropertiesJson()
+    {
+        return json_encode($this->sectionsProperties, JSON_PRETTY_PRINT);
+    }
+
+    public function setSectionsKeys($sectionsKeys)
+    {
+        $this->sectionsKeys = $sectionsKeys;
+    }
+
+    public function getSectionsKeys()
+    {
+        return $this->sectionsKeys;
+    }
+}

--- a/src/Models/ChunkModels/InteractiveMap/LogMarkerModel.php
+++ b/src/Models/ChunkModels/InteractiveMap/LogMarkerModel.php
@@ -1,0 +1,71 @@
+<?php
+namespace src\Models\ChunkModels\InteractiveMap;
+
+use src\Models\GeoCache\GeoCacheLog;
+use src\Models\User\User;
+use src\Utils\Text\Formatter;
+
+/**
+ * This is map marker which has log information in infowindow
+ * Cache properties are inherited from CacheMarkerModel
+ */
+class LogMarkerModel extends CacheMarkerModel
+{
+    public $logLink = null; // if there is no link there is no log :)
+    public $logText;
+    public $logIcon;
+    public $logType;
+    public $logTypeName;
+    public $logUserName;
+    public $logDate;
+
+    public static function fromGeoCacheLogFactory(
+        GeoCacheLog $log, User $user = null
+    ) {
+        $marker = new self();
+        $marker->importDataFromGeoCacheLog($log, $user);
+        return $marker;
+    }
+
+    protected function importDataFromGeoCacheLog(
+        GeoCacheLog $log, User $user = null
+    ) {
+        parent::importDataFromGeoCache($log->getGeoCache(), $user);
+
+        $this->id = $log->getId();
+        $this->logLink = $log->getLogUrl();
+        $text = strip_tags($log->getText(),'<br><p>');
+        $textLen = mb_strlen($text);
+        if ($textLen > 200) {
+            $text = mb_strcut($text, 0, 200);
+            // do not leave open tags on truncate
+            $text = preg_replace('/\<[^\>]*$/', '', $text);
+            $text .= '...';
+        }
+        $this->logText = $text;
+        $this->logIcon = $log->getLogIcon();
+        $this->logType = $log->getType();
+        $this->logTypeName = tr(
+            GeoCacheLog::typeTranslationKey($log->getType())
+        );
+        $this->logUserName = $log->getUser()->getUserName();
+        $this->logDate = Formatter::date($log->getDateCreated());
+    }
+
+    /**
+     * Check if all necessary data is set in this marker class
+     * @return boolean
+     */
+    public function checkMarkerData()
+    {
+        return parent::checkMarkerData()
+        && isset($this->logLink)
+        && isset($this->logText)
+        && isset($this->logIcon)
+        && isset($this->logType)
+        && isset($this->logTypeName)
+        && isset($this->logUserName)
+        && isset($this->logDate)
+        ;
+    }
+}

--- a/src/Models/GeoCache/GeoCache.php
+++ b/src/Models/GeoCache/GeoCache.php
@@ -704,6 +704,41 @@ class GeoCache extends GeoCacheCommons
         return tr(self::CacheRatingTranslationKey($this->ratingId));
     }
 
+    /**
+     * Computes the cache current log status for given user, based on the user
+     * log entries.
+     *
+     * @param \lib\Objects\User\User $forUser a user to compute current log
+     *     status for, may be null
+     *
+     * @return int current log status
+     */
+    public function getLogStatus(User $forUser=null)
+    {
+        $logStatus = null;
+        if (!is_null($forUser)) {
+            $logsCount = $this->getLogsCountByType(
+                $forUser,
+                array(
+                    GeoCacheLog::LOGTYPE_FOUNDIT,
+                    GeoCacheLog::LOGTYPE_DIDNOTFIND
+                )
+            );
+            if (
+                isset($logsCount[GeoCacheLog::LOGTYPE_FOUNDIT])
+                && $logsCount[GeoCacheLog::LOGTYPE_FOUNDIT]>0
+            ) {
+                $logStatus = GeoCacheLog::LOGTYPE_FOUNDIT;
+            } else if (
+                isset($logsCount[GeoCacheLog::LOGTYPE_DIDNOTFIND])
+                && $logsCount[GeoCacheLog::LOGTYPE_DIDNOTFIND]>0
+            ) {
+                $logStatus = GeoCacheLog::LOGTYPE_DIDNOTFIND;
+            }
+        }
+        return $logStatus;
+    }
+
     public function getCacheIcon(User $forUser=null)
     {
         $logStatus = null;

--- a/src/Models/GeoCache/GeoCacheCommons.php
+++ b/src/Models/GeoCache/GeoCacheCommons.php
@@ -4,6 +4,8 @@ namespace src\Models\GeoCache;
 use src\Models\BaseObject;
 use src\Utils\Debug\Debug;
 
+use \ReflectionClass;
+
 /**
  * Common consts etc. for geocaches
  *
@@ -466,5 +468,27 @@ class GeoCacheCommons extends BaseObject {
     public static function GetCacheUrlByWp($ocWaypoint)
     {
         return '/viewcache.php?wp=' . $ocWaypoint;
+    }
+
+    /**
+     * Returns a JSON structure containing a (constant_name, constant_value)
+     * pairs for all defined geocache statuses
+     *
+     * @return string JSON structure, ready for use in javascript f.ex.
+     */
+    public static function CacheStatusListJson()
+    {
+        $result = '{';
+        $gccClass = new ReflectionClass(__CLASS__);
+        foreach ($gccClass->getConstants() as $name => $value) {
+            if (preg_match('/^STATUS\_/', $name) === 1 && is_numeric($value)) {
+                if (strlen($result) > 1) {
+                    $result .= ',';
+                }
+                $result .= '"' . $name . '":"' . $value . '"';
+            }
+        }
+        $result .= '}';
+        return $result;
     }
 }

--- a/src/Models/GeoCache/GeoCacheLogCommons.php
+++ b/src/Models/GeoCache/GeoCacheLogCommons.php
@@ -4,6 +4,8 @@ namespace src\Models\GeoCache;
 use src\Utils\Debug\Debug;
 use src\Models\BaseObject;
 
+use \ReflectionClass;
+
 /**
  * Common consts etc. for geocache log
  */
@@ -233,6 +235,28 @@ class GeoCacheLogCommons extends BaseObject
         foreach ($logTypes as $logType) {
             $result[$logType] = self::typeTranslationKey($logType);
         }
+        return $result;
+    }
+
+    /**
+     * Returns a JSON structure containing a (constant_name, constant_value)
+     * pairs for all defined log types
+     *
+     * @return string JSON structure, ready for use in javascript f.ex.
+     */
+    public static function LogTypeListJson()
+    {
+        $result = '{';
+        $gccClass = new ReflectionClass(__CLASS__);
+        foreach ($gccClass->getConstants() as $name => $value) {
+            if (preg_match('/^LOGTYPE\_/', $name) === 1 && is_numeric($value)) {
+                if (strlen($result) > 1) {
+                    $result .= ',';
+                }
+                $result .= '"' . $name . '":"' . $value . '"';
+            }
+        }
+        $result .= '}';
         return $result;
     }
 }

--- a/src/Models/Neighbourhood/Neighbourhood.php
+++ b/src/Models/Neighbourhood/Neighbourhood.php
@@ -16,6 +16,17 @@ class Neighbourhood extends BaseObject
     const ITEM_TITLEDCACHES = 6;
     const ITEM_RECOMMENDEDCACHES = 7;
 
+    // An array of Neighbourhood sections with corresponding translation keys
+    const SECTIONS = [
+        self::ITEM_MAP => 'map',
+        self::ITEM_LATESTCACHES => 'newest_caches',
+        self::ITEM_UPCOMINGEVENTS => 'incomming_events',
+        self::ITEM_FTFCACHES => 'ftf_awaiting',
+        self::ITEM_LATESTLOGS => 'latest_logs',
+        self::ITEM_TITLEDCACHES => 'startPage_latestTitledCaches',
+        self::ITEM_RECOMMENDEDCACHES => 'top_recommended'
+    ];
+
     /**
      * Id in DB
      *

--- a/src/Models/OcConfig/MapConfigTrait.php
+++ b/src/Models/OcConfig/MapConfigTrait.php
@@ -90,6 +90,12 @@ trait MapConfigTrait {
         }
         return $result;
     }
+
+    public static function getMapMarkersFamily()
+    {
+        return self::getMapVar('markersFamily');
+    }
+    
     /**
      * Returns map properties
      *

--- a/src/Views/chunks/interactiveMap/interactiveMap.tpl.php
+++ b/src/Views/chunks/interactiveMap/interactiveMap.tpl.php
@@ -1,0 +1,100 @@
+<?php
+
+use src\Utils\Uri\Uri;
+use src\Utils\View\View;
+use src\Models\ChunkModels\InteractiveMap\InteractiveMapModel;
+
+/**
+ * This chunk displays interactive map with different kinds of markers.
+ * Markers should be passed by $mapModel.
+ *
+ * OpenLayers chunk should be loaded to header by:
+ *  $this->view->addHeaderChunk('openLayers5');
+ *
+ */
+return function (InteractiveMapModel $mapModel, $canvasId)
+{
+    $publicSrcPath = '/views/chunks/interactiveMap/';
+
+    // load chunk CSS
+    View::callChunkInline('loadCssByJs',
+        Uri::getLinkWithModificationTime(
+            $publicSrcPath . 'interactiveMap.css'
+        )
+    );
+    View::callChunkInline('handlebarsJs');
+?>
+
+<script src="<?=Uri::getLinkWithModificationTime(
+    $publicSrcPath . 'interactiveMap.js')?>"></script>
+
+<!-- load markers scripts and popup templates -->
+<?php
+    // shared javascript marker libs to load
+    $markerLibs = [
+        $publicSrcPath . "markers/ocMarker.js"
+    ];
+
+    $markerLibsLoaded = false;
+    $markerTypes = array_fill_keys($mapModel->getMarkerTypes(), true);
+    $markerTypes["highlightedMarker"] = false;
+    foreach ($markerTypes as $markerType => $loadTpl) {
+        if (!$markerLibsLoaded) {
+            $markerLibsLoaded = true;
+            foreach ($markerLibs as $lib) {
+?>
+<script src="<?=Uri::getLinkWithModificationTime($lib)?>"></script>
+<?php
+            } //foreach-markerLibs
+        } //if-markerLibsLoaded
+        try {
+            $markerJs = Uri::getLinkWithModificationTime(
+                $publicSrcPath . 'markers/' . $mapModel->getMarkersFamily()
+                . '/'. $markerType . '.js'
+            );
+?>
+<script type="text/javascript" src="<?=$markerJs?>"></script>
+<?php   } catch(Exception $ex) {
+            /* ignore if a file does not exist */
+        }
+        if ($loadTpl) {
+?>
+<script type="text/x-handlebars-template" class="<?=$markerType?>" >
+            <?php include(__DIR__.'/markers/'.$markerType.'Popup.tpl.php'); ?>
+</script>
+<?php   } //if-loadTpl
+} //foreach-markerTypes ?>
+<!-- end of load markers scripts popup templates -->
+
+<script>
+$(document).ready(function() {
+    InteractiveMapServices.getInteractiveMap("<?=$canvasId?>", {
+        targetDiv: "<?=$canvasId?>",
+        centerOn: <?=$mapModel->getCoords()->getAsOpenLayersFormat()?>,
+        mapStartZoom: <?=$mapModel->getZoom()?>,
+        forceMapZoom: <?=$mapModel->isZoomForced()?'true':'false'?>,
+        startExtent: <?=$mapModel->getStartExtentJson()?>,
+        selectedLayerKey: "<?=$mapModel->getSelectedLayerName()?>",
+        infoMessage: "<?=$mapModel->getInfoMessage()?>",
+        markersData: <?=$mapModel->getMarkersDataJson()?>,
+        sectionsProperties: <?=$mapModel->getSectionsPropertiesJson()?>,
+        sectionsNames: {
+        <?php foreach($mapModel->getSectionsKeys() as $section=>$key) { ?>
+            '<?=$section?>': '<?=tr($key)?>',
+        <?php } //foreach $sectionsKeys ?>
+        },
+        markerMgrs: {
+        <?php foreach($mapModel->getMarkerTypes() as $markerType) { ?>
+            <?=$markerType?>: <?php
+                include(__DIR__ . '/markers/' .$markerType .'Mgr.tpl.php');
+            ?>,
+        <?php } //foreach $markerTypes ?>
+        },
+        markersFamily: "<?=$mapModel->getMarkersFamily() ?>",
+    }).init();
+});
+</script>
+
+<?php
+};
+//end of chunk - nothing should be after this line

--- a/src/Views/chunks/interactiveMap/markers/cacheMarkerMgr.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/cacheMarkerMgr.tpl.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This is JS object containing functions used to handle markers
+ * - markerFactory - creates marker based on data row
+ * - infoWindowFactory - creates inforWindow based on row data
+ * - data - data rows of this type
+ *
+ * All functions are used from within dynamic map chunk.
+ */
+
+?>
+{
+    markerFactory: function(map, type, id, ocData, section){
+        return createOCMarkerFeature(
+            type, id, ocData, new CacheMarker(map, ocData), section
+        );
+    },
+
+}

--- a/src/Views/chunks/interactiveMap/markers/cacheMarkerPopup.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/cacheMarkerPopup.tpl.php
@@ -1,0 +1,101 @@
+<?php //This is handlebars-js template - see https://handlebarsjs.com/ for format details ?>
+
+<div class="imp-cache">
+    {{#if sectionName}}
+    <div class="imp-table ipm-section">
+        <div class="imp-row">
+            <div class="imp-cell ipm-section">{{sectionName}}</div>
+        </div>
+    </div>
+    {{/if}}
+    <div class="imp-table">
+        <div class="imp-row">
+            <div class="imp-cell imp-icon">
+                <img src="{{icon}}" alt="{{wp}}" title="{{wp}}">
+            </div>
+            <div class="imp-cell">
+                <a href="{{link}}" class="links" target="_blank">
+                    <div class="imp-wp">{{wp}}</div>
+                    {{name}}
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="imp-table imp-details">
+        <div class="imp-row">
+            <div class="imp-cell">
+                {{#if isEvent}}
+                <span class="imp-label"><?=tr("beginning")?>:</span>&nbsp;{{eventStartDate}}
+                {{else}}
+                <span class="imp-label"><?=tr("size")?>:</span>&nbsp;{{size}}
+                {{/if}}
+            </div>
+            <div class="imp-cell imp-counter">
+                {{#if isEvent}}
+                <img src="/images/log/attend.svg" alt="<?=tr("attendends")?>"> x {{founds}} <?=tr("attendends")?>
+                {{else}}
+                <img src="/images/log/found.svg" alt="<?=tr('found')?>"> x {{founds}} <?=tr('found')?>
+                {{/if}}
+            </div>
+        </div>
+        <div class="imp-row">
+            <div class="imp-cell">
+                {{#if rating}}<span class="imp-label"><?=tr('score')?>:</span>&nbsp;{{rating}}</a>{{/if}}
+            </div>
+            <div class="imp-cell imp-counter">
+                {{#if isEvent}}
+                <img src="/images/log/will_attend.svg" alt="<?=tr("will_attend")?>"> x {{notFounds}} <?=tr("will_attend")?>
+                {{else}}
+                <img src="/images/log/dnf.svg" alt="<?=tr('not_found')?>"> x {{notFounds}} <?=tr('not_found')?>
+                {{/if}}
+            </div>
+        </div>
+        <div class="imp-row">
+            <div class="imp-cell">
+                {{#if username}}<a href="{{userProfile}}" class="links" alt="{{username}}" title="{{username}}"><span class="imp-label"><?=tr('owner')?>:</span>&nbsp;{{username}}</a>{{/if}}
+            </div>
+            <div class="imp-cell imp-counter">
+                <img src="/images/free_icons/thumb_up.png" alt="<?=tr("scored")?>"> {{ratingVotes}} x <?=tr("scored")?>
+            </div>
+        </div>
+        {{#if isStandingOut}}
+        <div class="imp-row">
+            <div class="imp-cell">
+                {{#if titledDesc}}
+                <img src="/images/free_icons/award_star_gold_1.png" alt="{{titledDesc}}"> <span class="imp-label">{{titledDesc}}</span>
+                {{/if}}
+            </div>
+            <div class="imp-cell imp-counter">
+                {{#if recommendations}}
+                <img src="/images/rating-star.png" alt="<?=tr("recommended")?>"> {{recommendations}} x <?=tr("recommended")?>
+                {{/if}}
+            </div>
+        </div>
+        {{/if}}
+    </div>
+    {{#if powerTrailName}}
+    <div class="imp-table imp-details">
+        <div class="imp-row">
+            <div class="imp-narrow-cell">
+                <span class="imp-label"><?=tr("pt000")?>:</span>
+            </div>
+            <div class="imp-cell">
+                <a href="{{powerTrailUrl}}" title="{{powerTrailName}}" target="_blank" class="links">
+                    <img src="{{powerTrailIcon}}" alt="<?=tr("pt000")?>" title="{{powerTrailName}}"> {{powerTrailName}}
+                </a>
+            </div>
+        </div>
+    </div>
+    {{/if}}
+  <span class="imp-closer"></span>
+</div>
+{{#if showNavi}}
+<div class="imp-navi">
+    <div class="imp-backward">
+        <img src="/images/blue/arrow2.png" alt="&lt;" title="<?=tr('map_popup_previous')?>">
+    </div>
+    <div class="imp-forward">
+        <img src="/images/blue/arrow2.png" alt="&gt;" title="<?=tr('map_popup_next')?>">
+    </div>
+</div>
+{{/if}}

--- a/src/Views/chunks/interactiveMap/markers/cacheSetMarkerMgr.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/cacheSetMarkerMgr.tpl.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This is JS object containing functions used to handle markers
+ * - markerFactory - creates marker based on data row
+ * - infoWindowFactory - creates inforWindow based on row data
+ * - data - data rows of this type
+ *
+ * All functions are used from within dynamic map chunk.
+ */
+
+?>
+{
+    markerFactory: function(map, type, id, ocData, section) {
+        if (typeof section === "undefined") {
+            section = "_DEFAULT_";
+        }
+        var iconFeature = new ol.Feature({
+            geometry: new ol.geom.Point(ol.proj.fromLonLat([parseFloat(ocData.lon), parseFloat(ocData.lat)])),
+            ocData: {
+                markerSection: section,
+                markerType: type,
+                markerId: id
+            }
+        });
+        feature.setId(section + '_' + type + '_' + ocData.id);
+        iconFeature.setStyle(new ol.style.Style({
+            image: new ol.style.Icon( {
+                anchorOrigin: 'bottom-left',
+                anchor: [0.5, 0],
+                anchorXUnits: 'fraction',
+                anchorYUnits: 'pixels',
+                src: ocData.icon,
+            })
+        }));
+        return iconFeature;
+    },
+}

--- a/src/Views/chunks/interactiveMap/markers/cacheWithLogMarkerMgr.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/cacheWithLogMarkerMgr.tpl.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This is JS object containing functions used to handle markers
+ * - markerFactory - creates marker based on data row
+ * - infoWindowFactory - creates inforWindow based on row data
+ * - data - data rows of this type
+ *
+ * All functions are used from within dynamic map chunk.
+ */
+
+?>
+{
+    markerFactory: function(map, type, id, ocData) {
+        if (typeof section === "undefined") {
+            section = "_DEFAULT_";
+        }
+        var iconFeature = new ol.Feature({
+            geometry: new ol.geom.Point(ol.proj.fromLonLat([parseFloat(ocData.lon), parseFloat(ocData.lat)])),
+            ocData: {
+                markerSection: section,
+                markerType: type,
+                markerId: id
+            }
+        });
+        feature.setId(section + '_' + type + '_' + ocData.id);
+        iconFeature.setStyle(new ol.style.Style({
+            image: new ol.style.Icon( {
+                anchor: [0.5, 0.5],
+                anchorXUnits: 'fraction',
+                anchorYUnits: 'fraction',
+                src: ocData.icon,
+                scale: 0.5,
+            })
+        }));
+        return iconFeature;
+    },
+}

--- a/src/Views/chunks/interactiveMap/markers/guideMarkerMgr.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/guideMarkerMgr.tpl.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This is JS object containing functions used to handle markers
+ * - markerFactory - creates marker based on data row
+ * - infoWindowFactory - creates inforWindow based on row data
+ * - data - data rows of this type
+ *
+ * All functions are used from within dynamic map chunk.
+ */
+
+?>
+{
+    markerFactory: function(map, type, id, ocData, section) {
+        if (typeof section === "undefined") {
+            section = "_DEFAULT_";
+        }
+        var iconFeature = new ol.Feature({
+            geometry: new ol.geom.Point(ol.proj.fromLonLat([parseFloat(ocData.lon), parseFloat(ocData.lat)])),
+            ocData: {
+                markerSection: section,
+                markerType: type,
+                markerId: id
+            }
+          });
+        feature.setId(section + '_' + type + '_' + ocData.id);
+        iconFeature.setStyle(new ol.style.Style({
+            image: new ol.style.Icon({
+                anchorOrigin: "bottom-left",
+                anchor: [8, 0],
+                anchorXUnits: 'pixel',
+                anchorYUnits: 'pixel',
+                src: ocData.icon,
+                scale: 1,
+            })
+        }));
+        return iconFeature;
+    },
+}

--- a/src/Views/chunks/interactiveMap/markers/guideMarkerPopup.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/guideMarkerPopup.tpl.php
@@ -1,0 +1,49 @@
+<?php //This is handlebars-js template - see https://handlebarsjs.com/ for format details ?>
+
+<div class="imp-guide">
+    <div class="imp-table">
+        <div class="imp-row">
+            <div class="imp-cell">
+                <img src="/images/free_icons/vcard.png" alt="img">
+            </div>
+            <div class="imp-cell">
+                <a href="{{link}}" class="links" target="_blank">{{username}}</a>
+            </div>
+        </div>
+        <div class="imp-row">
+            <div class="imp-cell"></div>
+            <div class="imp-cell">
+                <div class="imp-desc">
+                    {{{userDesc}}}
+                </div>
+            </div>
+        </div>
+        <div class="imp-row">
+            <div class="imp-cell">
+                <img src="/images/rating-star.png" alt="*" title="*">
+            </div>
+            <div class="imp-cell">
+                {{recCount}} <?=tr('guides_recommendations')?>
+            </div>
+        </div>
+        <div class="imp-row">
+            <div class="imp-cell">
+                <img src="/images/free_icons/email.png" alt="mailTo">
+            </div>
+            <div class="imp-cell">
+                <a class="links" href="/UserProfile/mailTo/{{user_id}}" target="_blank"><?=tr('guides_sendemail')?></a>
+            </div>
+        </div>
+    </div>
+    <span class="imp-closer"></span>
+</div>
+{{#if showNavi}}
+<div class="imp-navi">
+    <div class="imp-backward">
+        <img src="/images/blue/arrow2.png" alt="&lt;" title="<?=tr('map_popup_previous')?>">
+    </div>
+    <div class="imp-forward">
+        <img src="/images/blue/arrow2.png" alt="&gt;" title="<?=tr('map_popup_next')?>">
+    </div>
+</div>
+{{/if}}

--- a/src/Views/chunks/interactiveMap/markers/logMarkerMgr.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/logMarkerMgr.tpl.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This is JS object containing functions used to handle markers
+ * - markerFactory - creates marker based on data row
+ * - infoWindowFactory - creates inforWindow based on row data
+ * - data - data rows of this type
+ *
+ * All functions are used from within dynamic map chunk.
+ */
+
+?>
+{
+    markerFactory: function(map, type, id, ocData, section){
+        return createOCMarkerFeature(
+            type, id, ocData, new LogMarker(map, ocData), section
+        );
+    },
+}

--- a/src/Views/chunks/interactiveMap/markers/logMarkerPopup.tpl.php
+++ b/src/Views/chunks/interactiveMap/markers/logMarkerPopup.tpl.php
@@ -1,0 +1,48 @@
+<?php //This is handlebars-js template - see https://handlebarsjs.com/ for format details ?>
+
+<div class="imp-cache-log">
+    {{#if sectionName}}
+    <div class="imp-table ipm-section">
+        <div class="imp-row">
+            <div class="imp-cell ipm-section">{{sectionName}}</div>
+        </div>
+    </div>
+    {{/if}}
+    <div class="imp-table">
+        <div class="imp-row">
+            <div class="imp-cell imp-cache-icon">
+                <img src="{{icon}}" alt="{{wp}}" title="{{wp}}">
+            </div>
+            <div class="imp-cell">
+                <a href="{{link}}" class="links" target="_blank">{{name}}</a>
+                {{#if username}}({{username}}){{/if}}
+            </div>
+        </div>
+        {{#if logLink}}
+        <div class="imp-row imp-block">
+            <div class="imp-cell imp-log-icon">
+                <img src="{{logIcon}}" title="{{logTypeName}}" alt="{{logTypeName}}">
+            </div>
+            <div class="imp-cell">
+                <a href="{{logLink}}" class="links" target="_blank">
+                    <span class="imp-user">{{logUsername}}</span> ({{logDate}})
+                    {{#if logText}}
+                    <div class="imp-content">{{{logText}}}</div>
+                    {{/if}}
+                </a>
+            </div>
+        </div>
+        {{/if}}
+    </div>
+  <span class="imp-closer"></span>
+</div>
+{{#if showNavi}}
+<div class="imp-navi">
+    <div class="imp-backward">
+        <img src="/images/blue/arrow2.png" alt="&lt;" title="<?=tr('map_popup_previous')?>">
+    </div>
+    <div class="imp-forward">
+        <img src="/images/blue/arrow2.png" alt="&gt;" title="<?=tr('map_popup_next')?>">
+    </div>
+</div>
+{{/if}}

--- a/src/Views/myNbhInteractive/config.tpl.php
+++ b/src/Views/myNbhInteractive/config.tpl.php
@@ -1,0 +1,167 @@
+<?php
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="content2-container">
+  <?=$view->callChunk('infoBar', null, $view->infoMsg, $view->errorMsg)?>
+  <div class="nbh-top-config-btns">
+    <a class="btn btn-md <?=($view->selectedNbh == 0) ? 'btn-primary' : 'btn-default'?>" href="<?=SimpleRouter::getLink($view->controller, 'config', 0)?>"><?=tr('my_neighborhood')?></a>
+    <?php foreach ($view->neighbourhoodsList as $nbh) {
+      if ($nbh->getSeq() == 0) {
+          continue;
+      } ?>
+    <a class="btn btn-md <?=($view->selectedNbh == $nbh->getSeq()) ? 'btn-primary' : 'btn-default'?>" href="<?=SimpleRouter::getLink($view->controller, 'config', $nbh->getSeq())?>"><?=$nbh->getName()?></a>
+    <?php } // end foreach neighbourhoodsList ?>
+    <?php if ($view->selectedNbh == -1) { ?>
+    <a class="btn btn-md btn-primary" href="<?=SimpleRouter::getLink($view->controller, 'config', '-1')?>">?</a>
+    <?php } // end if selectedNbh = -1
+      if (count($view->neighbourhoodsList) <= $view->maxnbh) { ?>
+    <a class="btn btn-md btn-success" href="<?=SimpleRouter::getLink($view->controller, 'config', '-1')?>" title="<?=tr('myn_addarea_info')?>"><img src="/images/misc/plus-sign.svg" class="icon16" alt="<?=tr('new')?>">&nbsp;<?=tr('new')?></a>
+    <?php } // end if ?>
+    <span class="nbh-button-right">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh) ?>" class="btn btn-default btn-md"><?=tr('exit_config')?></a>
+    </span>
+  </div>
+
+<?php if ($view->coordsOK == 0) {
+    if ($view->selectedNbh == 0) { ?>
+      <div class="callout callout-warning"><?=tr('myn_intro')?></div>
+    <?php } // if selectedNbh == 0 ?>
+  <div class="notice"><?=tr('myn_map_info1')?></div>
+<?php } elseif ($view->selectedNbh == 0) { ?>
+  <div class="notice"><?=tr('myn_name_default')?></div>
+<?php } else { ?>
+  <div class="notice"><?=tr('myn_name_addition')?></div>
+<?php } // end if coordsOK ?>
+  <div class="notice"><?=tr('myn_map_info2')?></div>
+  <div id="nbhmapmain" class="nbh-map"></div>
+  <?php $view->callChunk('interactiveMap/interactiveMap', $view->mapModel, "nbhmapmain");?>
+
+  <div class="align-center">
+    <div id="nbh-startdraw-btn" class="btn btn-md btn-success"><?=tr('myn_map_drawbtn')?></div>
+    <div id="nbh-coords-line">
+      <span id="nbh-coords-lat"></span>
+      <span id="nbh-coords-lon"></span> |
+      <span id="nbh-radius"></span> km
+    </div>
+  </div>
+
+<script>
+    let configDraw;
+    let configDrawHooks = {
+        "updateConfig": updateConfig
+    };
+
+    $(document).ready(function() {
+        configDraw = new ConfigDraw(
+            InteractiveMapServices.getMapObject("nbhmapmain"), <?=$view->minRadius?>, <?=$view->maxRadius?>
+        );
+        configDraw.setHooks(configDrawHooks);
+        let initLat, initLon, initRadius;
+        <?php if ($view->coordsOK == 1) { ?>
+        initLat = <?=$view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLatitude()?>;
+        initLon = <?=$view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLongitude()?>;
+        initRadius = <?=$view->neighbourhoodsList[$view->selectedNbh]->getRadius()?>;
+        $('#nbh-coords-lat').text(latToText($('#input-lat').val()));
+        $('#nbh-coords-lon').text(lonToText($('#input-lon').val()));
+        $('#nbh-radius').text($('#input-radius').val());
+        $('#nbh-startdraw-btn').hide();
+        $('#nbh-coords-line').show();
+        <?php } else { // else if coordsOK ?>
+        $('#nbh-startdraw-btn').click(function() {
+            configDraw.startDrawing();
+            $('#nbh-startdraw-btn').hide();
+            $('#nbh-coords-line').show();
+        });
+        <?php } // end if coordsOK ?>
+        configDraw.init([ initLat, initLon ], initRadius);
+    });
+
+    function updateConfig(lat, lon, radius) {
+        $('#input-radius').val(radius);
+        $('#nbh-radius').text(radius);
+        $('#input-lat').val(lat);
+        $('#input-lon').val(lon);
+        $('#nbh-coords-lat').text(latToText(lat));
+        $('#nbh-coords-lon').text(lonToText(lon));
+    }
+
+    function latToText(lat) {
+        let text = 'N ';
+        if (lat < 0) {
+            text = 'S ';
+        };
+        lat = Math.abs(lat);
+        let v1 = Math.floor(lat);
+        let v2 = Math.round((lat - v1) * 60000) / 1000;
+        text += v1 + '° ' + v2 + '\'';
+        return text;
+    }
+
+    function lonToText(lon) {
+        let text = 'E ';
+        if (lon < 0) {
+            text = 'W ';
+        };
+        lon = Math.abs(lon);
+        let v1 = Math.floor(lon);
+        let v2 = Math.round((lon - v1) * 60000) / 1000;
+        text += v1 + '° ' + v2 + '\'';
+        return text;
+    }
+  </script>
+
+  <div class="buffer"></div>
+  <form method="post" action="<?=SimpleRouter::getLink($view->controller, 'save', $view->selectedNbh)?>">
+<?php if ($view->selectedNbh == 0) { // Main MyNeighbourhood area ?>
+  <fieldset>
+    <legend>&nbsp;<?=tr('myn_style_lbl')?>&nbsp;</legend>
+    <label for="radio-1"><?=tr('myn_style_full')?></label>
+    <input type="radio" name="style" value="full" id="radio-1" class="nbh-radio" <?=$view->preferences['style']['name'] == 'full' ? 'checked' : ''?>>
+    <label for="radio-2"><?=tr('myn_style_min')?></label>
+    <input type="radio" name="style" value="min" id="radio-2" class="nbh-radio" <?=$view->preferences['style']['name'] == 'min' ? 'checked' : ''?>>
+  </fieldset>
+  <div class="buffer"></div>
+  <fieldset id="cacheitems-slider-fset">
+    <legend>&nbsp;<?=tr('myn_cacheitems_lbl')?>&nbsp;</legend>
+    <div id="nbh-slider">
+      <div id="nbh-custom-handle" class="ui-slider-handle"></div>
+    </div>
+  </fieldset>
+  <div class="buffer"></div>
+  <input type="hidden" name="caches-perpage" id="input-caches" value="<?=$view->preferences['style']['caches-count']?>">
+  <div class="align-center">
+    <button class="btn btn-primary btn-md"><?=tr('save_changes')?></button>
+    <a href="<?=SimpleRouter::getLink('UserProfile', 'notifySettings')?>" class="btn btn-default btn-md"><?=tr('settings_notifications')?></a>
+    <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh) ?>" class="btn btn-default btn-md"><?=tr('exit_config')?></a>
+  </div>
+<?php } else { // Additional Myneighbourhood area ?>
+    <fieldset>
+    <legend><?=tr('myn_name')?></legend>
+    <input type="text" name="name" id="input-name" class="ui-widget ui-widget-content ui-corner-all" value="<?=($view->selectedNbh == -1) ? '' : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>" maxlength="16" required>
+    </fieldset>
+  <div class="buffer"></div>
+  <div class="align-center">
+    <button class="btn btn-primary btn-md"><?=tr('save_changes')?></button>
+    <button class="btn btn-danger btn-md" id="nbh-delete-btn"><?=tr('myn_delete')?></button>
+    <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh) ?>" class="btn btn-default btn-md"><?=tr('exit_config')?></a>
+  </div>
+  <div class="nbh-nodisplay">
+    <div id="nbh-delete-dialog-confirm" title="<?=tr('myn_delete')?>">
+      <p><span class="ui-icon ui-icon-alert" id="nbh-delete-dialog-icon"></span><?=tr('myn_delete_confirm')?></p>
+    </div>
+  </div>
+<?php } // end if-else ?>
+  <input type="hidden" name="lon" id="input-lon" value="<?=$view->coordsOK == 1 ? $view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLongitude() : '' ?>">
+  <input type="hidden" name="lat" id="input-lat" value="<?=$view->coordsOK == 1 ? $view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLatitude() : '' ?>">
+  <input type="hidden" name="radius" id="input-radius" value="<?=$view->coordsOK == 1 ? $view->neighbourhoodsList[$view->selectedNbh]->getRadius() : '' ?>">
+  </form>
+<script>
+    let cancelButton = "<?=tr('cancel')?>";
+    let deleteButton = "<?=tr('delete')?>";
+    let deleteLink = "<?=SimpleRouter::getLink($view->controller, 'delete', $view->selectedNbh)?>";
+    let cachesCount = <?=$view->preferences['style']['caches-count']?>;
+    let minCaches = <?=$view->minCaches?>;
+    let maxCaches = <?=$view->maxCaches?>;
+</script>
+</div>

--- a/src/Views/myNbhInteractive/detail_FTFCaches.tpl.php
+++ b/src/Views/myNbhInteractive/detail_FTFCaches.tpl.php
@@ -1,0 +1,52 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('ftf_awaiting')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+    </div>
+  </div>
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><span class="nbh-nowrap"><?=tr('date_hidden_label')?></span></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->caches as $cache) { ?>
+      <tr>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <strong><?=$cache->getCacheName() ?></strong>
+            <?php if ($cache->isPowerTrailPart()) { ?>
+              <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+            <?php } // end of if isPowerTrailPart?>
+            <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+            <span class="nbh-full-only"><br>
+            <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+            <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+            <?=tr($cache->getSizeTranslationKey())?></span> |
+            <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $cache->getCoordinates()))?> km
+            <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $cache->getCoordinates()))?>deg)"></span>
+          </div>
+        </td>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <?=Formatter::date($cache->getDatePlaced())?>
+        </td>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel);?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/detail_LatestCaches.tpl.php
+++ b/src/Views/myNbhInteractive/detail_LatestCaches.tpl.php
@@ -1,0 +1,79 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+use src\Controllers\LogEntryController;
+use src\Models\GeoCache\GeoCacheLog;
+
+$logController = new LogEntryController();
+?>
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('newest_caches')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+    </div>
+  </div>
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><span class="nbh-nowrap"><?=tr('date_hidden_label')?></span></th>
+        <th><?=tr('new_logs_myn')?></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->caches as $cache) { ?>
+      <tr>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <strong><?=$cache->getCacheName() ?></strong>
+            <?php if ($cache->isPowerTrailPart()) { ?>
+              <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+            <?php } // end of if isPowerTrailPart?>
+            <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+            <span class="nbh-full-only"><br>
+            <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+            <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+            <?=tr($cache->getSizeTranslationKey())?></span> |
+            <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $cache->getCoordinates()))?> km
+            <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $cache->getCoordinates()))?>deg)"></span>
+            <?php if ($cache->getRecommendations() > 0) { ?>
+              | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+              (<?=$cache->getRecommendations()?>)
+            <?php } // end of if getRecommendations() ?>
+          </div>
+        </td>
+        <td>
+          <?=Formatter::date($cache->getDatePlaced())?>
+        </td>
+        <?php
+          $log = $logController->loadLogs($cache, false, 0, 1);
+          if (! empty($log)) { ?>
+            <td onclick="location.href='<?=$log[0]->getLogUrl()?>';" style="cursor: pointer;">
+              <div class="lightTipped">
+                <img src="<?=GeoCacheLog::GetIconForType($log[0]->getType())?>" class="icon16" alt="<?=tr(GeoCacheLog::typeTranslationKey($log[0]->getType()))?>">
+                <?=Formatter::date($log[0]->getDate())?>
+                <strong><?=$log[0]->getUser()->getUserName()?></strong>
+                <span class="nbh-full-only"><br>
+                <?=mb_substr(strip_tags($log[0]->getText()), 0, 35)?><?=(mb_strlen(strip_tags($log[0]->getText())) > 35 ? '...' : '')?></span>
+              </div>
+              <div class="lightTip"><?=$log[0]->getText()?></div>
+            </td>
+            <?php
+              } else { ?>
+            <td></td>
+            <?php  }
+              unset($log);
+            ?>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel); ?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/detail_LatestLogs.tpl.php
+++ b/src/Views/myNbhInteractive/detail_LatestLogs.tpl.php
@@ -1,0 +1,70 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Text\UserInputFilter;
+use src\Utils\Uri\SimpleRouter;
+use src\Models\GeoCache\GeoCacheLog;
+
+?>
+<!-- aaa -->
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('latest_logs')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+     </div>
+  </div>
+
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><?=tr('myn_log_txt')?></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->logs as $log) { ?>
+      <tr>
+        <td onclick="location.href='<?=$log->getGeoCache()->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$log->getGeoCache()->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($log->getGeoCache()->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <a href="<?=$log->getGeoCache()->getCacheUrl()?>">
+              <strong><?=$log->getGeoCache()->getCacheName() ?></strong>
+              <?php if ($log->getGeoCache()->isPowerTrailPart()) { ?>
+                <img src="<?=$log->getGeoCache()->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($log->getGeoCache()->getPowerTrail()->getName())?>">
+              <?php } // end of if isPowerTrailPart?>
+              <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$log->getGeoCache()->getOwner()->getUserName()?></strong>
+              <span class="nbh-full-only"><br>
+              <img src="<?=$log->getGeoCache()->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$log->getGeoCache()->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$log->getGeoCache()->getDifficulty() / 2?>">
+              <img src="<?=$log->getGeoCache()->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$log->getGeoCache()->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$log->getGeoCache()->getTerrain() / 2?>">
+              <?=tr($log->getGeoCache()->getSizeTranslationKey())?></span> |
+              <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $log->getGeoCache()->getCoordinates()))?> km
+              <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $log->getGeoCache()->getCoordinates()))?>deg)"></span>
+            </a>
+          </div>
+        </td>
+        <td>
+          <div class="nbh-desc-container lightTipped" onclick="location.href='<?=$log->getLogUrl()?>';" style="cursor: pointer;">
+            <img src="<?=$log->getLogIcon()?>" class="icon16" alt="<?=tr(GeoCacheLog::typeTranslationKey($log->getType()))?>">
+            <a href="<?=$log->getLogUrl()?>">
+              <span class="nbh-nowrap"><?=Formatter::date($log->getDate())?></span>
+              <strong><?=$log->getUser()->getUserName()?></strong>
+              <?php if ($log->getType() == GeoCacheLog::LOGTYPE_FOUNDIT && $log->isRecommendedByUser($log->getUser())) { ?>
+                <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+              <?php } // end of if isRecommendedByUser ?>
+              <span class="nbh-full-only"><br>
+              <?=mb_substr(strip_tags($log->getText()), 0, 70)?><?=(mb_strlen(strip_tags($log->getText())) > 70 ? '...' : '')?></span>
+            </a>
+          </div>
+          <div class="lightTip"><?=UserInputFilter::purifyHtmlString($log->getText())?></div>
+        </td>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel);?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/detail_RecommendedCaches.tpl.php
+++ b/src/Views/myNbhInteractive/detail_RecommendedCaches.tpl.php
@@ -1,0 +1,79 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+use src\Controllers\LogEntryController;
+use src\Models\GeoCache\GeoCacheLog;
+
+$logController = new LogEntryController();
+?>
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('top_recommended')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+    </div>
+  </div>
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><span class="nbh-nowrap"><?=tr('date_hidden_label')?></span></th>
+        <th><?=tr('new_logs_myn')?></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->caches as $cache) { ?>
+      <tr>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <strong><?=$cache->getCacheName() ?></strong>
+            <?php if ($cache->isPowerTrailPart()) { ?>
+              <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+            <?php } // end of if isPowerTrailPart?>
+            <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+            <span class="nbh-full-only"><br>
+            <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+            <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+            <?=tr($cache->getSizeTranslationKey())?></span> |
+            <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $cache->getCoordinates()))?> km
+            <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $cache->getCoordinates()))?>deg)"></span>
+            <?php if ($cache->getRecommendations() > 0) { ?>
+              | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+              (<?=$cache->getRecommendations()?>)
+            <?php } // end of if getRecommendations() ?>
+          </div>
+        </td>
+        <td>
+          <?=Formatter::date($cache->getDatePlaced())?>
+        </td>
+        <?php
+          $log = $logController->loadLogs($cache, false, 0, 1);
+          if (! empty($log)) { ?>
+            <td onclick="location.href='<?=$log[0]->getLogUrl()?>';" style="cursor: pointer;">
+              <div class="lightTipped">
+                <img src="<?=GeoCacheLog::GetIconForType($log[0]->getType())?>" class="icon16" alt="<?=tr(GeoCacheLog::typeTranslationKey($log[0]->getType()))?>">
+                <?=Formatter::date($log[0]->getDate())?>
+                <strong><?=$log[0]->getUser()->getUserName()?></strong>
+                <span class="nbh-full-only"><br>
+                <?=mb_substr(strip_tags($log[0]->getText()), 0, 35)?><?=(mb_strlen(strip_tags($log[0]->getText())) > 35 ? '...' : '')?></span>
+              </div>
+              <div class="lightTip"><?=$log[0]->getText()?></div>
+            </td>
+            <?php
+              } else { ?>
+            <td></td>
+            <?php  }
+              unset($log);
+            ?>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel);?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/detail_TitledCaches.tpl.php
+++ b/src/Views/myNbhInteractive/detail_TitledCaches.tpl.php
@@ -1,0 +1,87 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+use src\Controllers\LogEntryController;
+use src\Models\GeoCache\CacheTitled;
+use src\Models\GeoCache\GeoCacheLog;
+
+$logController = new LogEntryController();
+?>
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('startPage_latestTitledCaches')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+    </div>
+  </div>
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><span class="nbh-nowrap"><?=tr('date_hidden_label')?></span></th>
+        <th><span class="nbh-nowrap"><?=tr('myn_titleddate')?></span></th>
+        <th><?=tr('new_logs_myn')?></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->caches as $cache) { ?>
+      <tr>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <strong><?=$cache->getCacheName() ?></strong>
+            <?php if ($cache->isPowerTrailPart()) { ?>
+              <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+            <?php } // end of if isPowerTrailPart?>
+            <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+            <span class="nbh-full-only"><br>
+            <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+            <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+            <?=tr($cache->getSizeTranslationKey())?></span> |
+            <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $cache->getCoordinates()))?> km
+            <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $cache->getCoordinates()))?>deg)"></span>
+            <?php if ($cache->getRecommendations() > 0) { ?>
+              | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+              (<?=$cache->getRecommendations()?>)
+            <?php } // end of if getRecommendations() ?>
+          </div>
+        </td>
+        <td>
+          <?=Formatter::date($cache->getDatePlaced())?>
+        </td>
+        <td>
+          <?php $cacheTitled = CacheTitled::fromCacheIdFactory($cache->getCacheId());
+            echo Formatter::date($cacheTitled->getTitledDate());
+            unset($cacheTitled);
+          ?>
+        </td>
+        <?php
+          $log = $logController->loadLogs($cache, false, 0, 1);
+          if (! empty($log)) { ?>
+            <td onclick="location.href='<?=$log[0]->getLogUrl()?>';" style="cursor: pointer;">
+              <div class="lightTipped">
+                <img src="<?=GeoCacheLog::GetIconForType($log[0]->getType())?>" class="icon16" alt="<?=tr(GeoCacheLog::typeTranslationKey($log[0]->getType()))?>">
+                <?=Formatter::date($log[0]->getDate())?>
+                <strong><?=$log[0]->getUser()->getUserName()?></strong>
+                <span class="nbh-full-only"><br>
+                <?=mb_substr(strip_tags($log[0]->getText()), 0, 20)?><?=(mb_strlen(strip_tags($log[0]->getText())) > 20 ? '...' : '')?></span>
+              </div>
+              <div class="lightTip"><?=$log[0]->getText()?></div>
+            </td>
+            <?php
+              } else { ?>
+            <td></td>
+            <?php  }
+              unset($log);
+            ?>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel);?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/detail_UpcommingEvents.tpl.php
+++ b/src/Views/myNbhInteractive/detail_UpcommingEvents.tpl.php
@@ -1,0 +1,72 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+use src\Controllers\LogEntryController;
+use src\Models\GeoCache\GeoCacheLog;
+
+$logController = new LogEntryController();
+?>
+<div class="content2-container">
+  <div class="nbh-pageheader">
+    <?=tr('incomming_events')?> (<?=($view->selectedNbh == 0) ? tr('my_neighborhood') : $view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    <div class="nbh-md-buttons">
+      <a href="<?=SimpleRouter::getLink($view->controller, 'index', $view->selectedNbh)?>" class="btn btn-md btn-default nbh-back-btn"><?=tr('myn_btn_back')?></a>
+    </div>
+  </div>
+  <table class="table full-width">
+    <thead>
+      <tr>
+        <th><?=tr('cache')?></th>
+        <th><?=tr('myn_event_organizer')?></th>
+        <th><?=tr('date_event_label')?></th>
+        <th><?=tr('new_logs_myn')?></th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($view->caches as $cache) { ?>
+      <tr>
+        <td onclick="location.href='<?=$cache->getCacheUrl()?>';" style="cursor: pointer;">
+          <div class="nbh-image-container">
+            <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+          </div>
+          <div class="nbh-desc-container">
+            <strong><?=$cache->getCacheName() ?></strong>
+            <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->coords, $cache->getCoordinates()))?> km
+            <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->coords, $cache->getCoordinates()))?>deg)"></span>
+            | <img src="/images/log/16x16-will_attend.png" alt="<?=tr('will_attend')?>" title="<?=tr('will_attend')?>" class="icon16"> <?=$cache->getNotFounds()?></span>
+          </div>
+        </td>
+        <td>
+          <strong><?=$cache->getOwner()->getUserName()?></strong>
+        </td>
+        <td>
+          <?=Formatter::date($cache->getDatePlaced())?>
+        </td>
+        <?php
+          $log = $logController->loadLogs($cache, false, 0, 1);
+          if (! empty($log)) { ?>
+            <td onclick="location.href='<?=$log[0]->getLogUrl()?>';" style="cursor: pointer;">
+              <div class="lightTipped">
+                <img src="<?=GeoCacheLog::GetIconForType($log[0]->getType())?>" class="icon16" alt="<?=tr(GeoCacheLog::typeTranslationKey($log[0]->getType()))?>">
+                <?=Formatter::date($log[0]->getDate())?>
+                <strong><?=$log[0]->getUser()->getUserName()?></strong>
+                <span class="nbh-full-only"><br>
+                <?=mb_substr(strip_tags($log[0]->getText()), 0, 35)?><?=(mb_strlen(strip_tags($log[0]->getText())) > 35 ? '...' : '')?></span>
+              </div>
+              <div class="lightTip"><?=$log[0]->getText()?></div>
+            </td>
+            <?php
+              } else { ?>
+            <td></td>
+            <?php  }
+              unset($log);
+            ?>
+      </tr>
+    <?php } ?>
+    </tbody>
+  </table>
+  <?php $view->callChunkInline('pagination', $view->paginationModel); ?>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>

--- a/src/Views/myNbhInteractive/myNeighbourhood.tpl.php
+++ b/src/Views/myNbhInteractive/myNeighbourhood.tpl.php
@@ -1,0 +1,82 @@
+<?php
+use src\Utils\Uri\SimpleRouter;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Models\Coordinates\Coordinates;
+
+?>
+<div class="content2-container">
+  <?php foreach ($view->neighbourhoodsList as $nbh) {
+      if ($nbh->getSeq() == $view->selectedNbh) {
+          $btnClassMod = 'btn-primary';
+      } else {
+          $btnClassMod = 'btn-default';
+      }
+      ?>
+    <a class="btn btn-md <?=$btnClassMod?>" href="<?=SimpleRouter::getLink($view->controller, 'index', $nbh->getSeq())?>"><?=$nbh->getName()?></a>
+  <?php } // end foreach neighbourhoodsList ?>
+  <a class="btn btn-md btn-success" href="<?=SimpleRouter::getLink($view->controller, 'config', $view->selectedNbh)?>"><img src="/images/free_icons/cog.png" class="icon16" alt="<?=tr('config')?>">&nbsp;<?=tr('config')?></a>
+
+  <div class="nbh-sort-list">
+  <?php
+    $order = [];
+    foreach ($view->preferences['items'] as $key => $item) {
+        $order[$item['order']] = $item;
+        $order[$item['order']]['item'] = $key;
+    }
+    ksort($order);
+    foreach ($order as $item) {
+      $classSize = ($item['fullsize'] == 1) ? 'nbh-full' : 'nbh-half';
+      switch ($item['item']) {
+          case Neighbourhood::ITEM_MAP:
+              $subTemplate = '/' . $view->templatesPath . 'sub_Map';
+              break;
+          case Neighbourhood::ITEM_LATESTCACHES:
+              $subTemplate = '/' . $view->templatesPath . 'sub_LatestCaches';
+              break;
+          case Neighbourhood::ITEM_UPCOMINGEVENTS:
+              $subTemplate = '/' . $view->templatesPath . 'sub_UpcommingEvents';
+              break;
+          case Neighbourhood::ITEM_FTFCACHES:
+              $subTemplate = '/' . $view->templatesPath . 'sub_FTFCaches';
+              break;
+          case Neighbourhood::ITEM_LATESTLOGS:
+              $subTemplate = '/' . $view->templatesPath . 'sub_LatestLogs';
+              break;
+          case Neighbourhood::ITEM_TITLEDCACHES:
+              $subTemplate = '/' . $view->templatesPath . 'sub_TitledCaches';
+              break;
+          case Neighbourhood::ITEM_RECOMMENDEDCACHES:
+              $subTemplate = '/' . $view->templatesPath . 'sub_RecommendedCaches';
+              break;
+          default:
+              break;
+      }
+      ?>
+      <div class="nbh-block <?=$classSize?>" id="item_<?=$item['item']?>" section="<?=$item['item']?>">
+          <?=$view->callSubTpl($subTemplate)?>
+      </div>
+  <?php } ?>
+  </div>
+  <?php
+    list($latNS, $lat_h, $lat_min) = $view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLatitudeParts(Coordinates::COORDINATES_FORMAT_DEG_MIN);
+    list($lonEW, $lon_h, $lon_min) =  $view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLongitudeParts(Coordinates::COORDINATES_FORMAT_DEG_MIN);
+  ?>
+  <div class="buffer"></div>
+  <div class="align-center">
+    <a href="/search.php?searchbydistance&amp;resetqueryid=y&amp;distance=<?=$view->neighbourhoodsList[$view->selectedNbh]->getRadius()?>&amp;latNS=<?=$latNS?>&amp;lat_h=<?=$lat_h?>&amp;lat_min=<?=$lat_min?>&amp;lonEW=<?=$lonEW?>&amp;lon_h=<?=$lon_h?>&amp;lon_min=<?=$lon_min?>#search-by-distance-table" class="btn btn-default btn-md">
+      <?=tr('mnu_searchCache')?> (<?=$view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    </a>
+    <a href="<?=SimpleRouter::getLink(MainMapController::class, 'embeded')?>?lat=<?=$view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLatitude()?>&amp;lon=<?=$view->neighbourhoodsList[$view->selectedNbh]->getCoords()->getLongitude()?>&amp;zoom=10"
+       class="btn btn-default btn-md">
+      <?=tr('mnu_cacheMap')?> (<?=$view->neighbourhoodsList[$view->selectedNbh]->getName()?>)
+    </a>
+  </div>
+  <div class="buffer"></div>
+  <div class="notice"><?=tr('myn_dragdrop')?></div>
+  <div class="notice"><?=tr('myn_distances')?></div>
+</div>
+<script>
+let changeOrderUri = "<?=SimpleRouter::getLink($view->controller, 'changeOrderAjax')?>"
+let changeSizeAjaxUri = "<?=SimpleRouter::getLink($view->controller, 'changeSizeAjax')?>"
+let changeDisplayAjaxUri = "<?=SimpleRouter::getLink($view->controller, 'changeDisplayAjax')?>"
+</script>

--- a/src/Views/myNbhInteractive/sub_FTFCaches.tpl.php
+++ b/src/Views/myNbhInteractive/sub_FTFCaches.tpl.php
@@ -1,0 +1,46 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('ftf_awaiting')?>
+  <div class='btn-group nbh-sm-buttons'>
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_FTFCACHES]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->FTFCaches)) { ?>
+  <div class="align-center"><?=tr('list_of_caches_is_empty')?></div>
+<?php } else {
+  foreach ($view->FTFCaches as $cache) {?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_FTFCACHES?>_cacheMarker_<?=$cache->getCacheId()?>" class="nbh-line-container">
+    <a href="<?=$cache->getCacheUrl()?>">
+      <div class="nbh-image-container">
+        <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      </div>
+      <div class="nbh-desc-container">
+        <strong><?=$cache->getCacheName() ?></strong>
+        <?php if ($cache->isPowerTrailPart()) { ?>
+          <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+        <?php } // end of if isPowerTrailPart?>
+        <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+        <span class="nbh-full-only"><br>
+        <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+        <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+        <?=tr($cache->getSizeTranslationKey())?></span> |
+        <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?>deg)"></span>
+      </div>
+    </a>
+  </div>
+  <?php } //end foreach
+  if (count($view->FTFCaches) == $view->preferences['style']['caches-count']) { ?>
+    <a class="btn btn-sm btn-default" href="<?=SimpleRouter::getLink($view->controller, 'ftfCaches', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+  <?php } // end if
+} // end if-else empty ?>
+</div>

--- a/src/Views/myNbhInteractive/sub_LatestCaches.tpl.php
+++ b/src/Views/myNbhInteractive/sub_LatestCaches.tpl.php
@@ -1,0 +1,52 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Uri\SimpleRouter;
+use src\Models\Neighbourhood\Neighbourhood;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('newest_caches')?>
+  <div class="btn-group nbh-sm-buttons">
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_LATESTCACHES]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->latestCaches)) { ?>
+  <div class="align-center"><?=tr('list_of_caches_is_empty')?></div>
+<?php } else {
+  foreach ($view->latestCaches as $cache) {?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_LATESTCACHES?>_cacheMarker_<?=$cache->getCacheId()?>" class="nbh-line-container">
+    <a href="<?=$cache->getCacheUrl()?>">
+      <div class="nbh-image-container">
+        <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      </div>
+      <div class="nbh-desc-container">
+        <strong><?=$cache->getCacheName() ?></strong>
+        <?php if ($cache->isPowerTrailPart()) { ?>
+          <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+        <?php } // end of if isPowerTrailPart?>
+        <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+        <span class="nbh-full-only"><br>
+        <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+        <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>"></span>
+        <span class="nbh-nowrap"><?=Formatter::date($cache->getDatePlaced())?></span> |
+        <span class="nbh-full-only"><?=tr($cache->getSizeTranslationKey())?> |</span>
+        <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?>deg)"></span>
+        <?php if ($cache->getRecommendations() > 0) { ?>
+          | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+          (<?=$cache->getRecommendations()?>)
+        <?php } // end of if getRecommendations() ?>
+      </div>
+    </a>
+  </div>
+  <?php } //end foreach
+  if (count($view->latestCaches) == $view->preferences['style']['caches-count']) { ?>
+    <a class="btn btn-sm btn-default" href="<?=SimpleRouter::getLink($view->controller,'latestCaches', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+  <?php } // end if
+  } ?>
+</div>

--- a/src/Views/myNbhInteractive/sub_LatestLogs.tpl.php
+++ b/src/Views/myNbhInteractive/sub_LatestLogs.tpl.php
@@ -1,0 +1,54 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Utils\Text\UserInputFilter;
+use src\Utils\Uri\SimpleRouter;
+use src\Models\GeoCache\GeoCacheLog;
+use src\Models\Neighbourhood\Neighbourhood;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('latest_logs')?>
+  <div class="btn-group nbh-sm-buttons">
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_LATESTLOGS]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->latestLogs)) { ?>
+    <div class="align-center"><?=tr('list_of_latest_logs_is_empty')?></div>
+<?php } else {
+  foreach ($view->latestLogs as $log) {?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_LATESTLOGS?>_logMarker_<?=$log->getId()?>" class="nbh-line-container">
+  <div class="lightTipped">
+    <div class="nbh-image-container">
+      <img src="<?=$log->getLogIcon()?>" class="nbh-icon" alt="<?=tr(GeoCacheLog::typeTranslationKey($log->getType()))?>">
+    </div>
+    <div class="nbh-desc-container" onclick="location.href='<?=$log->getLogUrl()?>';" style="cursor: pointer;">
+      <img src="<?=$log->getGeoCache()->getCacheIcon($view->user) ?>" class="icon16" title="<?=tr($log->getGeoCache()->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      <a href="<?=$log->getLogUrl()?>">
+        <strong><?=$log->getGeoCache()->getCacheName() ?></strong>
+        <?php if ($log->getGeoCache()->isPowerTrailPart()) { ?>
+          <img src="<?=$log->getGeoCache()->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($log->getGeoCache()->getPowerTrail()->getName())?>">
+        <?php } // end of if isPowerTrailPart?>
+        <span class="nbh-full-only"><?=tr('hidden_by')?> <strong><?=$log->getGeoCache()->getOwner()->getUserName()?></strong><br></span>
+        <?php if ($log->getType() == GeoCacheLog::LOGTYPE_FOUNDIT && $log->isRecommendedByUser($log->getUser())) { ?>
+          <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>"> |
+        <?php } // end of if isRecommendedByUser ?>
+        <span class="nbh-nowrap"><?=Formatter::date($log->getDate())?></span>
+        | <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $log->getGeoCache()->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $log->getGeoCache()->getCoordinates()))?>deg)"></span>
+        | <strong><?=$log->getUser()->getUserName()?></strong>
+      </a>
+      </div>
+  </div>
+  <div class="lightTip"><?=UserInputFilter::purifyHtmlString($log->getText())?></div>
+  </div>
+  <?php } //end foreach
+  if (count($view->latestLogs) == $view->preferences['style']['caches-count']) { ?>
+    <a class="btn btn-sm btn-default" href="<?=SimpleRouter::getLink($view->controller,'latestLogs', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+  <?php } // end if
+  } ?>
+</div>

--- a/src/Views/myNbhInteractive/sub_Map.tpl.php
+++ b/src/Views/myNbhInteractive/sub_Map.tpl.php
@@ -1,0 +1,14 @@
+<?php
+use src\Models\Neighbourhood\Neighbourhood;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('map')?>
+  <div class="btn-group nbh-sm-buttons">
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>" id="nbh-map-hide"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>" id="nbh-map-resize"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div id="nbhmap" class="nbh-block-content nbh-usermap<?=$view->preferences['items'][Neighbourhood::ITEM_MAP]['show'] == true ? '' : ' nbh-nodisplay'?>"></div>
+<?php $view->callChunk('interactiveMap/interactiveMap', $view->mapModel, "nbhmap");?>

--- a/src/Views/myNbhInteractive/sub_RecommendedCaches.tpl.php
+++ b/src/Views/myNbhInteractive/sub_RecommendedCaches.tpl.php
@@ -1,0 +1,48 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('top_recommended')?> <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+  <div class='btn-group nbh-sm-buttons'>
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_RECOMMENDEDCACHES]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->topRatedCaches)) { ?>
+  <div class="align-center"><?=tr('list_of_caches_is_empty')?></div>
+<?php } else {
+  foreach ($view->topRatedCaches as $cache) {?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_RECOMMENDEDCACHES?>_cacheMarker_<?=$cache->getCacheId()?>" class="nbh-line-container">
+    <a href="<?=$cache->getCacheUrl()?>">
+      <div class="nbh-image-container">
+        <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      </div>
+      <div class="nbh-desc-container">
+        <strong><?=$cache->getCacheName() ?></strong>
+        <?php if ($cache->isPowerTrailPart()) { ?>
+          <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+        <?php } // end of if isPowerTrailPart?>
+        <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+        <span class="nbh-full-only"><br>
+        <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+        <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>">
+        <?=tr($cache->getSizeTranslationKey())?></span> |
+        <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?>deg)"></span>
+        | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+        (<?=$cache->getRecommendations()?>)
+      </div>
+    </a>
+  </div>
+  <?php } //end foreach
+  if (count($view->topRatedCaches) == $view->preferences['style']['caches-count']) { ?>
+    <a class="btn btn-sm btn-default" href="<?=SimpleRouter::getLink($view->controller, 'mostRecommended', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+  <?php } // end if
+  } ?>
+</div>

--- a/src/Views/myNbhInteractive/sub_TitledCaches.tpl.php
+++ b/src/Views/myNbhInteractive/sub_TitledCaches.tpl.php
@@ -1,0 +1,57 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Models\GeoCache\CacheTitled;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('startPage_latestTitledCaches')?>
+  <div class='btn-group nbh-sm-buttons'>
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_TITLEDCACHES]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->latestTitled)) { ?>
+  <div class="align-center"><?=tr('list_of_caches_is_empty')?></div>
+<?php } else { ?>
+  <?php foreach ($view->latestTitled as $cache) {
+      $cacheTitled = CacheTitled::fromCacheIdFactory($cache->getCacheId());
+  ?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_TITLEDCACHES?>_cacheMarker_<?=$cache->getCacheId()?>" class="nbh-line-container">
+    <a href="<?=$cache->getCacheUrl()?>">
+      <div class="nbh-image-container">
+        <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      </div>
+      <div class="nbh-desc-container">
+        <strong><?=$cache->getCacheName() ?></strong>
+        <?php if ($cache->isPowerTrailPart()) { ?>
+          <img src="<?=$cache->getPowerTrail()->getFootIcon()?>" alt="<?=tr('pt002')?>" title="<?=htmlspecialchars($cache->getPowerTrail()->getName())?>">
+        <?php } // end of if isPowerTrailPart?>
+        <span class="nbh-full-only"><?=tr('hidden_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+        <span class="nbh-min-only"> |</span><span class="nbh-full-only"><br>
+        <img src="<?=$cache->getDifficultyIcon()?>" alt="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>" title="<?=tr('task_difficulty')?>: <?=$cache->getDifficulty() / 2?>">
+        <img src="<?=$cache->getTerrainIcon()?>" alt="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>" title="<?=tr('terrain_difficulty')?>: <?=$cache->getTerrain() / 2?>"></span>
+        <span class="nbh-nowrap"><?=Formatter::date($cacheTitled->getTitledDate())?></span> |
+        <span class="nbh-full-only"><?=tr($cache->getSizeTranslationKey())?> |</span>
+        <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?>deg)"></span>
+        <?php if ($cache->getRecommendations() > 0) { ?>
+          | <img src="/images/rating-star.png" alt="<?=tr('number_obtain_recommendations')?>">
+          (<?=$cache->getRecommendations()?>)
+        <?php } // end of if getRecommendations() ?>
+      </div>
+    </a>
+  </div>
+  <?php
+      unset($cacheTitled);
+  } //end foreach
+  if (count($view->latestTitled) == $view->preferences['style']['caches-count']) { ?>
+    <a class="btn btn-sm btn-default" href="<?=SimpleRouter::getLink($view->controller, 'titledCaches', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+  <?php } // end if
+} ?>
+</div>

--- a/src/Views/myNbhInteractive/sub_UpcommingEvents.tpl.php
+++ b/src/Views/myNbhInteractive/sub_UpcommingEvents.tpl.php
@@ -1,0 +1,45 @@
+<?php
+use src\Utils\Gis\Gis;
+use src\Utils\Text\Formatter;
+use src\Models\Neighbourhood\Neighbourhood;
+use src\Utils\Uri\SimpleRouter;
+
+?>
+<div class="nbh-block-header">
+  <?=tr('incomming_events')?>
+  <div class='btn-group nbh-sm-buttons'>
+    <button class="btn btn-xs btn-default nbh-hide-toggle" title="<?=tr('myn_hlp_hide')?>"><span class="nbh-eye"></span></button>
+    <button class="btn btn-xs btn-default nbh-size-toggle" title="<?=tr('myn_hlp_resize')?>"><span class="ui-icon ui-icon-arrow-2-e-w"></span></button>
+  </div>
+</div>
+
+<div class="nbh-block-content<?=$view->preferences['items'][Neighbourhood::ITEM_UPCOMINGEVENTS]['show'] == true ? '' : ' nbh-nodisplay'?>">
+
+<?php if (empty($view->upcomingEvents)) { ?>
+  <div class="align-center"><?=tr('list_of_events_is_empty')?></div>
+<?php } else {
+  foreach ($view->upcomingEvents as $cache) {?>
+  <div id="mynbh_item_<?=Neighbourhood::ITEM_UPCOMINGEVENTS?>_cacheMarker_<?=$cache->getCacheId()?>" class="nbh-line-container">
+    <a href="<?=$cache->getCacheUrl()?>">
+      <div class="nbh-image-container">
+        <img src="<?=$cache->getCacheIcon($view->user) ?>" class="nbh-icon" title="<?=tr($cache->getCacheTypeTranslationKey()) ?>" alt="<?=tr('cache') ?>">
+      </div>
+      <div class="nbh-desc-container">
+        <strong><?=$cache->getCacheName() ?></strong>
+        <span class="nbh-full-only"><?=tr('organized_by')?></span><span class="nbh-min-only">|</span> <strong><?=$cache->getOwner()->getUserName()?></strong>
+        <span class="nbh-full-only"><br></span><span class="nbh-min-only">|</span>
+        <span class="nbh-nowrap"><?=Formatter::date($cache->getDatePlaced())?></span> |
+        <span class="nbh-nowrap"><?=round(Gis::distanceBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?> km
+        <img src="/images/misc/arrow-north.svg" class="nbh-arrow-north" alt="<?=tr('direction')?>" style="transform: rotate(<?=round(Gis::calcBearingBetween($view->neighbourhoodsList[$view->selectedNbh]->getCoords(), $cache->getCoordinates()))?>deg)"></span>
+        <span class="nbh-full-only">| <img src="/images/log/16x16-will_attend.png" alt="<?=tr('will_attend')?>" title="<?=tr('will_attend')?>" class="icon16"> <?=$cache->getNotFounds()?></span>
+      </div>
+    </a>
+  </div>
+  <?php } //end foreach
+  if (count($view->upcomingEvents) == $view->preferences['style']['caches-count']) { ?>
+    <div class="align-right">
+      <a class="btn btn-sm btn-default" href="<?SimpleRouter::getLink($view->controller,'upcommingEvents', $view->selectedNbh)?>" title="<?=tr('myn_hlp_more')?>"><?=tr('more')?></a>
+    </div>
+  <?php } // end if
+} ?>
+</div>


### PR DESCRIPTION
The repository seems to be almost stale, so...

This is a proposition of changes to an existing Dynamic Map, together with corresponding changes is My Neighbourhood. Because of the nature of changes, as perceived from an external user point, I named it an Interactive Map.

IMPORTANT: Because there is a bunch of changes which I consider should be validated by someone, and not only developers but OC Team and advanced users too, the whole set of changes is made to coexist with an official My Neighbourhood, but replacing it after validation should require few changes only, apart from files relocation. To assure this coexistence, some MyNeighbourhood files have been simply copied to another location, while another ones has been only slightly changed.

What is new from a user point of view:

- A popup with marker details, showed by clicking on map marker, allows now to see not only a top-most marker, but also "move" to the next/previous marker being under the exact coordinates of the "clicked one",
- The visibility and order of markers shown on map is consistent with currently set order and visibility of My Neighbourhood "sections" (latest caches, latest logs etc.) and changing the section order or visibility adjusts the map appearance on client side. Ordering: the most top section markers are displayed on top, the second one are next etc.
- The visibility and order changes should apply to currently opened popup contents too.
- If the marker belongs to a named section, the section title is shown in the top part of popup box.
- When the mouse/cursor is moved over a row containing a particular entry, a corresponding marker is "highlighted" on the map and the "highlight" is toned down on mouse/cursor exit.

What is new from a developer point of view (main things):

- All markers within MapModel are now placed within sections. When a marker does not belong to any section, it should be placed within a special, `_DEFAULT_` section.
- Each section has a corresponding layer created in map and the visibility and ordering are layers' operations.
- `DynamicMap` itself (now `InteractiveMap`), its tools etc. have been rewritten to the more objective version, with prototyping where there is a chance for more than one instance creation.
- `InteractiveMapServices` global object should be now an entry point for every external usage.
- Markers have been rewritten to an objective, prototyped version, with inheritance introduced, and grouped within named 'marker family', where each defined family should have its own styling. Only a 'simple' family, using icons "computed" on server side is available now, but an implementation of more advanced 'okapi' icons is in progress.
- A more detailed information is passed with each marker within `markerData`, it is a step to introduce client-side 'okapi' icons too.

Above changes should be available for validation for OCTeam, Advanced Users and System Admins under '/MyNbhInteractive' relative url.

Should work (tested) on Firefox 78, Chrome 83, Edge 44. Does not show latest logs on IE 11 because of SVG icons, but current My Neighbourhood does not show them too.