### PR TITLE
(fix) Simplify login page during OKAPI OAuth flow

### DIFF
--- a/public/views/userAuth/userAuth.css
+++ b/public/views/userAuth/userAuth.css
@@ -7,6 +7,9 @@
 	font-weight: bold;
 	text-align: right;
 }
+.loginInput {
+	max-width: calc(100vw - 170px - 30px)
+}
 
 label {
 	font-size: 12px;

--- a/src/Controllers/PageLayout/MainLayoutController.php
+++ b/src/Controllers/PageLayout/MainLayoutController.php
@@ -90,6 +90,9 @@ class MainLayoutController extends BaseController
         $this->view->setVar('_backgroundSeason', $this->view->getSeasonCssName());
 
         $this->view->setVar('_showVideoBanner', $this->view->showVideoBanner());
+        $this->view->setVar('_hideTopLoginForm', $this->view->hideTopLoginForm());
+        $this->view->setVar('_hideTopNavAndMainMenu', $this->view->hideTopNavAndMainMenu());
+        $this->view->setVar('_responsiveModeEnabled', $this->view->responsiveModeEnabled());
 
         if ($this->view->showVideoBanner()) {
             $this->view->setVar('_topBannerTxt', $this->ocConfig->getTopBannerTxt());

--- a/src/Utils/View/View.php
+++ b/src/Utils/View/View.php
@@ -305,6 +305,30 @@ class View
         return $this->_showVideoBannerState;
     }
 
+    public function hideTopLoginForm()
+    {
+        if (self::mobile()) {
+            return true;
+        }
+        return false;
+    }
+
+    public function hideTopNavAndMainMenu()
+    {
+        if (self::mobile()) {
+            return true;
+        }
+        return false;
+    }
+
+    public function responsiveModeEnabled()
+    {
+        if (self::mobile()) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @return boolean - true if the view should be optimized for mobile devices
      */

--- a/src/Views/common/main.tpl.php
+++ b/src/Views/common/main.tpl.php
@@ -7,7 +7,7 @@ $view->addHeaderChunk('darkmodeJS');
 
 ?>
 <!DOCTYPE html>
-<html lang="<?= $view->getLang(); ?>">
+<html lang="<?= $view->getLang(); ?>" <?= $view->responsiveModeEnabled() ? 'class="responsive-enabled"' : '' ?>>
 <head>
   <meta charset="utf-8">
 
@@ -160,19 +160,21 @@ $view->addHeaderChunk('darkmodeJS');
               </a>
             </div>
           <?php } else { //user-not-logged?>
-            <form action="<?= _SimpleRouter::getLink('UserAuthorization', 'login'); ?>" method="post" name="login" class="form-group-sm">
-              <label for="top-form-email" class="btn btn-sm btn-default btn-right-straight">
-                <img src="/images/misc/user.svg" class="icon16" alt="<?= tr('loginForm_userOrEmail'); ?>" title="<?= tr('loginForm_userOrEmail'); ?>">
-              </label>
-              <input name="email" id="top-form-email" type="text" class="form-control input120 btn-left-straight" value="" autocomplete="username" placeholder="<?= tr('loginForm_userOrEmail'); ?>" required>
-              <label for="top-form-password" class="btn btn-sm btn-default btn-right-straight">
-                <img src="/images/misc/key.svg" class="icon16" alt="<?= tr('loginForm_password'); ?>" title="<?= tr('loginForm_password'); ?>">
-              </label>
-              <input name="password" id="top-form-password" type="password" class="form-control input120 btn-left-straight" value="" autocomplete="current-password" placeholder="<?= tr('loginForm_password'); ?>" required>
-              <input type="hidden" name="target" value="<?= $view->_target; ?>">
-              <input type="submit" value="<?= tr('login'); ?>" class="btn btn-primary btn-sm">
-              <a href="<?= _SimpleRouter::getLink('UserRegistration'); ?>" class="btn btn-success btn-sm"><?= tr('registration'); ?></a>
-            </form>
+            <?php if (! $view->_hideTopLoginForm) { ?>
+                <form action="<?= _SimpleRouter::getLink('UserAuthorization', 'login'); ?>" method="post" name="login" class="form-group-sm">
+                  <label for="top-form-email" class="btn btn-sm btn-default btn-right-straight">
+                    <img src="/images/misc/user.svg" class="icon16" alt="<?= tr('loginForm_userOrEmail'); ?>" title="<?= tr('loginForm_userOrEmail'); ?>">
+                  </label>
+                  <input name="email" id="top-form-email" type="text" class="form-control input120 btn-left-straight" value="" autocomplete="username" placeholder="<?= tr('loginForm_userOrEmail'); ?>" required>
+                  <label for="top-form-password" class="btn btn-sm btn-default btn-right-straight">
+                    <img src="/images/misc/key.svg" class="icon16" alt="<?= tr('loginForm_password'); ?>" title="<?= tr('loginForm_password'); ?>">
+                  </label>
+                  <input name="password" id="top-form-password" type="password" class="form-control input120 btn-left-straight" value="" autocomplete="current-password" placeholder="<?= tr('loginForm_password'); ?>" required>
+                  <input type="hidden" name="target" value="<?= $view->_target; ?>">
+                  <input type="submit" value="<?= tr('login'); ?>" class="btn btn-primary btn-sm">
+                  <a href="<?= _SimpleRouter::getLink('UserRegistration'); ?>" class="btn btn-success btn-sm"><?= tr('registration'); ?></a>
+                </form>
+            <?php } ?>
           <?php } //user-not-logged?>
 
         </div>
@@ -228,90 +230,50 @@ $view->addHeaderChunk('darkmodeJS');
       <!-- HEADER -->
 
                 <!-- Navigation - horizontal menu bar -->
-                <div id="nav2">
+                <?php if (!$view->hideTopNavAndMainMenu()) { ?>
+                  <div id="nav2">
                     <ul class="rythm_nav2">
-                        <?php foreach ($view->_menuBar as $key => $url) { ?>
-                          <?php if (is_array($url)) { //array="open in new window"?>
-                            <li><a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
-                          <?php } else { ?>
-                            <li><a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
-                          <?php } ?>
-                        <?php } //foreach _menuBar?>
+                      <?php foreach ($view->_menuBar as $key => $url) { ?>
+                        <?php if (is_array($url)) { //array="open in new window"?>
+                        <li><a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a></li>
+                        <?php } else { ?>
+                        <li><a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a></li>
+                        <?php } ?>
+                      <?php } //foreach _menuBar?>
                     </ul>
-                </div>
+                  </div>
+                <?php } ?>
 
                 <!-- Buffer after header -->
                 <div class="buffer" style="height:20px;"></div>
 
                 <!-- NAVIGATION -->
                 <!-- Navigation Left menu -->
+                <?php if(! $view->hideTopNavAndMainMenu()){ ?>
+                  <div id="nav3">
+                    <?php if (!$view->_isUserLogged) { ?>
+                      <!-- non-authorized user menu -->
+                      <ul class="rythm_nav3MainMenu">
+                        <li class="title"><?= tr('main_menu'); ?></li>
 
-                <div id="nav3">
-                    <?php if (! $view->_isUserLogged) { ?>
-                    <!-- non-authorized user menu -->
-                    <ul class="rythm_nav3MainMenu">
-                      <li class="title"><?= tr('main_menu'); ?></li>
+                          <?php foreach ($view->_nonAuthUserMenu as $key => $url) { ?>
+                            <li class="group">
+                                <?php if (is_array($url)) { //array="open in new window"?>
+                                  <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
+                                <?php } else { // !is_array($url)?>
+                                  <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
+                                <?php } // if-is_array($url)?>
+                            </li>
+                          <?php } //foreach?>
 
-                      <?php foreach ($view->_nonAuthUserMenu as $key => $url) { ?>
-                        <li class="group">
-                            <?php if (is_array($url)) { //array="open in new window"?>
-                              <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
-                            <?php } else { // !is_array($url)?>
-                              <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
-                            <?php } // if-is_array($url)?>
-                        </li>
-                      <?php } //foreach?>
+                      </ul>
 
-                    </ul>
+                    <?php } else { //if-_isUserLogged?>
 
-                <?php } else { //if-_isUserLogged?>
-
-                    <!-- authorized menu -->
-                    <ul class="rythm_nav3MainMenu">
-                      <li class="title"><?= tr('main_menu'); ?></li>
-                      <?php foreach ($view->_authUserMenu as $key => $url) { ?>
-                        <li class="group">
-                            <?php if (is_array($url)) { //array="open in new window"?>
-                              <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
-                            <?php } else { // !is_array($url)?>
-                              <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
-                            <?php } // if-is_array($url)?>
-                        </li>
-                      <?php } //foreach?>
-                    </ul>
-
-                    <!-- custom user menu -->
-                    <ul class="rythm_nav3UserMenu">
-                      <li class="title"><?= tr('user_menu'); ?></li>
-                      <?php foreach ($view->_customUserMenu as $key => $url) { ?>
-                        <li class="group">
-                            <a href="<?= $url; ?>">
-                              <?= $key; ?>
-                            </a>
-                        </li>
-                      <?php } //foreach?>
-                    </ul>
-
-
-                    <!-- additional menu -->
-                    <ul class="rythm_nav3AddsMenu">
-                      <li class="title"><?= tr('mnu_additionalMenu'); ?></li>
-                      <?php foreach ($view->_additionalMenu as $key => $url) { ?>
-                        <li class="group">
-                            <?php if (is_array($url)) { //array="open in new window"?>
-                              <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
-                            <?php } else { // !is_array($url)?>
-                              <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
-                            <?php } // if-is_array($url)?>
-                        </li>
-                      <?php } //foreach?>
-                    </ul>
-
-                    <?php if ($view->_isAdmin) { ?>
-                      <!-- admin menu -->
-                      <ul>
-                          <li class="title"><?= tr('administration'); ?></li>
-                          <?php foreach ($view->_adminMenu as $key => $url) { ?>
+                      <!-- authorized menu -->
+                      <ul class="rythm_nav3MainMenu">
+                        <li class="title"><?= tr('main_menu'); ?></li>
+                          <?php foreach ($view->_authUserMenu as $key => $url) { ?>
                             <li class="group">
                                 <?php if (is_array($url)) { //array="open in new window"?>
                                   <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
@@ -321,12 +283,55 @@ $view->addHeaderChunk('darkmodeJS');
                             </li>
                           <?php } //foreach?>
                       </ul>
-                    <?php } //admin?>
 
-                <?php } //if-_isUserLogged?>
+                      <!-- custom user menu -->
+                      <ul class="rythm_nav3UserMenu">
+                        <li class="title"><?= tr('user_menu'); ?></li>
+                          <?php foreach ($view->_customUserMenu as $key => $url) { ?>
+                            <li class="group">
+                              <a href="<?= $url; ?>">
+                                  <?= $key; ?>
+                              </a>
+                            </li>
+                          <?php } //foreach?>
+                      </ul>
+
+
+                      <!-- additional menu -->
+                      <ul class="rythm_nav3AddsMenu">
+                        <li class="title"><?= tr('mnu_additionalMenu'); ?></li>
+                          <?php foreach ($view->_additionalMenu as $key => $url) { ?>
+                            <li class="group">
+                                <?php if (is_array($url)) { //array="open in new window"?>
+                                  <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
+                                <?php } else { // !is_array($url)?>
+                                  <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
+                                <?php } // if-is_array($url)?>
+                            </li>
+                          <?php } //foreach?>
+                      </ul>
+
+                        <?php if ($view->_isAdmin) { ?>
+                        <!-- admin menu -->
+                        <ul>
+                          <li class="title"><?= tr('administration'); ?></li>
+                            <?php foreach ($view->_adminMenu as $key => $url) { ?>
+                              <li class="group">
+                                  <?php if (is_array($url)) { //array="open in new window"?>
+                                    <a href="<?= $url[0]; ?>" target="_blank" rel="noopener"><?= $key; ?></a>
+                                  <?php } else { // !is_array($url)?>
+                                    <a href="<?= $url; ?>" rel="noopener"><?= $key; ?></a>
+                                  <?php } // if-is_array($url)?>
+                              </li>
+                            <?php } //foreach?>
+                        </ul>
+                        <?php } //admin?>
+
+                    <?php } //if-_isUserLogged?>
 
                     <!-- Main title -->
-                </div>
+                  </div>
+                <?php } ?>
 
       <!--     CONTENT -->
       <div class="templateContainer">
@@ -423,7 +428,7 @@ $view->addHeaderChunk('darkmodeJS');
       var re = new RegExp(cookie_name+'=1');
 
       if (!x.match(re)) {
-          html.classList.remove("responsive-enabled");
+          // html.classList.remove("responsive-enabled");
       } else {
           html.classList.add("responsive-enabled");
       }

--- a/src/Views/userAuth/loginPage.tpl.php
+++ b/src/Views/userAuth/loginPage.tpl.php
@@ -12,13 +12,13 @@ use src\Utils\Uri\SimpleRouter;
     <div class="input-group input-group-md">
       <label for="userName" class="input-group-addon loginLabel"><?=tr('loginForm_userOrEmail')?></label>
       <input id="userName" name="email" maxlength="80" type="text" value="<?=$view->prevEmail?>"
-             class="form-control input300" autocomplete="username"  required>
+             class="form-control input300 loginInput" autocomplete="username"  required>
     </div>
     <div class="buffer"></div>
     <div class="input-group input-group-md">
       <label for="password" class="input-group-addon loginLabel"><?=tr('loginForm_password')?></label>
       <input id="password" name="password" maxlength="60" type="password"
-             class="form-control input300" autocomplete="current-password" required>
+             class="form-control input300 loginInput" autocomplete="current-password" required>
     </div>
     <div class="buffer"></div>
     <input type="hidden" name="target" value="<?=$view->target?>">

--- a/src/Views/userRegistration/register.tpl.php
+++ b/src/Views/userRegistration/register.tpl.php
@@ -17,14 +17,14 @@ use src\Utils\Uri\SimpleRouter;
   <form action="<?=SimpleRouter::getLink('UserRegistration','registerSubmit')?>" method="post">
     <div class="input-group input-group-md">
       <label for="username-input" class="input-group-addon loginLabel"><?=tr('username_label')?></label>
-      <input id="username-input" name="username" type="text" value="<?=$view->username?>" class="form-control input200" maxlength="60" autocomplete="username" required>
+      <input id="username-input" name="username" type="text" value="<?=$view->username?>" class="form-control input200 loginInput" maxlength="60" autocomplete="username" required>
     </div>
 
     <div class="buffer"></div>
 
     <div class="input-group input-group-md">
       <label for="email-input" class="input-group-addon loginLabel"><?=tr('email_address')?></label>
-      <input id="email-input" name="email" type="email"  value="<?=$view->email?>" class="form-control input200" maxlength="60" autocomplete="email" required>
+      <input id="email-input" name="email" type="email"  value="<?=$view->email?>" class="form-control input200 loginInput" maxlength="60" autocomplete="email" required>
     </div>
 
     <div class="buffer"></div>
@@ -33,7 +33,7 @@ use src\Utils\Uri\SimpleRouter;
       <label for="newpw-password" class="input-group-addon loginLabel"><?=tr('password')?></label>
       <span class="newpw-showpass newpw-eyeopen" id="newpw-showpass-switch" title="<?=tr('password_showhide')?>"></span>
       <span class="newpw-pass-meter"><meter id="newpw-meter" value="0" min="0" max="10"></meter></span>
-      <input id="newpw-password" name="password" type="password" class="form-control input200" maxlength="60" autocomplete="new-password" required>
+      <input id="newpw-password" name="password" type="password" class="form-control input200 loginInput" maxlength="60" autocomplete="new-password" required>
     </div>
 
     <div class="buffer"></div>


### PR DESCRIPTION
Currently, the login page used in the OKAPI OAuth flow (`login.php?mobileView=1&target=…`) shows two login forms, main menu, and horizontal navigation, causing confusion on mobile devices.

This change extends the handling of the `mobileView=1` parameter to:
- Hide the top login form
- Hide the horizontal navigation
- Hide the main menu
- Enable responsive mode by default

This results in a simplified, minimal login page with a single login form optimized for mobile use during OAuth authorization.

Note: As a side effect, visiting URLs like `/index.php?mobileView=1` will render an incomplete page, but this parameter is intended only for the OAuth flow.

Closes #2513