### PR TITLE
Don't escape implicit backslashes when string is single quoted

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -170,6 +170,7 @@ return (new PhpCsFixer\Config())
         'no_binary_string' => true,
         'simple_to_complex_string_variable' => true,
         'single_quote' => true,
+        'escape_implicit_backslashes' => ['single_quoted' => false],
 
         // Whitespace
         'array_indentation' => true,


### PR DESCRIPTION
This option should be default, but... it works differently.