### PR TITLE
(fix) Fix adding entries to `caches_additions` for new caches

### DIFF
--- a/src/Models/GeoCache/GeoCache.php
+++ b/src/Models/GeoCache/GeoCache.php
@@ -1753,7 +1753,7 @@ class GeoCache extends GeoCacheCommons
     {
         $oldAltitude = $this->getAltitude();
 
-        if ($oldAltitude != $newAltitude) {
+        if ($oldAltitude != $newAltitude || $newAltitude === null) {
             $this->cacheAddtitions->updateAltitude($newAltitude);
         }
     }

--- a/src/Utils/Database/Updates/108_add_caches_without_altitude_to_caches_additions.php
+++ b/src/Utils/Database/Updates/108_add_caches_without_altitude_to_caches_additions.php
@@ -1,0 +1,46 @@
+<?php
+
+// created on 2025-01-18 by stefan1214/stefopl
+
+namespace src\Utils\Database\Updates;
+
+class C17372103015411 extends UpdateScript
+{
+    public function getProperties()
+    {
+        return [
+            // see /docs/DbUpdate.md
+            'uuid' => '05D20C85-ECDC-E743-7B6B-0FDB81FADE42',
+            'run' => 'manual',
+        ];
+    }
+
+    // IMPORTANT:
+    // Any output by 'echo', 'print' etc. will be PUBLIC (see #1923).
+    // Do not output any sensitive information.
+
+    public function run()
+    {
+        // Insert your update code here, using $this->db for database access.
+
+        // The update will be run inside a transaction. It will also run
+        // with set_time_limit(0), so don't create any endless loops!
+
+        $this->db->simpleQuery(
+            "INSERT INTO caches_additions (cache_id, altitude) SELECT c.cache_id, NULL FROM caches c LEFT JOIN caches_additions ca ON c.cache_id = ca.cache_id WHERE ca.cache_id IS NULL"
+        );
+
+    }
+
+    public function rollback()
+    {
+        // If possible and feasible, provide code here which reverses the
+        // changes made by run(). Otherwiese please REMOVE the rollback method.
+        // This will disable the "rollback" action on the Admin.DbUpdate page.
+
+        // The rollback will be run inside a transaction. It will also run
+        // with set_time_limit(0), so don't create any endless loops!
+    }
+};
+
+return new C17372103015411;

--- a/src/Utils/Database/Updates/108_add_caches_without_altitude_to_caches_additions.php
+++ b/src/Utils/Database/Updates/108_add_caches_without_altitude_to_caches_additions.php
@@ -11,7 +11,7 @@ class C17372103015411 extends UpdateScript
         return [
             // see /docs/DbUpdate.md
             'uuid' => '05D20C85-ECDC-E743-7B6B-0FDB81FADE42',
-            'run' => 'manual',
+            'run' => 'auto',
         ];
     }
 


### PR DESCRIPTION
Updated the `updateAltitude` method to correctly add a `NULL` `altitude` entry to `caches_additions` for new caches. 
Added a database update to insert missing entries into `caches_additions` for caches without altitude.