### PR TITLE
Change redirect behavior after submitting cache description

### DIFF
--- a/src/Controllers/CacheDescController.php
+++ b/src/Controllers/CacheDescController.php
@@ -64,9 +64,17 @@ class CacheDescController extends ViewBaseController
         $this->view->loadJQuery();
 
         $this->view->setVar('languages', $this->getLanguagesObj($desc));
-
         $this->view->setVar('cache', $geocache);
         $this->view->setVar('desc', $desc);
+
+        // returnUrl is used to redirect to the page where the user was before editing the cache description
+        $returnUrl = $_GET['returnUrl'] ?? $_SERVER['HTTP_REFERER'] ?? null;
+        if ($returnUrl) {
+            $parsed = parse_url($returnUrl);
+            $returnUrl = ($parsed['path'] ?? '')
+                . (isset($parsed['query']) ? '?' . $parsed['query'] : '');
+        }
+        $this->view->setVar('returnUrl', $returnUrl);
 
         $this->view->setTemplate('cacheDescEdit/cacheDescEdit');
         $this->view->buildView();
@@ -156,6 +164,6 @@ class CacheDescController extends ViewBaseController
 
         $desc->saveToDb();
 
-        $this->view->redirect($geocache->getCacheUrl());
+        $this->view->redirect($_POST['returnUrl'] ?? $geocache->getCacheUrl());
     }
 }

--- a/src/Views/cacheDescEdit/cacheDescEdit.tpl.php
+++ b/src/Views/cacheDescEdit/cacheDescEdit.tpl.php
@@ -22,6 +22,8 @@ $view->callChunk('tinyMCE');
 <form action="/CacheDesc/save/<?=$cache->getWaypointId()?>/<?=$desc->getLang()?>"
       method="post" enctype="application/x-www-form-urlencoded" id="cacheeditform">
 
+    <input type="hidden" name="returnUrl" value="<?=htmlspecialchars($view->returnUrl ?? '')?>" />
+
     <?=$view->callSubTpl("/cacheDescEdit/cacheDescEditForm")?>
 
     <div class="content2-container">


### PR DESCRIPTION
#2497 

This PR is to change redirection behavior after submitting the cache description form.

**Current behavior:**
After submitting the cache description form, the user is always redirected to the cache page `viewcache.php`, regardless of where they started the edit (e.g. from the cache page or the edit cache page).

**New behavior:**
After submitting the cache description form, the user is redirected back to the page from which they entered the edit description page (e.g. back to the edit cache page or cache page).
If the origin page cannot be determined, e.g. user just entered the edit url directly to the address bar, the user is redirected to the cache page as before.
