### PR TITLE
Wrong getCacheType call changed to a correct getStatus

### DIFF
--- a/src/Controllers/PrintListController.php
+++ b/src/Controllers/PrintListController.php
@@ -42,7 +42,7 @@ class PrintListController extends BaseController
                 function (GeoCache $cache) {
                     return [
                         'type' => $cache->getCacheType(),
-                        'status' => $cache->getCacheType(),
+                        'status' => $cache->getStatus(),
                         'user_sts' => null,
                     ];
                 }));


### PR DESCRIPTION
A simple change fixing the "wrong flag" icon effect on the printList page.