### PR TITLE
PHP 8.1 mysql PDO driver compatibility improvement

### DIFF
--- a/src/Utils/Database/OcDb.php
+++ b/src/Utils/Database/OcDb.php
@@ -254,7 +254,7 @@ class OcDb extends OcPdo
 
         if ($row) {
             $value = reset($row);
-            if ($value == null) {
+            if (is_null($value)) {
                 return $default;
             } else {
                 return $value;


### PR DESCRIPTION
A small improvement to compatibility with PHP 8.1 mysql PDO driver, regarding to [PHP manual](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql):

> Integers and floats in result sets will now be returned using native PHP types instead of strings when using emulated prepared statements.

This should fix a problem with GeoCache ratingVotes not updating on PL node.