### PR TITLE
(quick fix) Connection timed out Models/Coordinates/Altitude.php:125

### DIFF
--- a/src/Controllers/Cron/Jobs/AltitudeUpdateJob.php
+++ b/src/Controllers/Cron/Jobs/AltitudeUpdateJob.php
@@ -47,6 +47,7 @@ class AltitudeUpdateJob extends Job
                     continue;
                 }
                 $geocache->updateAltitude($altitude);
+                sleep(1);
             }
         } // for
     }


### PR DESCRIPTION
Add delay to prevent exceeding OpenTopoData API rate limit