### PR TITLE
(fix) ErrorException when accessing PowerTrail details by OCTeam

### DIFF
--- a/powerTrail.php
+++ b/powerTrail.php
@@ -11,6 +11,7 @@ use src\Models\OcConfig\OcConfig;
 use src\Models\PowerTrail\Log;
 use src\Models\PowerTrail\PowerTrail;
 use src\Models\User\User;
+use src\Utils\Debug\Debug;
 use src\Utils\I18n\I18n;
 use src\Utils\Text\Formatter;
 use src\Utils\Uri\OcCookie;
@@ -243,13 +244,23 @@ switch ($actionPerformed) {
         tpl_set_var('fullCountryMap', '1');
         break;
     case 'showSerie':
-        if (!isset($_GET['ptrail'])) {
+        if (!isset($_GET['ptrail']) || empty($_GET['ptrail']) || (is_numeric($_GET['ptrail']) && intval($_GET['ptrail']) > intval(PowerTrail::getMaxPowerTrailId()))) {
             // just redirect to all powertrails
             header('Location: ' . '//' . $_SERVER['HTTP_HOST'] . '/powerTrail.php');
 
             exit;
         }
         $powerTrail = new PowerTrail(['id' => (int)$_GET['ptrail']]);
+
+        if (empty($powerTrail->getName()) && empty($powerTrail->getType())) {
+            Debug::errorLog(sprintf(
+                "Power Trail does not exist or is incomplete. ID: %s",
+                $_GET['ptrail'] ?? '',
+            ));
+            header('Location: ' . '//' . $_SERVER['HTTP_HOST'] . '/powerTrail.php');
+            exit;
+        }
+
         $ptOwners = $pt->getPtOwners();
         $_SESSION['ptName'] = powerTrailBase::clearPtNames($powerTrail->getName());
         tpl_set_var('powerTrailId', $powerTrail->getId());
@@ -276,8 +287,8 @@ switch ($actionPerformed) {
             }
             tpl_set_var('ptStatusSelector', generateStatusSelector($powerTrail->getStatus()));
             tpl_set_var('removeCacheButtonDisplay', $removeCacheButtonDisplay);
-            tpl_set_var('leadingUserId', $leadingUser['user_id']);
-            tpl_set_var('leadingUserName', htmlspecialchars($leadingUser['username']));
+            tpl_set_var('leadingUserId', $leadingUser['user_id'] ?? '');
+            tpl_set_var('leadingUserName', htmlspecialchars($leadingUser['username'] ?? ''));
             tpl_set_var('fullCountryMap', '0');
             tpl_set_var('ptTypeName', tr($ptTypesArr[$powerTrail->getType()]['translate']));
             tpl_set_var('displaySelectedPowerTrail', 'block');
@@ -477,13 +488,15 @@ function displayPtOwnerList(PowerTrail $powerTrail)
     $ownerList = '';
     isset($_SESSION['user_id']) ? $userLogged = $_SESSION['user_id'] : $userLogged = -1;
     // @var $owner src\Models\PowerTrail\Owner
-    foreach ($ptOwners as $owner) {
-        $ownerList .= '<a href="viewprofile.php?userid=' . $owner->getUserId() . '">' . $owner->getUserName() . '</a>';
+    if($ptOwners){
+        foreach ($ptOwners as $owner) {
+            $ownerList .= '<a href="viewprofile.php?userid=' . $owner->getUserId() . '">' . $owner->getUserName() . '</a>';
 
-        if ($owner->getUserId() != $userLogged) {
-            $ownerList .= '<span style="display: none" class="removeUserIcon"><img onclick="ajaxRemoveUserFromPt(' . $owner->getUserId() . ')" src="images/free_icons/cross.png" width=10 title="' . tr('pt029') . '" alt="' . tr('pt029') . '"></span>, ';
-        } else {
-            $ownerList .= ', ';
+            if ($owner->getUserId() != $userLogged) {
+                $ownerList .= '<span style="display: none" class="removeUserIcon"><img onclick="ajaxRemoveUserFromPt(' . $owner->getUserId() . ')" src="images/free_icons/cross.png" width=10 title="' . tr('pt029') . '" alt="' . tr('pt029') . '"></span>, ';
+            } else {
+                $ownerList .= ', ';
+            }
         }
     }
     return substr($ownerList, 0, -2);

--- a/powerTrail/powerTrailController.php
+++ b/powerTrail/powerTrailController.php
@@ -1,5 +1,6 @@
 <?php
 
+use src\Utils\Cache\OcMemCache;
 use src\Utils\Database\OcDb;
 use src\Utils\Generators\Uuid;
 use src\Models\User\User;
@@ -212,6 +213,13 @@ class powerTrailController
             $logQuery = 'INSERT INTO `PowerTrail_actionsLog`(`PowerTrailId`, `userId`, `actionDateTime`, `actionType`, `description`) VALUES (:1,:2,NOW(),1,:3)';
             $db->multiVariableQuery($logQuery, $newProjectId, $this->user->getUserId(),
                 $this->ptAPI->logActionTypes[1]['type']);
+
+            OcMemCache::refreshAndReturn('PowerTrail:getMaxPowerTrailId', 60*60, function() {
+                $db = OcDb::instance();
+                $query = 'SELECT MAX(id) FROM PowerTrail';
+                return $db->simpleQueryValue($query, 0);
+            });
+
             header("location: powerTrail.php?ptAction=showSerie&ptrail=$newProjectId");
 
             return true;

--- a/src/Models/PowerTrail/PowerTrail.php
+++ b/src/Models/PowerTrail/PowerTrail.php
@@ -9,6 +9,7 @@ use src\Models\GeoCache\Collection;
 use src\Models\GeoCache\GeoCache;
 use src\Models\OcConfig\OcConfig;
 use src\Models\User\User;
+use src\Utils\Cache\OcMemCache;
 use src\Utils\Debug\Debug;
 
 class PowerTrail extends BaseObject
@@ -676,4 +677,13 @@ class PowerTrail extends BaseObject
 
         return tr($statusTranslationArray[$this->status]['translate']);
     }
+
+    public static function getMaxPowerTrailId()
+    {
+        return OcMemCache::getOrCreate('PowerTrail:getMaxPowerTrailId', 60 * 60, function() {
+            $query = 'SELECT MAX(id) FROM PowerTrail';
+            return self::db()->simpleQueryValue($query, 0);
+        });
+    }
+
 }


### PR DESCRIPTION
ErrorException: [/srv/ocpl/powerTrail.php:279] Trying to access array offset on false 
https://opencaching.pl/powerTrail.php?ptAction=showSerie&ptrail= 
https://opencaching.pl/powerTrail.php?ptAction=showSerie&ptrail=46 
https://opencaching.pl/powerTrail.php?ptAction=showSerie&ptrail=99999

- Added check for empty or invalid 'ptrail' parameter to prevent error when accessing PowerTrail details.
- Handled missing 'leadingUser' and 'ptOwners' for PowerTrail 46 and other cases.