### PR TITLE
Fixed decimal coordinates display on the map

### DIFF
--- a/public/views/chunks/dynamicMap/dynamicMapCommons.js
+++ b/public/views/chunks/dynamicMap/dynamicMapCommons.js
@@ -251,7 +251,7 @@ var CoordinatesUtil = {
                   lonParts.min.toFixed(3) + "'";
 
       case this.FORMAT.DECIMAL:
-        return latHemisfere + " " + lonParts.deg.toFixed(5) + "° " +
+        return latHemisfere + " " + latParts.deg.toFixed(5) + "° " +
                lonHemisfere + " " + lonParts.deg.toFixed(5) + "°";
 
       case this.FORMAT.DEG_MIN_SEC:
@@ -653,4 +653,3 @@ var OcLayerServices = {
     }
 
 };
-


### PR DESCRIPTION
Long ago (in 2018) I had passed this fix along with some other improvements which were questioned, so the PR was not merged then. Now it is this little fix only.