### PR TITLE
#2295: DB changes for reactivation rules implementation

### DIFF
--- a/config/geocache.default.php
+++ b/config/geocache.default.php
@@ -49,3 +49,16 @@ $geocache['titledCacheMinFounds'] = 10;
  */
 $geocache['coordsHiddenForNonLogged'] = true;
 
+/**
+ * If reactivation rules are enabled (present) in geocache editor
+ */
+$geocache['reactivationRulesEnabled'] = false;
+
+/**
+ * This has sense ONLY if option $geocache['reactivationRulesEnabled'] == true.
+ *
+ * List of the translation keys with predefined reactivation rules texts.
+ * Order of the keys here will be reflacted in the geocache editor.
+ * If the list is empty only custom (user defined) option will be active.
+ */
+$geocache['reactivationRulesPredefinedOpts'] = [];

--- a/editdesc.php
+++ b/editdesc.php
@@ -79,7 +79,7 @@ if ( $desc_record = XDb::xFetchArray($desc_rs) ) {
 
             XDb::xSql(
                 "UPDATE `cache_desc` SET
-                    `last_modified`=NOW(), `desc_html`= '2', `desc_htmledit`= '1',
+                    `last_modified`=NOW(), `desc_html`= '2',
                     `desc`= ?, `short_desc`= ?, `hint`= ?, `language`= ?
                 WHERE `id`= ? ",
                 $desc, $short_desc, nl2br($hints), $desclang, $descid);

--- a/newdesc.php
+++ b/newdesc.php
@@ -76,7 +76,7 @@ if (!$loggedUser) {
                         ", '', $cache_id);
 
                         //add to DB
-                        XDb::xSql("INSERT INTO `cache_desc` (`id`,`cache_id`,`language`,`desc`,`desc_html`,`desc_htmledit`,
+                        XDb::xSql("INSERT INTO `cache_desc` (`id`,`cache_id`,`language`,`desc`,`desc_html`,
                                                        `hint`,`short_desc`,`last_modified`,`uuid`,`node`,`rr_comment`)
                              VALUES ('', ?, ?, ?, 2, ?, ?, ?, NOW(), ?, ?, ?)",
                              $cache_id, $sel_lang, $desc, '1', nl2br($hints), $short_desc, $desc_uuid,

--- a/src/Models/GeoCache/GeoCacheDesc.php
+++ b/src/Models/GeoCache/GeoCacheDesc.php
@@ -20,7 +20,6 @@ class GeoCacheDesc extends BaseObject
     private $language="";
     private $desc="";
     private $desc_html=0;
-    private $desc_htmledit;
     private $hint = "";
     private $short_desc = "";
     private $date_created;
@@ -78,7 +77,6 @@ class GeoCacheDesc extends BaseObject
         $this->language = $descDbRow['language'];
         $this->desc = $descDbRow['desc'];
         $this->desc_html = $descDbRow['desc_html'];
-        $this->desc_htmledit = $descDbRow['desc_htmledit'];
         $this->hint = $descDbRow['hint'];
         $this->short_desc = $descDbRow['short_desc'];
         $this->date_created = $descDbRow['date_created'];

--- a/src/Models/OcConfig/GeocacheConfigTrait.php
+++ b/src/Models/OcConfig/GeocacheConfigTrait.php
@@ -51,6 +51,17 @@ trait GeocacheConfigTrait
         return self::getKeyFromGeoCacheConfig('coordsHiddenForNonLogged');
     }
 
+    public static function isReactivationRulesEnabled(): bool
+    {
+        return self::getKeyFromGeoCacheConfig('reactivationRulesEnabled');
+    }
+
+    public static function getReactivationRulesPredefinedOpts(): array
+    {
+        return self::getKeyFromGeoCacheConfig('reactivationRulesPredefinedOpts');
+    }
+
+
     protected function getGeoCacheConfig(): array
     {
         if (! $this->geocacheConfig) {

--- a/src/Utils/Database/Updates/106_reactivationRule.php
+++ b/src/Utils/Database/Updates/106_reactivationRule.php
@@ -1,0 +1,48 @@
+<?php
+
+// created on 2021-09-05 by kojoty
+
+namespace src\Utils\Database\Updates;
+
+class C1630794421576 extends UpdateScript
+{
+    public function getProperties()
+    {
+        return [
+            // see /docs/DbUpdate.md
+            'uuid' => '0BB2968A-26FF-720B-2D0F-1A96F556DC8A',
+            'run' => 'auto',
+        ];
+    }
+
+    // IMPORTANT:
+    // Any output by 'echo', 'print' etc. will be PUBLIC (see #1923).
+    // Do not output any sensitive information.
+
+    public function run()
+    {
+        // Insert your update code here, using $this->db for database access.
+
+        // Add comment to rr_comment column
+        $this->db->simpleQuery(
+            "ALTER TABLE `cache_desc` CHANGE `rr_comment` `rr_comment` TINYTEXT
+             COMMENT 'OcTeam notes displayed in geocache description'");
+
+        // Add new column for reactivation description
+        $this->db->simpleQuery(
+            "ALTER TABLE `cache_desc` ADD `reactivation_rule`
+                TINYTEXT
+                DEFAULT NULL
+                COMMENT 'Geocache reactivation rules defined by geocache user'
+                AFTER `rr_comment`");
+
+        // Drop unused column in cache decsr. table
+        $this->db->simpleQuery("ALTER TABLE `cache_desc` DROP `desc_htmledit`");
+
+        // The update will be run inside a transaction. It will also run
+        // with set_time_limit(0), so don't create any endless loops!
+    }
+
+};
+
+return new C1630794421576;


### PR DESCRIPTION
Changes:

- Add reactivation_rule column in cache desc. table in DB
- Remove unused desc_htmledit from cache_desc table + minor code changes
- Config default settings
