### PR TITLE
fix #2554 Editing unpublished cache does not change type

### DIFF
--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -264,6 +264,7 @@ $translations = [
     'distance_incorrect' => 'Incorrect distance. Legal format: aa.aaa',
     'date_incorrect' => 'Incorrect date. Legal format: YYYY-MM-DD',
     'no_cache_name' => 'Missing geocache name',
+    'type_virtual_webcam_restricted' => 'Virtual and Webcam caches can only be changed by the OC Team. Your cache type has been restored to its previous value.',
     'descwp_incorrect' => 'No description.',
     'type_incorrect' => 'Cache type is incorrect!',
     'typewp_incorrect' => 'No waypoint selected!',

--- a/src/Views/editcache.tpl.php
+++ b/src/Views/editcache.tpl.php
@@ -283,6 +283,7 @@ $view->callChunk('timepicker');
                         return _chkVirtual()">
                     {typeoptions}
                 </select>
+                {type_message}
             </td>
         </tr>
         <tr><td>&nbsp;</td>


### PR DESCRIPTION
Earlier, only OC Team members were allowed to change a cache type to virtual or webcam. There was no feedback to the user, and the submitted type was silently overwritten with the previous value.

Changes:
- Added an error message so users are informed when the type change is restricted.
- Allowed changing type to virtual/webcam for unpublished caches (STATUS_NOTYETAVAILABLE) if the user does not require cache verification and the target type is not listed in $geocache['noNewCachesOfTypes'].