### PR TITLE
Prevents geopath multiple publishing, shows correctly status change after button click, fixes #1776

### DIFF
--- a/powerTrail/ajaxUpdateStatus.php
+++ b/powerTrail/ajaxUpdateStatus.php
@@ -1,87 +1,114 @@
 <?php
 
-use src\Utils\Database\OcDb;
-use src\Models\PowerTrail\PowerTrail;
-use src\Utils\Generators\Uuid;
 use src\Models\ApplicationContainer;
+use src\Models\PowerTrail\PowerTrail;
+use src\Utils\Database\OcDb;
+use src\Utils\Generators\Uuid;
 
-require_once __DIR__.'/../lib/common.inc.php';
+require_once __DIR__ . '/../lib/common.inc.php';
+
+$updateStatusResult = [
+    'updateStatusResult' => false,
+    'message' => '',
+];
 
 $loggedUser = ApplicationContainer::GetAuthorizedUser();
-if(!$loggedUser){
-    echo "User not authorized!";
-    exit;
-}
-$ptAPI = new powerTrailBase;
 
-$powerTrailId = (int) $_REQUEST['projectId'];
-$powerTrail = new PowerTrail(array('id' => $powerTrailId));
-$newStatus = (int) $_REQUEST['newStatus'];
-if(isset($_REQUEST['commentTxt'])) {
-    $commentText = htmlspecialchars($_REQUEST['commentTxt']);
-} else {
-    $commentText = false;
-}
+if ($loggedUser) {
+    $ptAPI = new powerTrailBase();
 
-// check if user is owner of selected power Trail
-if($ptAPI::checkIfUserIsPowerTrailOwner($loggedUser->getUserId(), $powerTrailId) == 1 ||
-    $loggedUser->hasOcTeamRole()) {
-    switch ($newStatus) {
-        case PowerTrail::STATUS_OPEN: // publish
-            $commentType = 3;
-            if(!$commentText) {
-                $commentText = tr('pt215').'!';
-            }
-            break;
-        case PowerTrail::STATUS_INSERVICE: // in service
-            $commentType = 4;
-            if(!$commentText) {
-                $commentText = tr('pt217').'!';
-            }
-            break;
-        case PowerTrail::STATUS_CLOSED: // permannet Closure
-            $commentType = 5;
-            if(!$commentText) {
-                $commentText = tr('pt218').'!';
-            }
-            break;
-        default:
-            $commentType = 1;
-            if(!$commentText) {
-                $commentText = tr('pt056').'!';
-            }
-            break;
+    $powerTrailId = (int) $_REQUEST['projectId'];
+    $powerTrail = new PowerTrail(['id' => $powerTrailId]);
+    $newStatus = (int) $_REQUEST['newStatus'];
+
+    if (isset($_REQUEST['commentTxt'])) {
+        $commentText = htmlspecialchars($_REQUEST['commentTxt']);
+    } else {
+        $commentText = false;
     }
 
-    // update geoPatch status
-    $updateStatusResult = $powerTrail->setAndStoreStatus($newStatus);
-    if($updateStatusResult['updateStatusResult'] === true){
-        $db = OcDb::instance();
-        // add comment
-        $query = 'INSERT INTO `PowerTrail_comments`
-                  (`userId`, `PowerTrailId`, `commentType`, `commentText`,
-                   `logDateTime`, `dbInsertDateTime`, `deleted`, uuid)
-                  VALUES (:1, :2, :3, :4, NOW(), NOW(), 0, '.Uuid::getSqlForUpperCaseUuid().' )';
+    // check if user is owner of selected power Trail
+    if (
+        $ptAPI::checkIfUserIsPowerTrailOwner(
+            $loggedUser->getUserId(),
+            $powerTrailId
+        ) == 1
+        || $loggedUser->hasOcTeamRole()
+    ) {
+        switch ($newStatus) {
+            case PowerTrail::STATUS_OPEN: // publish
+                $commentType = 3;
 
-        $db->multiVariableQuery($query, $loggedUser->getUserId(), $powerTrailId, $commentType,  $commentText );
-        // add action log
-        $logQuery = 'INSERT INTO `PowerTrail_actionsLog`(
-                        `PowerTrailId`, `userId`, `actionDateTime`, `actionType`, `description`, `cacheId`
-                        ) VALUES (:1,:2,NOW(),6,:3,:4)';
-        $db->multiVariableQuery($logQuery, $powerTrailId, $loggedUser->getUserId(), $ptAPI->logActionTypes[6]['type'], 0);
+                if (! $commentText) {
+                    $commentText = tr('pt215') . '!';
+                }
+                break;
+            case PowerTrail::STATUS_INSERVICE: // in service
+                $commentType = 4;
+
+                if (! $commentText) {
+                    $commentText = tr('pt217') . '!';
+                }
+                break;
+            case PowerTrail::STATUS_CLOSED: // permanent Closure
+                $commentType = 5;
+
+                if (! $commentText) {
+                    $commentText = tr('pt218') . '!';
+                }
+                break;
+            default:
+                $commentType = 1;
+
+                if (! $commentText) {
+                    $commentText = tr('pt056') . '!';
+                }
+                break;
+        }
+
+        // update geoPatch status
+        $updateStatusResult = $powerTrail->setAndStoreStatus($newStatus);
+
+        if ($updateStatusResult['updateStatusResult']) {
+            $db = OcDb::instance();
+            // add comment
+            $query = 'INSERT INTO `PowerTrail_comments`
+                (`userId`, `PowerTrailId`, `commentType`, `commentText`,
+                `logDateTime`, `dbInsertDateTime`, `deleted`, uuid)
+                VALUES (:1, :2, :3, :4, NOW(), NOW(), 0, '
+                . Uuid::getSqlForUpperCaseUuid()
+                . ' )';
+
+            $db->multiVariableQuery(
+                $query,
+                $loggedUser->getUserId(),
+                $powerTrailId,
+                $commentType,
+                $commentText
+            );
+            // add action log
+            $logQuery = 'INSERT INTO `PowerTrail_actionsLog`(
+                `PowerTrailId`, `userId`, `actionDateTime`, `actionType`,
+                `description`, `cacheId`
+                ) VALUES (:1,:2,NOW(),6,:3,:4)';
+            $db->multiVariableQuery(
+                $logQuery,
+                $powerTrailId,
+                $loggedUser->getUserId(),
+                $ptAPI->logActionTypes[6]['type'],
+                0
+            );
+        } else {
+            $updateStatusResult['message'] = tr('pt241');
+        }
     }
+
+    $updateStatusResult['currentStatus'] = $powerTrail->getStatus();
+    $updateStatusResult['currentStatusTranslation']
+        = $powerTrail->getStatusTranslation();
 } else {
-    $updateStatusResult = array (
-        'updateStatusResult' => false,
-        'message' => tr('pt241'),
-    );
+    $updateStatusResult['message'] = 'User not authorized!';
 }
 
-$updateStatusResult['currentStatus'] = $powerTrail->getStatus();
-$updateStatusResult['currentStatusTranslation'] = $powerTrail->getStatusTranslation();
-
-if ($updateStatusResult['updateStatusResult']) {
-    print $updateStatusResult['currentStatusTranslation'];
-} else {
-    print $updateStatusResult['message'];
-}
+header('Content-type: application/json');
+echo json_encode($updateStatusResult);

--- a/src/Models/PowerTrail/PowerTrail.php
+++ b/src/Models/PowerTrail/PowerTrail.php
@@ -614,7 +614,7 @@ class PowerTrail extends BaseObject
 
     public function setAndStoreStatus($status): array
     {
-        if ($status == self::STATUS_OPEN && $this->canBeOpened() === false) {
+        if ($status == self::STATUS_OPEN && ! $this->canBeOpened()) {
             $result = [
                 'updateStatusResult' => false,
                 'message' => tr('pt240'),

--- a/src/Models/PowerTrail/PowerTrail.php
+++ b/src/Models/PowerTrail/PowerTrail.php
@@ -2,54 +2,75 @@
 
 namespace src\Models\PowerTrail;
 
+use DateTime;
+use src\Models\BaseObject;
 use src\Models\Coordinates\Coordinates;
 use src\Models\GeoCache\Collection;
 use src\Models\GeoCache\GeoCache;
-use src\Models\BaseObject;
+use src\Models\OcConfig\OcConfig;
 use src\Models\User\User;
 use src\Utils\Debug\Debug;
-use src\Models\OcConfig\OcConfig;
 
 class PowerTrail extends BaseObject
 {
+    public const TYPE_GEODRAW = 1;
 
-    const TYPE_GEODRAW = 1;
-    const TYPE_TOURING = 2;
-    const TYPE_NATURE = 3;
-    const TYPE_THEMATIC = 4;
-    const STATUS_OPEN = 1;
-    const STATUS_UNAVAILABLE = 2;
-    const STATUS_CLOSED = 3;
-    const STATUS_INSERVICE = 4;
+    public const TYPE_TOURING = 2;
+
+    public const TYPE_NATURE = 3;
+
+    public const TYPE_THEMATIC = 4;
+
+    public const STATUS_OPEN = 1;
+
+    public const STATUS_UNAVAILABLE = 2;
+
+    public const STATUS_CLOSED = 3;
+
+    public const STATUS_INSERVICE = 4;
 
     private $id;
+
     private $name;
+
     private $image;
+
     private $type;
+
     private $centerCoordinates;
+
     private $status;
 
-    /* @var $dateCreated \DateTime */
+    /** @var DateTime */
     private $dateCreated;
+
     private $cacheCount;
+
     private $activeGeocacheCount = 0;
+
     private $archivedGeocacheCount = 0;
+
     private $unavailableGeocacheCount = 0;
+
     private $description;
+
     private $perccentRequired;
+
     private $conquestedCount;
+
     private $points;
 
-    /**
-     *  @var Collection
-     */
+    /** @var Collection */
     private $geocaches;
+
     private $owners = false;
+
     private $powerTrailConfiguration;
 
     public function __construct(array $params)
     {
         parent::__construct();
+
         if (isset($params['id'])) {
             $this->id = (int) $params['id'];
 
@@ -70,16 +91,17 @@ class PowerTrail extends BaseObject
     {
         if (is_null($fields)) {
             // default select all fields
-            $fields = "*";
+            $fields = '*';
         }
 
-        $ptq = "SELECT $fields FROM `PowerTrail` WHERE `id` = :1 LIMIT 1";
+        $ptq = "SELECT {$fields} FROM `PowerTrail` WHERE `id` = :1 LIMIT 1";
         $s = $this->db->multiVariableQuery($ptq, $this->id);
 
         if ($this->db->rowCount($s) != 1) {
-           //no such powertrail in DB?
-           $this->dataLoaded = false; //mark object as NOT containing data
-           return;
+            //no such powertrail in DB?
+            $this->dataLoaded = false; //mark object as NOT containing data
+
+            return;
         }
 
         $this->setFieldsByUsedDbRow($this->db->dbResultFetch($s));
@@ -96,7 +118,7 @@ class PowerTrail extends BaseObject
                     $this->name = $val;
                     break;
                 case 'image':
-                    if ($val === '') { /* no image was loaded by user, set default image */
+                    if ($val === '') { // no image was loaded by user, set default image
                         $val = '/images/blue/powerTrailGenericLogo.png';
                     }
                     $this->image = $val;
@@ -108,7 +130,7 @@ class PowerTrail extends BaseObject
                     $this->status = (int) $val;
                     break;
                 case 'dateCreated':
-                    $this->dateCreated = new \DateTime($val);
+                    $this->dateCreated = new DateTime($val);
                     break;
                 case 'cacheCount':
                     $this->cacheCount = (int) $val;
@@ -125,7 +147,6 @@ class PowerTrail extends BaseObject
                 case 'points':
                     $this->points = $val;
                     break;
-
                 case 'centerLatitude':
                 case 'centerLongitude':
                     // cords are handled below...
@@ -133,7 +154,7 @@ class PowerTrail extends BaseObject
                 case 'uuid': //uuid is not supportet yet
                     break;
                 default:
-                    Debug::errorLog("Unknown column: $key");
+                    Debug::errorLog("Unknown column: {$key}");
             }
         }
 
@@ -144,20 +165,20 @@ class PowerTrail extends BaseObject
         }
 
         $this->dataLoaded = true; //mark object as containing data
-
     }
 
-    public static function CheckForPowerTrailByCache($cacheId, $includeHiddenGeoPath=false)
+    public static function CheckForPowerTrailByCache($cacheId, $includeHiddenGeoPath = false)
     {
         $queryPt = 'SELECT `id`, `name`, `image`, `type` FROM `PowerTrail`
                     WHERE `id` IN
                         ( SELECT `PowerTrailId` FROM `powerTrail_caches` WHERE `cacheId` =:1 )';
 
-        if(!$includeHiddenGeoPath){
+        if (! $includeHiddenGeoPath) {
             $queryPt .= ' AND status = 1 ';
         }
 
         $s = self::db()->multiVariableQuery($queryPt, $cacheId);
+
         return self::db()->dbResultFetchAll($s);
     }
 
@@ -165,9 +186,7 @@ class PowerTrail extends BaseObject
     {
         $imgPath = '/images/blue/';
         $icon = '';
-        if ($typeId === null) {
-            $typeId = $this->type;
-        }
+
         switch ($typeId) {
             case self::TYPE_GEODRAW:
                 $icon = 'footprintRed.png';
@@ -182,6 +201,7 @@ class PowerTrail extends BaseObject
                 $icon = 'footprintYellow.png';
                 break;
         }
+
         return $imgPath . $icon;
     }
 
@@ -205,28 +225,26 @@ class PowerTrail extends BaseObject
         return self::GetPowerTrailIconsByType($this->type);
     }
 
-    /**
-     * @param \DateTime $dateCreated
-     */
-    public function setDateCreated(\DateTime $dateCreated)
+    public function setDateCreated(DateTime $dateCreated)
     {
         $this->dateCreated = $dateCreated;
+
         return $this;
     }
 
     public function getPowerTrailUrl()
     {
         $url = '/powerTrail.php?ptAction=showSerie&ptrail=';
+
         return $url . $this->id;
     }
 
     /**
-     * @return  Collection
+     * @return Collection
      */
     public function getGeocaches()
     {
-        if (!$this->geocaches->isReady()) {
-
+        if (! $this->geocaches->isReady()) {
             $query = 'SELECT pc.isFinal, c.*, u.username
                       FROM  powerTrail_caches AS pc
                         JOIN caches AS c ON c.cache_id = pc.cacheId
@@ -234,15 +252,16 @@ class PowerTrail extends BaseObject
                       WHERE pc.PowerTrailId = :1
                       ORDER BY c.name';
 
-
             $s = $this->db->multiVariableQuery($query, $this->id);
             $geoCachesDbResult = $this->db->dbResultFetchAll($s);
 
-            $geocachesIdArray = array();
+            $geocachesIdArray = [];
+
             foreach ($geoCachesDbResult as $geoCacheDbRow) {
                 $geocache = new GeoCache();
                 $geocache->loadFromRow($geoCacheDbRow)->setIsPowerTrailPart(true);
                 $geocache->setPowerTrail($this);
+
                 if ($geoCacheDbRow['isFinal'] == 1) {
                     $geocache->setIsPowerTrailFinalGeocache(true);
                 }
@@ -253,6 +272,7 @@ class PowerTrail extends BaseObject
             $this->geocaches->setGeocachesIdArray($geocachesIdArray);
             $this->caculateGeocachesCountByStatus();
         }
+
         return $this->geocaches;
     }
 
@@ -265,6 +285,7 @@ class PowerTrail extends BaseObject
 
         $s = $this->db->multiVariableQuery($query, $this->id);
         $ownerDb = $this->db->dbResultFetchAll($s);
+
         foreach ($ownerDb as $user) {
             $owner = new Owner($user);
             $owner->setPrivileages($user['privileages']);
@@ -313,7 +334,7 @@ class PowerTrail extends BaseObject
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getDateCreated()
     {
@@ -351,6 +372,7 @@ class PowerTrail extends BaseObject
     public function setPowerTrailConfiguration($powerTrailConfiguration)
     {
         $this->powerTrailConfiguration = $powerTrailConfiguration;
+
         return $this;
     }
 
@@ -359,20 +381,22 @@ class PowerTrail extends BaseObject
      */
     public function getOwners()
     {
-        if (!$this->owners) {
+        if (! $this->owners) {
             $this->loadPtOwners();
         }
+
         return $this->owners;
     }
 
     /**
      * check if specified user is owner of the powerTrail
-     * @param integer $userId
+     * @param int $userId
      * @return bool
      */
     public function isUserOwner($userId)
     {
         $owners = $this->getOwners();
+
         if (is_array($owners)) {
             foreach ($owners as $owner) {
                 if ($userId == $owner->getUserId()) {
@@ -380,13 +404,15 @@ class PowerTrail extends BaseObject
                 }
             }
         }
+
         return false;
     }
 
     public function getFoundCachsByUser($userId)
     {
-        $cachesFoundByUser = array();
+        $cachesFoundByUser = [];
         $sqlInStString = $this->buildSqlStringOfAllPtGeocachesId();
+
         if ($sqlInStString !== '') {
             $query = 'SELECT `cache_id` AS `geocacheId` FROM `cache_logs` WHERE `cache_id` in (' . $sqlInStString . ') AND `deleted` = 0 AND `user_id` = :1 AND `type` = "1" ';
             $s = $this->db->multiVariableQuery($query, (int) $userId);
@@ -406,9 +432,11 @@ class PowerTrail extends BaseObject
             WHERE `cache_id` IN (
                 SELECT `cacheId` FROM `powerTrail_caches` WHERE `PowerTrailId` =:1
             )',
-            $this->id);
+            $this->id
+        );
 
         $answer = $this->db->dbResultFetch($s);
+
         if ($answer['cacheCount'] != $this->cacheCount) {
             $updateQuery = 'UPDATE `PowerTrail` SET `cacheCount` =:1  WHERE `id` = :2 ';
             $this->db->multiVariableQuery($updateQuery, $answer['cacheCount'], $this->id);
@@ -425,7 +453,7 @@ class PowerTrail extends BaseObject
         if ($this->cacheCount < $this->getPtMinCacheCountLimit()) {
 //            $text .= tr('pt227').tr('pt228');
 
-            print '[test only] geoPath #<a href="powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id .' '. $this->name . ' </a> (geoPtah cache count=' . $this->cacheCount . ' is lower than minimum=' . $this->getPtMinCacheCountLimit() . ') <br/>';
+            echo '[test only] geoPath #<a href="powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id . ' ' . $this->name . ' </a> (geoPtah cache count=' . $this->cacheCount . ' is lower than minimum=' . $this->getPtMinCacheCountLimit() . ') <br/>';
 //            $db = OcDb::instance();
 //            $queryStatus = 'UPDATE `PowerTrail` SET `status`= :1 WHERE `id` = :2';
 //            $db->multiVariableQuery($queryStatus, 4, $pt['id']);
@@ -437,6 +465,7 @@ class PowerTrail extends BaseObject
         } else {
             $result = false;
         }
+
         return $result;
     }
 
@@ -450,6 +479,7 @@ class PowerTrail extends BaseObject
                 return $date['limit'];
             }
         }
+
         return false;
     }
 
@@ -458,22 +488,22 @@ class PowerTrail extends BaseObject
      */
     public function disableUncompletablePt($serverUrl)
     {
-
         $this->getGeocaches();
         $requiredGeocacheCount = $this->caclulateRequiredGeocacheCount();
 
         if ($this->perccentRequired < \src\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED) { // disable power trail witch too low percent required
-            print '<span style="color: orange"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id .' '. $this->name . '</a> will be put in service because too low perccentRequired. (Current Percent:' . $this->perccentRequired . ' Required: ' . \src\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED . ') [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
+            echo '<span style="color: orange"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id . ' ' . $this->name . '</a> will be put in service because too low perccentRequired. (Current Percent:' . $this->perccentRequired . ' Required: ' . \src\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED . ') [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
         }
 
         if ($this->activeGeocacheCount < $requiredGeocacheCount) {
             if ($this->archivedGeocacheCount > $requiredGeocacheCount) { // close powerTrail permanent
-                print '<span style="color: red"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id .' '. $this->name . '</a> will be closed permanently. Total cache count: ' . $this->cacheCount . ' / Active geocaches: ' . $this->activeGeocacheCount . ' / Required: ' . $requiredGeocacheCount . '. / Archived geocaches: ' . $this->archivedGeocacheCount . ' [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
+                echo '<span style="color: red"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id . ' ' . $this->name . '</a> will be closed permanently. Total cache count: ' . $this->cacheCount . ' / Active geocaches: ' . $this->activeGeocacheCount . ' / Required: ' . $requiredGeocacheCount . '. / Archived geocaches: ' . $this->archivedGeocacheCount . ' [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
 //              $text = tr('pt227').tr('pt234');
 //              ddd($text);
             }
+
             if ($this->unavailableGeocacheCount >= ($this->cacheCount - $requiredGeocacheCount)) { // disable powerTrail for service only
-                print '<span style="color: black"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id .' '. $this->name . '</a> will be put in service (uncompletable) Total cache count: ' . $this->cacheCount . ' / Active geocaches: ' . $this->activeGeocacheCount . ' / Required: ' . (($this->cacheCount * $this->perccentRequired) / 100) . '  / Archived geocaches: ' . $this->archivedGeocacheCount . ' [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
+                echo '<span style="color: black"> geoPath #<a href="' . $serverUrl . 'powerTrail.php?ptAction=showSerie&ptrail=' . $this->id . '">' . $this->id . ' ' . $this->name . '</a> will be put in service (uncompletable) Total cache count: ' . $this->cacheCount . ' / Active geocaches: ' . $this->activeGeocacheCount . ' / Required: ' . (($this->cacheCount * $this->perccentRequired) / 100) . '  / Archived geocaches: ' . $this->archivedGeocacheCount . ' [<a href="' . $serverUrl . '/powerTrailCOG.php?ptSelector=' . $this->id . '">cog link</a>]</span><br/>';
 //              $db->multiVariableQuery('UPDATE `PowerTrail` SET `status`= :1 WHERE `id` = :2', self::STATUS_INSERVICE, $this->id);
                 //$query = 'INSERT INTO `PowerTrail_comments`(`userId`, `PowerTrailId`, `commentType`, `commentText`, `logDateTime`, `dbInsertDateTime`, `deleted`) VALUES (-1, :1, 4, :2, NOW(), NOW(),0)';
                 $text = tr('pt227') . tr('pt234');
@@ -481,8 +511,10 @@ class PowerTrail extends BaseObject
                 // $db->multiVariableQuery($query, $pt['id'], $text);
                 //emailOwners($pt['id'], 4, date('Y-m-d H:i:s'), $text, 'newComment');
             }
+
             return true;
         }
+
         return false;
     }
 
@@ -502,14 +534,16 @@ class PowerTrail extends BaseObject
         $s = $this->db->multiVariableQuery($qr, $this->id, $userId);
         $powerTrailCacheLogsArr = $this->db->dbResultFetchAll($s);
 
-        $powerTrailCachesUserLogsByCache = array();
+        $powerTrailCachesUserLogsByCache = [];
+
         foreach ($powerTrailCacheLogsArr as $log) {
-            $powerTrailCachesUserLogsByCache[$log['cache_id']] = array(
+            $powerTrailCachesUserLogsByCache[$log['cache_id']] = [
                 'date' => $log['date'],
                 'text_html' => $log['text_html'],
                 'text' => $log['text'],
-            );
+            ];
         }
+
         return $powerTrailCachesUserLogsByCache;
     }
 
@@ -518,9 +552,11 @@ class PowerTrail extends BaseObject
         $this->getGeocaches();
         $geocachesIdArray = $this->geocaches->getGeocachesIdArray();
         $geocachesStr = '';
+
         foreach ($geocachesIdArray as $geocacheId) {
             $geocachesStr .= $geocacheId . ',';
         }
+
         return rtrim($geocachesStr, ',');
     }
 
@@ -529,6 +565,7 @@ class PowerTrail extends BaseObject
         $this->activeGeocacheCount = 0;
         $this->archivedGeocacheCount = 0;
         $this->unavailableGeocacheCount = 0;
+
         foreach ($this->geocaches as $geocache) {
             switch ($geocache->getStatus()) {
                 case GeoCache::STATUS_READY:
@@ -544,17 +581,17 @@ class PowerTrail extends BaseObject
         }
     }
 
-    function getActiveGeocacheCount()
+    public function getActiveGeocacheCount()
     {
         return $this->activeGeocacheCount;
     }
 
-    function getArchivedGeocacheCount()
+    public function getArchivedGeocacheCount()
     {
         return $this->archivedGeocacheCount;
     }
 
-    function getUnavailableGeocacheCount()
+    public function getUnavailableGeocacheCount()
     {
         return $this->unavailableGeocacheCount;
     }
@@ -571,64 +608,74 @@ class PowerTrail extends BaseObject
         $mySqlRequest = 'SELECT count(*) AS `ptConquestCount` FROM `PowerTrail_comments` WHERE `commentType` =2 AND `deleted` =0 AND `userId` =:1 AND `PowerTrailId` = :2';
         $s = $this->db->multiVariableQuery($mySqlRequest, $user->getUserId(), $this->getId());
         $mySqlResult = $this->db->dbResultFetch($s);
-        if ($mySqlResult['ptConquestCount'] > 0) {
-            return true;
-        } else {
-            return false;
-        }
+
+        return (bool) ($mySqlResult['ptConquestCount'] > 0);
     }
 
-    public function setAndStoreStatus($status)
+    public function setAndStoreStatus($status): array
     {
         if ($status == self::STATUS_OPEN && $this->canBeOpened() === false) {
-            $result = array(
+            $result = [
                 'updateStatusResult' => false,
-                'message' => tr('pt240')
-            );
+                'message' => tr('pt240'),
+            ];
         } else {
             $this->status = $status;
             $query = 'UPDATE `PowerTrail` SET `status` = :1 WHERE `PowerTrail`.`id` = :2 ';
             $this->db->multiVariableQuery($query, $status, $this->id);
-            $result = array(
+            $result = [
                 'updateStatusResult' => true,
-                'message' => tr('pt239')
-            );
+                'message' => tr('pt239'),
+            ];
         }
+
         return $result;
     }
 
     /**
-     *
      * Check if this power trail meet criteria to be opened
      *
      * Criteria:
      * - percent required > minimum percent required
      * - active geocahes Count >= required geocache count
      * - minimum geocaches count >= required geocaches count set in settings.inc.php
-     *
-     * @return boolean
      */
-    public function canBeOpened()
+    public function canBeOpened(): bool
     {
         $this->getGeocaches();
-        if ($this->perccentRequired < \src\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED) {
+
+        if ($this->status === self::STATUS_OPEN) {
             return false;
         }
-        if ($this->activeGeocacheCount < $this->caclulateRequiredGeocacheCount()) {
+
+        if (
+            $this->perccentRequired
+            < \src\Controllers\PowerTrailController::MINIMUM_PERCENT_REQUIRED
+        ) {
             return false;
         }
+
+        if (
+            $this->activeGeocacheCount
+            < $this->caclulateRequiredGeocacheCount()
+        ) {
+            return false;
+        }
+
         if ($this->activeGeocacheCount < OcConfig::geopathMinCacheCount()) {
             return false;
         }
-        if ($this->status === self::STATUS_CLOSED && !$this->getCurrentUser()->hasOcTeamRole()) {
-            return false;
-        }
-        return true;
+
+        return ! (
+            $this->status === self::STATUS_CLOSED
+            && ! $this->getCurrentUser()->hasOcTeamRole()
+        );
     }
 
     public function getStatusTranslation()
     {
         $statusTranslationArray = \src\Controllers\PowerTrailController::getPowerTrailStatus();
+
         return tr($statusTranslationArray[$this->status]['translate']);
     }
 }


### PR DESCRIPTION
Substantive changes:

- `powerTrail/ajaxUpdateStatus.php` returns correct JSON now instead of HTML,
- `src/Models/PowerTrail/PowerTrail.php`: `canBeOpened()` method additionally checks if geopath is published already

The rest of changes are minor logical fixes (like removing `this` in `static` method) and code style adjustments.

Remark: IMHO these files need a little deeper refactoring, but the whole geopath creation functionality is promised to be rewritten, so let it be as it is for now.