### PR TITLE
Fix #2417 Email notification template - logo size 

### DIFF
--- a/lib/settingsDefault.inc.php
+++ b/lib/settingsDefault.inc.php
@@ -37,6 +37,11 @@ $config = array(
 
     /** main logo picture (to be placed in /images/) */
     'headerLogo' => 'oc_logo.png',
+    /**
+     * email logo picture (to be placed in /images/)
+     * if empty, the headerLogo will be used
+     */
+    'emailHeaderLogo' => '',
     /** main logo; winter version, displayed during december and january. */
     'headerLogoWinter' => 'oc_logo_winter.png',
     /** qrcode logo: show qrcode image and link the prefered way.  */

--- a/powerTrail/sendEmail.php
+++ b/powerTrail/sendEmail.php
@@ -71,7 +71,7 @@ class sendEmail
             $username = 'SYSTEM';
         }
 
-        $mailbody = mb_ereg_replace('{oclogo}', OcConfig::getHeaderLogo(), $mailbody);
+        $mailbody = mb_ereg_replace('{oclogo}', OcConfig::getEmailHeaderLogo(), $mailbody);
         $mailbody = mb_ereg_replace('{mail_auto_generated}', tr('mail_auto_generated'), $mailbody);
         $mailbody = mb_ereg_replace('{commentDateTime}', date($siteDateTimeFormat, strtotime($commentDateTime)), $mailbody);
         $mailbody = mb_ereg_replace('{userId}', $userId, $mailbody);

--- a/resources/email/ocHeader.email.html
+++ b/resources/email/ocHeader.email.html
@@ -7,7 +7,7 @@
 <table width="80%">
     <tr>
         <td align="center" width="80">
-            <a href="{server}"><img border="0" src="{server}images/{oc_logo}" alt="{short_sitename}"></a>
+            <a href="{server}"><img border="0" src="{server}images/{oc_logo}" alt="{short_sitename}" width="64px" style="width: 64px"></a>
             <br />
             <a href="{server}" style="font-size: 11px; font-family: Verdana;">{sitename}</a>
         </td>

--- a/src/Models/OcConfig/OcConfig.php
+++ b/src/Models/OcConfig/OcConfig.php
@@ -47,6 +47,8 @@ final class OcConfig extends ConfigReader
 
     private string $headerLogo;
 
+    private string $emailHeaderLogo;
+
     private int $needFindLimit;
 
     private int $needApproveLimit;
@@ -127,6 +129,7 @@ final class OcConfig extends ConfigReader
         $this->mapQuestKey = $config['maps']['mapQuestKey'];
         $this->dateFormat = $dateFormat;
         $this->headerLogo = $config['headerLogo'];
+        $this->emailHeaderLogo = !empty($config['emailHeaderLogo']) ? $config['emailHeaderLogo'] : $config['headerLogo'];
         $this->needApproveLimit = $NEED_APPROVE_LIMIT;
         $this->needFindLimit = $NEED_FIND_LIMIT;
         $this->minimumAge = $config['limits']['minimum_age'];
@@ -238,6 +241,11 @@ final class OcConfig extends ConfigReader
     public static function getHeaderLogo(): string
     {
         return self::instance()->headerLogo;
+    }
+
+    public function getEmailHeaderLogo(): string
+    {
+        return self::instance()->emailHeaderLogo;
     }
 
     public static function getNeedFindLimit(): int

--- a/src/Utils/Email/EmailFormatter.php
+++ b/src/Utils/Email/EmailFormatter.php
@@ -60,7 +60,7 @@ class EmailFormatter
         }
 
         $header->setVariable("server", OcConfig::getAbsolute_server_URI());
-        $header->setVariable("oc_logo", OcConfig::getHeaderLogo());
+        $header->setVariable("oc_logo", OcConfig::getEmailHeaderLogo());
         $header->setVariable("sitename", OcConfig::getSiteName());
         $header->setVariable("short_sitename", OcConfig::getSiteShortName());
         $header->setVariable("mail_header_hi", tr("mail_header_hi"));

--- a/src/Views/error/commonFatalError.tpl.php
+++ b/src/Views/error/commonFatalError.tpl.php
@@ -31,7 +31,7 @@
 <div id="container">
 
     <a href="/">
-      <img src="<?=$view->_mainLogo?>" alt="Opencaching logo">
+      <img src="<?=$view->_mainLogo?>" alt="Opencaching logo" style="width: 64px">
     </a>
     <h3>This is ERROR!</h3>
 


### PR DESCRIPTION
fix(#2417): Email notification template - logo size

Add support for separate logos for website and emails (e.g., SVG for website, PNG for email) via settings in lib/settings.inc.php. Added width property for email logo and updated commonFatalError.tpl.php.

lib/settings.inc.php
$config['headerLogo'] = '/icons/oc_logo.svg';
$config['emailHeaderLogo'] = '/oc_logo.png';