### PR TITLE
Action style.yml - actions/cache version bumped to v3, fixes #2526

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -37,7 +37,7 @@ jobs:
           echo "::set-output name=path::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ steps.filter.outputs.addedOrModified == 'true' }}
         with:
           path: ${{ steps.composer-cache-dir.outputs.path }}


### PR DESCRIPTION
Bump actions/cache@v2 to actions/cache@v3 in workflow `style.yml`. Checked successfully in my repo fork. Should fix #2526