### PR TITLE
User removal changes, fixes #2515

### DIFF
--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -516,6 +516,12 @@ $translations = [
     'admin_user_rmUserConfirmed' => 'I confirm I want to remove this account',
     'admin_user_confirmationTxt' => 'Are you sure you want to irrevocably remove this user account.',
     'admin_user_confirmationEmail' => 'Be sure user request was send from address: %s',
+    'admin_user_rmResult_wrongRequest' => 'Wrong request',
+    'admin_user_rmResult_noUser' => 'No such user',
+    'admin_user_rmResult_alreadyRemoved' => 'Already removed',
+    'admin_user_rmResult_success' => 'Account and all its data removed',
+    'admin_user_rmDialog_title' => 'User removal status',
+    'admin_user_rmDialog_close' => 'Close',
 
     'titles' => 'Subject',
     'content' => 'Message',

--- a/src/Controllers/Admin/UserAdminApiController.php
+++ b/src/Controllers/Admin/UserAdminApiController.php
@@ -14,7 +14,10 @@ class UserAdminApiController extends ApiBaseController
 
         if (! $this->isUserLogged() || ! $this->loggedUser->hasOcTeamRole()) {
             // this controller is accessible only for OCTeam
-            $this->ajaxErrorResponse('Not authorized for this operation', HttpCode::STATUS_UNAUTHORIZED);
+            $this->ajaxErrorResponse(
+                'Not authorized for this operation',
+                HttpCode::STATUS_UNAUTHORIZED
+            );
         }
     }
 
@@ -24,22 +27,31 @@ class UserAdminApiController extends ApiBaseController
     public function removeUserAccount(int $userId = null): void
     {
         if (! $userId) {
-            $this->ajaxErrorResponse('Wrong request', HttpCode::STATUS_BAD_REQUEST);
+            $this->ajaxErrorResponse(
+                tr('admin_user_rmResult_wrongRequest'),
+                HttpCode::STATUS_BAD_REQUEST
+            );
         }
 
         /** @var User $accountToRemove */
         $accountToRemove = User::fromUserIdFactory($userId);
 
         if (! $accountToRemove) {
-            $this->ajaxErrorResponse('No such user', HttpCode::STATUS_NOT_FOUND);
+            $this->ajaxErrorResponse(
+                tr('admin_user_rmResult_noUser'),
+                HttpCode::STATUS_NOT_FOUND
+            );
         }
 
         // check if account is already locked
         if ($accountToRemove->isAlreadyRemoved()) {
-            $this->ajaxErrorResponse('Already removed', HttpCode::STATUS_BAD_REQUEST);
+            $this->ajaxErrorResponse(
+                tr('admin_user_rmResult_alreadyRemoved'),
+                HttpCode::STATUS_BAD_REQUEST
+            );
         }
 
         $accountToRemove->removeAccount($this->loggedUser);
-        $this->ajaxSuccessResponse('Account and all its data removed');
+        $this->ajaxSuccessResponse(tr('admin_user_rmResult_success'));
     }
 }

--- a/src/Controllers/Admin/UserAdminController.php
+++ b/src/Controllers/Admin/UserAdminController.php
@@ -54,6 +54,7 @@ class UserAdminController extends ViewBaseController
         $this->view->setVar('userNotes', AdminNoteSet::getNotesForUser($this->viewedUser, 10000));
         $this->view->addLocalCss(Uri::getLinkWithModificationTime('/views/admin/admin.css'));
         $this->view->loadJQuery();
+        $this->view->loadJQueryUI();
         $this->view->setTemplate('admin/user_admin');
         $this->view->buildView();
     }
@@ -73,7 +74,7 @@ class UserAdminController extends ViewBaseController
             if (
                 strpos($userName, '@')
                 && ! is_null($user = User::fromEmailFactory($userName))
-                ) {
+            ) {
                 $this->view->redirect(
                     SimpleRouter::getLink(
                         'Admin.UserAdmin',
@@ -98,6 +99,7 @@ class UserAdminController extends ViewBaseController
             // so display list of users
             if (mb_strlen($userName) >= 3) {
                 $usersTable = MultiUserQueries::searchUser($userName);
+
                 // If there is exact one result - redirect for user admin
                 if (sizeof($usersTable) == 1) {
                     $this->view->redirect(
@@ -108,6 +110,7 @@ class UserAdminController extends ViewBaseController
                         )
                     );
                 }
+
                 // If there is no results - show message
                 if (sizeof($usersTable) == 0) {
                     $this->errorMsg = tr('message_user_not_found');

--- a/src/Views/admin/user_admin.tpl.php
+++ b/src/Views/admin/user_admin.tpl.php
@@ -10,6 +10,25 @@ $user = $view->user;
 
 ?>
 <script>
+    $(function() {
+        $("#userRemoveResultInfo").dialog({
+            position: { my: "top", at: "center top+25%", of: window },
+            autoOpen: false,
+            modal: true,
+            hide: "explode",
+            show: "fade",
+            title: "<?= tr('admin_user_rmDialog_title'); ?>",
+            buttons: {
+                "<?= tr('admin_user_rmDialog_close'); ?>": function() {
+                     $(this).dialog("close");
+                }
+            },
+            close: function(event, ui) {
+                location.reload();
+            }
+        });
+    });
+
     function rmUserShowConfirmation() {
       $("#removeAccountBtn").hide();
       $("#removeAccountConfirmation").show();
@@ -20,17 +39,31 @@ $user = $view->user;
       $("#removeAccountConfirmation").hide();
     }
 
-    function rmUserConfirmed(){
+    function rmUserConfirmed() {
       $.ajax({
         type: 'GET',
         dataType: 'json',
-        url: '/Admin.UserAdminApi/removeUserAccount/<?=$user->getUserId()?>'
-      }).done(function(){
-        console.log("account removed");
-      }).fail(function(){
-        console.log("fail");
+        url: '/Admin.UserAdminApi/removeUserAccount/<?= $user->getUserId(); ?>'
+      }).done(function(data){
+        result =
+            Object.hasOwn(data, 'message') ? data['message']: 'Account removed';
+        console.log(result);
+        $('#userRemoveResultText').addClass('successmsg');
+        $('#userRemoveResultText').html(result);
+        $('#userRemoveResultInfo').dialog('open');
+        $(".ui-dialog-titlebar-close").hide();
+      }).fail(function(jqHXR, textStatus, errorThrown){
+        result =
+            Object.hasOwn(jqHXR, 'responseJSON')
+            && Object.hasOwn(jqHXR['responseJSON'], 'message')
+            ? jqHXR['responseJSON']['message']
+            : 'Account removal failed';
+        console.log(result);
+        $('#userRemoveResultText').addClass('errormsg');
+        $('#userRemoveResultText').html(result);
+        $('#userRemoveResultInfo').dialog('open');
+        $(".ui-dialog-titlebar-close").hide();
       })
-      location.reload();
     }
 </script>
 
@@ -204,4 +237,8 @@ $user = $view->user;
   </div>
 
 <?php } // end if $user->isUserActivated() ?>
+</div>
+
+<div id="userRemoveResultInfo" class="hidden" style="overflow: auto;">
+<p id="userRemoveResultText" style="text-align: center; margin: 5px; font-weight: bold;"></p>
 </div>


### PR DESCRIPTION
User removal status messages returned from server are now translated to current language and displayed using UI dialog. Then user admin page is reloaded. Should fix #2515.

Tested on Firefox and Chrome, latest versions.