### PR TITLE
Fix of the issue with geocache duplicates in geopaths

### DIFF
--- a/src/Controllers/GeoPathController.php
+++ b/src/Controllers/GeoPathController.php
@@ -125,7 +125,7 @@ class GeoPathController extends BaseController
             $this->ajaxErrorResponse("Cache not belong to logged user!", self::HTTP_STATUS_CONFLICT);
         }
 
-        if($cache->isPowerTrailPart()){
+        if($cache->isPowerTrailPart(TRUE)){
             $this->ajaxErrorResponse("Already part of GeoPath", self::HTTP_STATUS_CONFLICT);
         }
 


### PR DESCRIPTION
There was a bug which allow to add geocache to a few geopaths (but only if it previously belongs to non-active geopath).
Now this is fixed.