### PR TITLE
#2400 Geokrety cron does not handle too old lastupdate

### DIFF
--- a/src/Utils/Database/Updates/003_set_geokrety_last_update_to_now.php
+++ b/src/Utils/Database/Updates/003_set_geokrety_last_update_to_now.php
@@ -1,0 +1,40 @@
+<?php
+
+// created on 2026-02-24 by stefo
+
+namespace src\Utils\Database\Updates;
+
+return new class () extends UpdateScript {
+    public function getProperties()
+    {
+        return [
+            // see /docs/DbUpdate.md
+            'uuid' => '07F072C1-EF67-3231-F7DC-312BC1F605C6',
+            'run' => 'manual',
+        ];
+    }
+
+    // IMPORTANT:
+    // Any output by 'echo', 'print' etc. will be PUBLIC (see #1923).
+    // Do not output any sensitive information.
+
+    public function run()
+    {
+        // Insert your update code here, using $this->db for database access.
+
+        // The update will be run inside a transaction. It will also run
+        // with set_time_limit(0), so don't create any endless loops!
+
+        $this->db->simpleQuery("UPDATE sysconfig SET value = NOW() WHERE name='geokrety_lastupdate'");
+    }
+
+    public function rollback()
+    {
+        // If possible and feasible, provide code here which reverses the
+        // changes made by run(). Otherwiese please REMOVE the rollback method.
+        // This will disable the "rollback" action on the Admin.DbUpdate page.
+
+        // The rollback will be run inside a transaction. It will also run
+        // with set_time_limit(0), so don't create any endless loops!
+    }
+};


### PR DESCRIPTION
Adds a manual DB update to reset `geokrety_lastupdate` to NOW() in `sysconfig`. For local use when the timestamp is too old. In production, it should only be used as a last-resort if GeoKretyNewJob gets stuck. Repeated problems should be checked by an administrator.