### PR TITLE
Fix #2489 #2490 #2491 #2492  #2493 

### DIFF
--- a/editcache.php
+++ b/editcache.php
@@ -125,20 +125,21 @@ if ($cache_record = $dbc->dbResultFetch($s)) {
         $cache_attrib_pic = '<img id="attr{attrib_id}" src="{attrib_pic}" border="0" alt="{attrib_text}" title="{attrib_text}" onmousedown="toggleAttr({attrib_id}); yes_change();" /> ';
 
         $activation_form = '
-        <tr><td colspan="2">
-        <fieldset style="border: 1px solid black; width: 80%; height: 32%; background-color: #FFFFFF;">
-            <legend>&nbsp; <strong>' . tr('submit_new_cache') . '</strong> &nbsp;</legend>
+        <tr class="form-group-sm">
+          <td colspan="2">
+             <fieldset style="border: 1px solid black; width: 80%; height: 32%; background-color: #FFFFFF;">
+                <legend>&nbsp; <strong>' . tr('submit_new_cache') . '</strong> &nbsp;</legend>
                 <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_now" value="now" {publish_now_checked}>&nbsp;<label for="publish_now">' . tr('publish_now') . '</label><br />
                 <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_later" value="later" {publish_later_checked}>&nbsp;<label for="publish_later">' . tr('publish_date') . ':</label>
-                <input class="input40" type="text" name="activate_year" onChange="yes_change();" maxlength="4" value="{activate_year}"/> -
-                                <input class="input20" type="text" name="activate_month" onChange="yes_change();" maxlength="2" value="{activate_month}"/> -
-                <input class="input20" type="text" name="activate_day" onChange="yes_change();" maxlength="2" value="{activate_day}"/>&nbsp;
-                                <select name="activate_hour" class="input40" onChange="yes_change();" >
-                    {activation_hours}
+                <input type="text" class="form-control" id="activateDatePicker" id="activateDatePicker" value="{activate_year}-{activate_month}-{activate_day}" onchange="hiddenDatePickerChange(\'activate\'); selectPublishLater()"/>
+                <input class="input40" type="hidden" name="activate_year" id="activate_year" onChange="yes_change();" maxlength="4" value="{activate_year}"/>
+                <input class="input20" type="hidden" name="activate_month" id="activate_month" onChange="yes_change();" maxlength="2" value="{activate_month}"/>
+                <input class="input20" type="hidden" name="activate_day" id="activate_day" onChange="yes_change();" maxlength="2" value="{activate_day}"/>&nbsp;
+                <select name="activate_hour" class="form-control input70" onChange="yes_change();" >{activation_hours}
                 </select>&nbsp;–&nbsp;{activate_on_message}<br />
                 <input type="radio" onChange="yes_change();" class="radio" name="publish" id="publish_notnow" value="notnow" {publish_notnow_checked}>&nbsp;<label for="publish_notnow">' . tr('dont_publish_yet') . '</label>
-                </fieldset>
-                </td>
+              </fieldset>
+            </td>
         </tr>
         ';
 
@@ -951,9 +952,9 @@ if ($cache_record = $dbc->dbResultFetch($s)) {
 
             for ($i = 0; $i <= 23; $i++) {
                 if ($cache_activate_hour == $i) {
-                    $activation_hours .= '<option value="' . $i . '" selected="selected">' . $i . '</options>';
+                    $activation_hours .= '<option value="' . $i . '" selected="selected">' . $i . ':00</options>';
                 } else {
-                    $activation_hours .= '<option value="' . $i . '">' . $i . '</options>';
+                    $activation_hours .= '<option value="' . $i . '">' . $i . ':00</options>';
                 }
                 $activation_hours .= "\n";
             }
@@ -962,7 +963,7 @@ if ($cache_record = $dbc->dbResultFetch($s)) {
             if ($activate_date_not_ok) {
                 $tmp = mb_ereg_replace('{activate_on_message}', $date_not_ok_message, $tmp);
             } else {
-                $tmp = mb_ereg_replace('{activate_on_message}', '', $tmp);
+                $tmp = mb_ereg_replace('{activate_on_message}', tr('newcacheDateFormat'), $tmp);
             }
 
             tpl_set_var('activation_form', $tmp);
@@ -1175,6 +1176,7 @@ unset($dbc);
 $view->loadJQuery();
 //make the template and send it out
 tpl_set_tplname('editcache');
+tpl_set_var('language4js', I18n::getCurrentLang());
 tpl_BuildTemplate();
 
 /**

--- a/newcache.php
+++ b/newcache.php
@@ -73,11 +73,18 @@ $num_caches = $record['num_caches'];
 $cacheLimitByTypePerUser = GeoCache::getUserActiveCachesCountByType($loggedUser->getUserId());
 
 if ($num_caches < OcConfig::getNeedApproveLimit()) {
-    // user needs approvement for first 3 caches to be published
-    $needs_approvement = true;
-    tpl_set_var('hide_publish_start', '<!--');
-    tpl_set_var('hide_publish_end', '-->');
-    tpl_set_var('approvement_note', '<div class="notice errormsg">' . tr('first_cache_approvement') . '</div>');
+    if($loggedUser->getNewCachesNoLimit()){
+        $needs_approvement = false;
+        tpl_set_var('hide_publish_start', '');
+        tpl_set_var('hide_publish_end', '');
+        tpl_set_var('approvement_note', '');
+    }else{
+        // user needs approvement for first 3 caches to be published
+        $needs_approvement = true;
+        tpl_set_var('hide_publish_start', '<!--');
+        tpl_set_var('hide_publish_end', '-->');
+        tpl_set_var('approvement_note', '<div class="notice errormsg">' . tr('first_cache_approvement') . '</div>');
+    }
 } elseif ($loggedUser->getVerifyAll()) {
     $needs_approvement = true;
     tpl_set_var('hide_publish_start', '<!--');

--- a/public/css/style_screen.css
+++ b/public/css/style_screen.css
@@ -1453,6 +1453,10 @@ tr.geoKretLog {
     display: none;
 }
 
+#wptInfoCont{
+  min-height: 22px;
+}
+
 /* Dark Mode Styles Start */
 #theme-switcher{
   display: none;

--- a/src/Models/Admin/Report.php
+++ b/src/Models/Admin/Report.php
@@ -466,8 +466,12 @@ class Report extends BaseObject
         if ($this->userIdLeader == $this->userIdLastChange) { // Assign report to yourself
             $this->sendWatchEmails($logId);
         } else { // Assign report to other user
-            ReportEmailSender::sendReportNewLeader($this, $this->getUserLeader());
-            $this->sendWatchEmails($logId, [ $this->userIdLeader ]);
+            if($this->getUserLeader()->getUserId() !== ReportCommons::USER_NOBODY){
+                ReportEmailSender::sendReportNewLeader($this, $this->getUserLeader());
+            }
+            if($this->userIdLeader !== ReportCommons::USER_NOBODY){
+                $this->sendWatchEmails($logId, [ $this->userIdLeader ]);
+            }
         }
         if (! $this->isReportWatched($oldLeaderId) && ! is_null($oldLeaderId)) { // If previeous leader don't watch this report - inform him anyway
             ReportEmailSender::sendReportWatch($this, new User(['userId' => $oldLeaderId]), $logId);

--- a/src/Views/editcache.tpl.php
+++ b/src/Views/editcache.tpl.php
@@ -251,7 +251,33 @@ use src\Utils\Uri\SimpleRouter;
             window.open('<?= SimpleRouter::getLink(MainMapController::class, 'fullscreen'); ?>?circle&lat='+lat+'&lon='+lon); }
         return false;
     }
+
+    // data picker init
+    $(function() {
+        $.datepicker.setDefaults($.datepicker.regional['pl']);
+        $('#hiddenDatePicker, #activateDatePicker').datepicker (
+            $.datepicker.regional["{language4js}"]
+        ).datepicker("option", "dateFormat", "yy-mm-dd").val();
+    });
+
+    function hiddenDatePickerChange(identifier){
+        var dateTimeStr = $('#' + identifier + 'DatePicker').val();
+        var dateArr = dateTimeStr.split("-");
+        $("#" + identifier + "_year").val(dateArr[0]);
+        $("#" + identifier + "_month").val(dateArr[1]);
+        $("#" + identifier + "_day").val(dateArr[2]);
+    }
+
+    function selectPublishLater(){
+        $("#publish_later").prop("checked", true);
+    }
 </script>
+
+<style>
+  #hiddenDatePicker, #activateDatePicker{
+    width: 75px;
+  }
+</style>
 
 <form action="editcache.php" method="post" enctype="application/x-www-form-urlencoded" name="editcache_form" dir="ltr">
     <input type="hidden" name="cacheid" value="{cacheid}"/>

--- a/src/Views/newcache.tpl.php
+++ b/src/Views/newcache.tpl.php
@@ -86,6 +86,10 @@ $view->callChunk('tinyMCE');
         $("#" + identifier + "_day").val(dateArr[2]);
     }
 
+    function selectPublishLater(){
+        $("#publish_later").prop("checked", true);
+    }
+
     function checkRegion(){
         console.log('checkRegion');
 
@@ -931,7 +935,7 @@ $(document).ready(function(){
                     <legend>&nbsp; <strong>{{submit_new_cache}}</strong> &nbsp;</legend>
                     <input type="radio" class="radio" name="publish" id="publish_now" value="now" {publish_now_checked}/>&nbsp;<label for="publish_now">{{publish_now}}</label><br />
                     <input type="radio" class="radio" name="publish" id="publish_later" value="later" {publish_later_checked}/>&nbsp;<label for="publish_later">{{publish_date}}:</label>
-                    <input type="text" class="form-control" id="activateDatePicker" id="activateDatePicker" value="{activate_year}-{activate_month}-{activate_day}" onchange="hiddenDatePickerChange('activate');"/>
+                    <input type="text" class="form-control" id="activateDatePicker" value="{activate_year}-{activate_month}-{activate_day}" onchange="hiddenDatePickerChange('activate'); selectPublishLater();"/>
                     <input class="input40" type="hidden" name="activate_year"  id="activate_year"  value="{activate_year}"/>
                     <input class="input20" type="hidden" name="activate_month" id="activate_month" value="{activate_month}"/>
                     <input class="input20" type="hidden" name="activate_day"   id="activate_day"   value="{activate_day}"/>&nbsp;

--- a/src/Views/newcache.tpl.php
+++ b/src/Views/newcache.tpl.php
@@ -14,7 +14,8 @@ $view->callChunk('tinyMCE');
         $("#waypointsToChose").dialog({
             position: { my: "top+150", at: "top", of: window },
             autoOpen: false,
-            width: 500,
+            width: '100%',
+            maxWidth: 500,
             modal: true,
             show: {effect: 'bounce', duration: 350, /* SPECIF ARGUMENT */ times: 3},
             hide: "explode",
@@ -143,7 +144,6 @@ $view->callChunk('tinyMCE');
     var maAttributes = new Array({jsattributes_array});
 
     function startUpload(){
-      $('#f1_upload_form').hide();
       $('#ajaxLoaderLogo').show();
       return true;
     }
@@ -152,7 +152,6 @@ $view->callChunk('tinyMCE');
 
     function stopUpload(response){
         $('#ajaxLoaderLogo').hide();
-        $('#f1_upload_form').show();
         $('#wptInfo').html(response['status']['msg']);
         $('#wptInfo').removeClass('errormsg successmsg');
         if (response['status']['code'] == 0) {
@@ -583,13 +582,14 @@ $(document).ready(function(){
             <p class="content-title-noshade">{{newcache_import_wpt}}</p>
         </td>
         <td>
-            <div id="wptInfo" style="display: none;"></div>
-            <p id="f1_upload_form"><br/></p>
+            <div id="wptInfoCont">
+              <span id="wptInfo" style="display: none;"></span>
+            </div>
             <div class="form-inline">
                 <?php $view->callChunk('fileUpload', 'myfile', '.gpx'); ?>
                 <input id="gpxUpload" class="btn btn-primary btn-sm btn-upload" type="button" value="<?= tr('newcache_upload'); ?>"/>
+                <img style="display: none" id="ajaxLoaderLogo" src="images/misc/ptPreloader.gif" alt="">
             </div>
-            <img style="display: none" id="ajaxLoaderLogo" src="images/misc/ptPreloader.gif" alt="">
         </td>
     </tr>
     <tr>

--- a/src/Views/newcache.tpl.php
+++ b/src/Views/newcache.tpl.php
@@ -474,6 +474,19 @@ $view->callChunk('tinyMCE');
     return cnt;
     }
 
+    document.addEventListener("DOMContentLoaded", function () {
+        const input = document.getElementById("myfile");
+        if (input) {
+            input.addEventListener("change", function () {
+                if (input.files && input.files.length > 0) {
+                    const uploadButton = document.getElementById("gpxUpload");
+                    if (uploadButton) {
+                        uploadButton.click();
+                    }
+                }
+            });
+        }
+    });
 
 </script>
 <script>


### PR DESCRIPTION
- (fix) Correctly use selected waypoint's desc in GPX import (fix #2489) 
  - Descriptions were incorrectly taken from the first wpt element. Added fallback to use cmt if desc is empty.
- (feature) Streamline GPX import on new cache page (fix #2490)
- (fix) New cache - import GPX - status information makes page jump (fix #2491)
Commits on Apr 6, 2025
- (feature) New cache page - publish on field (fix #2492) 
  - Added onchange for the publish on date input to automatically check the publish_later radio button.
  - For users with the newCachesNoLimit option, the publish form is now displayed without approval requirements for the first 3 caches.
- (feature) Consistent publish on fields for "new cache" and "edit cache" pages (fix #2493)
- (fix) Prevent empty email recipient errors when assigning report to USER_NOBODY