### PR TITLE
php-cs-fixer: change working mode and add diff format

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,29 +10,44 @@ jobs:
   php:
     name: PHP
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get changed files
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          list-files: shell
+          base: ${{ github.ref }}
+          filters: |
+            addedOrModified:
+              - added|modified: '**.php'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
         with:
           php-version: '7.2'
 
       - name: Get Composer cache directory path
         id: composer-cache-dir
+        if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
         run: |
           echo "::set-output name=path::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v2
+        if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
         with:
           path: ${{ steps.composer-cache-dir.outputs.path }}
           key: composer-${{ hashFiles('composer.lock') }}
           restore-keys: composer-
 
       - name: Install PHP-CS-Fixer
+        if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
         run: composer global require friendsofphp/php-cs-fixer:^2.18
 
       - name: Run PHP-CS-Fixer
-        run: composer global exec -- php-cs-fixer fix --dry-run --diff
+        if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
+        run: composer global exec -- php-cs-fixer fix --config=.php_cs --dry-run --diff --diff-format=udiff --path-mode=intersection ${{ steps.filter.outputs.addedOrModified_files }}


### PR DESCRIPTION
Currently a `php-cs-fixer` action checks every php file in repository, with exclusion of some predefined directories in `.php_cs`. While it is desirable to have a whole code compliant with PSR-12 etc., the experience shows that it won't be fulfilled maybe in years. Therefore I would like to change the action behaviour to check only `*.php` files added or modified in the push or pull request that triggered the action.
In addition the `diff-format=udiff` argument will be added to show line numbers in `php-cs-fixer` diff output. When the 3.0 version will be available, this argument most probably can be safely removed.

The proposed changes uses `dorny/paths-filter@v2` because from all tested solutions it worked the best.

The tests included creating new branch with several commits in one push, including adding, deleting and modifying files, and subsequent pushes with different commits to an existing branch. The pull-request scenario was not tested, I hope the action will work correctly in this case too.
There is a risk that pushes or pulls with a hundred or more changed `*.php` files will not work, because of too long variable/arguments line. The tests worked with a hundred of files, but each within a relative short path.