### PR TITLE
Fix #2423 Region from coordinates does not work

### DIFF
--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -1845,6 +1845,7 @@ $translations = [
     'region_03' => 'Region found by local data (NUTS)',
     'region_04' => 'Region found by Google Maps',
     'region_mapQuest' => 'Region found by MapQuest API',
+    'region_nominatim' => 'Region found by Nominatim (OpenStreetMap)',
 
     'cacheType_1' => 'Traditional',
     'cacheType_2' => 'Multicache',

--- a/region.php
+++ b/region.php
@@ -50,12 +50,12 @@ if (! is_null($coords)) {
         tpl_set_var('googleDesc', '-');
     }
 
-    $mapQuestGeoCode = GeoCode::fromMapQuestApi($coords);
+    $nominatimGeoCode = GeoCode::fromNominatimApi($coords);
 
-    if ($mapQuestGeoCode) {
-        tpl_set_var('mapQuestDesc', $mapQuestGeoCode->getDescription(' > '));
+    if ($nominatimGeoCode) {
+        tpl_set_var('nominatimDesc', $nominatimGeoCode->getDescription(' > '));
     } else {
-        tpl_set_var('mapQuestDesc', '-');
+        tpl_set_var('nominatimDesc', '-');
     }
 } else {
     tpl_set_var('coords_str', '');

--- a/src/Models/Coordinates/GeoCode.php
+++ b/src/Models/Coordinates/GeoCode.php
@@ -201,7 +201,7 @@ class GeoCode
 
         $context = stream_context_create([
             'http' => [
-                'header' => "User-Agent: Opencaching\r\n"
+                'header' => "User-Agent: ".OcConfig::getSiteName()."\r\n"
             ]
         ]);
 

--- a/src/Views/region.tpl.php
+++ b/src/Views/region.tpl.php
@@ -15,8 +15,8 @@
 </div>
 
 <div style="margin-top:4px;">
-    <font size="2" color="#000080"><b>{{region_mapQuest}}</b></font><br/>
-    {mapQuestDesc} <br/>
+    <font size="2" color="#000080"><b>{{region_nominatim}}</b></font><br/>
+    {nominatimDesc} <br/>
 </div>
 
 </p>


### PR DESCRIPTION
I reviewed free alternatives, but I didn’t find anything interesting.

* Nominatim 1 request/second
https://operations.osmfoundation.org/policies/nominatim/
https://nominatim.org/release-docs/3.6/api/Reverse/
https://nominatim.openstreetmap.org/reverse.php?lat=54&lon=18&zoom=6&format=jsonv2

* https://www.bigdatacloud.com/reverse-geocoding
Base Up to 50K queries /month FREE
Once you hit your monthly quota, the API will return errors until the start of the next month, unless you upgrade your package.

* https://developer.mapy.cz/en/rest-api-mapy-cz/function/geocoding/
250 000 credits free credits per month

* https://docs.locationiq.com/reference/reverse-api Free 5000 requests /day, 2 requests /second

I switched from MapQuest to Nominatim. It works fine for Poland, but I’m not sure about the rest. There are also other methods for determining the region, such as NUTS. NUTS doesn’t work locally for me.