### PR TITLE
fix(#2434): prevent loading template on invalid editcache page access

### DIFF
--- a/editcache.php
+++ b/editcache.php
@@ -1162,9 +1162,9 @@ if ($cache_record = $dbc->dbResultFetch($s)) {
         tpl_set_var('reset', tr('reset'));
         tpl_set_var('submit', $submit);
     }
-    //TODO: not the owner
+    $view->redirect('/');
 }
-//TODO: cache not exist
+$view->redirect('/');
 
 unset($dbc);
 


### PR DESCRIPTION
Replaced TODO placeholders in `editcache.php` with `$view->redirect('/')` to handle cases where:
- the user is not the cache owner,
- the cache does not exist,
- or `/viewcache.php` is accessed without parameters.

This resolves "Undefined property: View::$geocache" ErrorException triggered in `common_tpl_funcs.php`.